### PR TITLE
Update Linkerd 2 in meshes.yml

### DIFF
--- a/_data/categories/meshes.yml
+++ b/_data/categories/meshes.yml
@@ -79,8 +79,8 @@
 - name: Linkerd 2.x (Conduit)
   desc: "Conduit - A Kubernetes-native (only) service mesh announced as a project in December 2017. In contrast to Istio and in learning from Linkerd, Conduit’s design principles revolve around a minimalist architecture and zero config philosophy, optimizing for streamlined setup.
 Open Source. From Buoyant. Written in Rust and Go."
-  link: https://conduit.io
-  autoinject: "Experimental"
+  link: https://linkerd.io
+  autoinject: "Yes"
   h2: "Yes"
   grpc: "Yes"
   tcp-web: "Yes"
@@ -88,7 +88,7 @@ Open Source. From Buoyant. Written in Rust and Go."
   multi-tenant: "?"
   prometheus: "Yes"
   tracing: "None"
-  encryption: "Experimental"
+  encryption: "Yes"
 
 - name: Mesher
   desc: "Mesher is service mesh implementation based on go-chassis which can work together with ServiceComb Service center running on any infrastructure. Mesher can work with go-chassis in same service mesh control plane and it supports both linux and windows OS"


### PR DESCRIPTION
Update Linkerd 2 entry to reflect that autoinjection and encryption are no
longer considered experimental, and update website link (runconduit.io is
now a redirect).

Closes #106