### PR TITLE
mobile

### DIFF
--- a/assets/css/materialize.css
+++ b/assets/css/materialize.css
@@ -2880,7 +2880,7 @@ ul.staggered-list li {
     display: none !important;
   }
   .site-title {
-    font-size: 3em;
+    font-size: 2.7em;
   }
   .small-on-med-and-down {
     width: 23px !important;


### PR DESCRIPTION
Reduce font size to keep site title on the same line as the site logo in mobile browsers.