### PR TITLE
Restyle landscape categories

### DIFF
--- a/_includes/service-meshes.html
+++ b/_includes/service-meshes.html
@@ -3,8 +3,23 @@
     <div class="card col s12" style="background-color: white;">
       <style> 
         ul {font-weight:bold;} 
-        li {margin-left:5px; font-weight: normal;} 
-        
+        li {
+          margin-left: 5px;
+          font-weight: normal;
+          float: right;
+          width: 200px;
+        }
+
+        .card-content {
+          padding: 0 0 5px 0 !important;
+          border-right: none;
+        }
+
+        .card-content:not(:last-child) {
+          border-bottom-width: 1px;
+          border-bottom-style: dashed;
+          border-bottom-color: var(--main-dark-grey);
+        }
         </style>
 
         <div class="card-content comparison">

--- a/landscape.html
+++ b/landscape.html
@@ -30,7 +30,7 @@ lang: en
       </div>
       <h1 style="text-align:center;color:aliceblue;padding-top:0px;margin-top:0px;">Service Mesh Landscape</h1>
     </div>
-      <div id="contact" class="section scrollspy" style="width:100%;">        
+      <div class="section scrollspy" style="width:100%;">        
         {% include service-meshes.html %}
       </div>
 


### PR DESCRIPTION
- Resolves #191 by applying styling from https://github.com/layer5io/layer5/issues/191#issuecomment-537304508 to the Categories section on the [Service Mesh Landscape](https://layer5.io/landscape/) page. The styling was added into an existing inline `<style>` tag on [line 4 of _includes/service-meshes.html](https://github.com/layer5io/layer5/blob/master/_includes/service-meshes.html#L4).
- Removes a duplicate `id` attribute from a `div` tag on [line 33 of landscape.html](https://github.com/layer5io/layer5/blob/master/landscape.html#L33)

