### PR TITLE
Add HAProxy to Landscape

### DIFF
--- a/_data/categories/non-functional.yml
+++ b/_data/categories/non-functional.yml
@@ -224,10 +224,10 @@
   link: http://www.haproxy.org/
   governance: HAProxy
   primary-lang: C
-  announce-date: "?"
-  ga-1-date: "?"
-  commerical: HAProxy Technologies
-  category: Load-Balancers
+  announce-date: "December 2001"
+  ga-1-date: "December 2001"
+  commercial: HAProxy Technologies
+  category: Service Proxy
 
 - name: Kong
   opensource: "Yes"

--- a/_data/categories/non-functional.yml
+++ b/_data/categories/non-functional.yml
@@ -226,7 +226,7 @@
   primary-lang: C
   announce-date: "December 2001"
   ga-1-date: "December 2001"
-  commercial: HAProxy Technologies
+  commerical: HAProxy Technologies
   category: Service Proxy
 
 - name: Kong

--- a/_data/categories/proxies.yml
+++ b/_data/categories/proxies.yml
@@ -7,6 +7,9 @@
 - name: Envoy
   link: https://www.envoyproxy.io
   desc: "Envoy - a modern proxy hosted by the CNCF. Many projects have sprung up to leverage Envoy, including Istio."
+- name: HAProxy
+  link: https://www.haproxy.org
+  desc: "HAProxy is the world's fastest and most widely used software load balancer, powering superior application delivery at any scale and in any environment."
 - name: nginMesh
   link: https://github.com/nginxinc/nginmesh
   desc: "nginMesh - launched in September 2017, the nginMesh project deploys Nginx as a sidecar proxy in Istio."


### PR DESCRIPTION
Add HAProxy as a Service Proxy to the Landscape

Update information about the initial version 1.0 release.

Closes #124