### PR TITLE
Resolves #65: added table sorting adjusted font colors on landscape page

### DIFF
--- a/_includes/service-mesh-categories.html
+++ b/_includes/service-mesh-categories.html
@@ -11,8 +11,8 @@
 
 <tbody>
 <tr>
-    <td><a href="https://conduit.io" class="orange-text">Conduit (Linkerd 2.x)</a></td>
-    <td><a href="https://www.hashicorp.com/blog/smart-networking-with-consul-and-service-meshes" class="orange-text">Consul Connect</a></td>
+    <td><a href="https://conduit.io">Conduit (Linkerd 2.x)</a></td>
+    <td><a href="https://www.hashicorp.com/blog/smart-networking-with-consul-and-service-meshes">Consul Connect</a></td>
     <td></td>
     <td></td>
     <td></td>
@@ -20,7 +20,7 @@
     <td></td>
 </tr>
 <tr>
-  <td><a href="https://www.turbinelabs.io/product" class="orange-text">Houston</a></td>
+  <td><a href="https://www.turbinelabs.io/product">Houston</a></td>
   <td></td>
   <td></td>
 </tr>
@@ -28,36 +28,36 @@
 </table>
 -->
          <ul>Service Mesh
-          <li><a href="https://www.hashicorp.com/blog/smart-networking-with-consul-and-service-meshes" class="orange-text">Consul Connect</a></li>
-          <li><a href="https://www.turbinelabs.io/product" class="orange-text">Houston</a></li>
-          <li><a href="https://istio.io" class="orange-text">Istio</a></li>
-          <li><a href="https://konghq.com/solutions/service-mesh/" class="orange-text">Kong</a></li>
-          <li><a href="https://linkerd.io" class="orange-text">Linkerd 1.x</a></li>
-           <li><a href="https://conduit.io" class="orange-text">Linkerd 2.x</a> (Conduit)</li>
-          <li><a href="https://github.com/alipay/sofa-mesh" class="orange-text">SOFAMesh</a></li>
-          <li><a href="https://vamp.io" class="orange-text">Vamp</a></li>
-          <li><a href="https://github.com/Netflix/zuul" class="orange-text">Zuul</a></li>
+          <li><a href="https://www.hashicorp.com/blog/smart-networking-with-consul-and-service-meshes">Consul Connect</a></li>
+          <li><a href="https://www.turbinelabs.io/product">Houston</a></li>
+          <li><a href="https://istio.io">Istio</a></li>
+          <li><a href="https://konghq.com/solutions/service-mesh/">Kong</a></li>
+          <li><a href="https://linkerd.io">Linkerd 1.x</a></li>
+           <li><a href="https://conduit.io">Linkerd 2.x</a> (Conduit)</li>
+          <li><a href="https://github.com/alipay/sofa-mesh">SOFAMesh</a></li>
+          <li><a href="https://vamp.io">Vamp</a></li>
+          <li><a href="https://github.com/Netflix/zuul">Zuul</a></li>
         </ul>
       </div>
       <div class="card-content" style="float: left;display: inline;background-color: white;">
         <ul>Client Library
-          <li><a href="https://akka.io" class="orange-text">Akka</a></li>
-          <li><a href="https://github.com/twitter/finagle/" class="orange-text">Finagle</a></li>
-          <li><a href="https://www.github.com/Netflix/Hystrix" class="orange-text">Hysterix</a></li>
-          <li><a href="https://github.com/Netflix/Ribbon" class="orange-text">Ribbon</a></li>
+          <li><a href="https://akka.io">Akka</a></li>
+          <li><a href="https://github.com/twitter/finagle/">Finagle</a></li>
+          <li><a href="https://www.github.com/Netflix/Hystrix">Hysterix</a></li>
+          <li><a href="https://github.com/Netflix/Ribbon">Ribbon</a></li>
         </ul>
       </div>
       <div class="card-content" style="float: left;display: inline;background-color: white;">
         <ul>API Gateway
-          <li><a href="https://getambassador.io" class="orange-text">Ambassador</a></li>
-          <li><a href="https://github.com/heptio/contour" class="orange-text">Contour</a></li>
-          <li><a href="https://github.com/kong/kong" class="orange-text">Kong</a></li>
-          <li><a href="http://openresty.org" class="orange-text">OpenResty</a></li>
+          <li><a href="https://getambassador.io">Ambassador</a></li>
+          <li><a href="https://github.com/heptio/contour">Contour</a></li>
+          <li><a href="https://github.com/kong/kong">Kong</a></li>
+          <li><a href="http://openresty.org">OpenResty</a></li>
         </ul>
       </div>
       <div class="card-content" style="float: left;display: inline;background-color: white;">
         <ul>Service or Edge Proxy
-          <li><a href="https://www.envoyproxy.io" class="orange-text">Envoy</a></li>
-          <li><a href="https://github.com/nginxinc/nginmesh" class="orange-text">nginMesh</a></li>
+          <li><a href="https://www.envoyproxy.io">Envoy</a></li>
+          <li><a href="https://github.com/nginxinc/nginmesh">nginMesh</a></li>
         </ul>
       </div>

--- a/_includes/service-mesh-functionality.html
+++ b/_includes/service-mesh-functionality.html
@@ -1,23 +1,24 @@
-      <table class="responsive-table highlight striped" style="color:var(--main-bg-color);">
-            <thead style="background-color: #a6b7be;color:#222; text-align:center; word-wrap: none;">
-                    <tr>
-              <th>Service Mesh</th>
-              <th>Auto Proxy Injection</th>
-              <th>TCP + WebSockets</th>
-              <th>HTTP, HTTP/2</th>
-              <th>gRPC</th>
-              <th>Multi-Cluster</th>
-              <th>Multi-Tenant</th>
-              <th>Prometheus Integration</th>
-              <th>Tracing Integration</th>
-              <th>Encryption</th>
+        <table id="meshes-table" class="responsive-table highlight striped" style="color:var(--main-bg-color);">
+        <thead style="background-color: #a6b7be;color:#222; text-align:center; word-wrap: none;">
+          <tr style="cursor: pointer">
+              <th onclick="sortTable('meshes-table',0)">Service Mesh</th>
+              <th onclick="sortTable('meshes-table',1)">Auto Proxy Injection</th>
+              <th onclick="sortTable('meshes-table',2)">TCP + WebSockets</th>
+              <th onclick="sortTable('meshes-table',3)">HTTP, HTTP/2</th>
+              <th onclick="sortTable('meshes-table',4)">gRPC</th>
+              <th onclick="sortTable('meshes-table',5)">Multi-Cluster</th>
+              <th onclick="sortTable('meshes-table',6)">Multi-Tenant</th>
+              <th onclick="sortTable('meshes-table',7)">Prometheus Integration</th>
+              <th onclick="sortTable('meshes-table',8)">Tracing Integration</th>
+              <th onclick="sortTable('meshes-table',9)">Encryption</th>
           </tr>
         </thead>
 
         <tbody>
-            {% for meshes in site.data.categories.meshes %}
+            {% assign meshes_by_category = site.data.categories.meshes | sort: "category" | reverse %}
+            {% for meshes in meshes_by_category %}
             <tr style="border: 1px dashed #a6b7be; text-align:center;">
-                <td><a href="{{meshes.link}}" title="{{meshes.desc}}" class="orange-text">{{meshes.name}}</a></td>
+                <td><a href="{{meshes.link}}" title="{{meshes.desc}}">{{meshes.name}}</a></td>
                 <td style="text-align:center;"> {{meshes.autoinject}} </td>
                 <td style="text-align:center;"> {{meshes.tcp-web}} </td>
                 <td style="text-align:center;"> {{meshes.h2}} </td>
@@ -29,5 +30,5 @@
                 <td style="text-align:center;"> {{meshes.encryption}} </td>
             </tr>
             {% endfor %}
-          </tbody>
+        </tbody>
         </table>

--- a/_includes/service-mesh-non-functional.html
+++ b/_includes/service-mesh-non-functional.html
@@ -1,22 +1,23 @@
-<table class="responsive-table highlight striped" style="color:var(--main-bg-color);">
+<table id="nonfunc-table" class="responsive-table highlight striped" style="color:var(--main-bg-color);">
     <thead style="background-color: #a6b7be;color:#222; text-align:center; word-wrap: none;">
-    <tr>
-        <th>Category</th>
-        <th>Name</th>
-        <th>Open Source</th>
-        <th>Governance</th>
-        <th>Primary Language</th>
-        <th>Project Announce</th>
-        <th>GA / 1.0</th>
-        <th>Commercial Offerings</th>
+    <tr style="cursor: pointer">
+        <th onclick="sortTable('nonfunc-table',0)">Category</th>
+        <th onclick="sortTable('nonfunc-table',1)">Name</th>
+        <th onclick="sortTable('nonfunc-table',2)">Open Source</th>
+        <th onclick="sortTable('nonfunc-table',3)">Governance</th>
+        <th onclick="sortTable('nonfunc-table',4)">Primary Language</th>
+        <th onclick="sortTable('nonfunc-table',5)">Project Announce</th>
+        <th onclick="sortTable('nonfunc-table',6)">GA / 1.0</th>
+        <th onclick="sortTable('nonfunc-table',7)">Commercial Offerings</th>
     </tr>
     </thead>
 
     <tbody>
-    {% for nonfunc in site.data.categories.non-functional %}
+    {% assign nonfunc_by_category = site.data.categories.non-functional | sort: "category" | reverse %}
+    {% for nonfunc in nonfunc_by_category %}
     <tr style="border: 1px dashed #a6b7be; text-align:center;">
         <td style="text-align:center;"> {{nonfunc.category}} </td>
-        <td><a href="{{nonfunc.link}}" title="{{nonfunc.link}}" class="orange-text">{{nonfunc.name}}</a></td>
+        <td><a href="{{nonfunc.link}}" title="{{nonfunc.link}}">{{nonfunc.name}}</a></td>
         <td style="text-align:center;"> {{nonfunc.opensource}} </td>
         <td style="text-align:center;"> {{nonfunc.governance}} </td>
         <td style="text-align:center;"> {{nonfunc.primary-lang}} </td>
@@ -30,3 +31,4 @@
 
 <!-- tablesorter plugin -->
 <script src="/assets/js/table-colors-category.js"></script>
+<script src="/assets/js/table-sort.js"></script>

--- a/_includes/service-mesh-tools.html
+++ b/_includes/service-mesh-tools.html
@@ -1,73 +1,73 @@
-      <table class="responsive-table highlight striped" style="color:var(--main-bg-color);">
+      <table id="tools-table" class="responsive-table highlight striped" style="color:var(--main-bg-color);">
         <thead style="background-color: #a6b7be;color:#222; text-align:center;">
-          <tr style="text-align:center; white-space: nowrap;">
-              <th>Tool</th>
-              <th>Written in</th>
-              <th>Written for</th>
-              <th>Supported by</th>
-              <th>Description</th>
+          <tr style="text-align:center; white-space: nowrap; cursor: pointer;">
+              <th onclick="sortTable('tools-table',0)">Tool</th>
+              <th onclick="sortTable('tools-table',1)">Written in</th>
+              <th onclick="sortTable('tools-table',2)">Written for</th>
+              <th onclick="sortTable('tools-table',3)">Supported by</th>
+              <th onclick="sortTable('tools-table',4)">Description</th>
           </tr>
         </thead>
 
         <tbody>
           <tr style="border: 1px dashed #a6b7be; text-align:center;">
-              <td><a href="https://github.com/istio/fortio/" class="orange-text">fortio</td>
+              <td><a href="https://github.com/istio/fortio/">fortio</td>
               <td>Golang</td>
               <td>Istio, general use</td>
               <td>Istio</td>
               <td style="white-space: pre-wrap;">A load testing library and command line tool and web UI. Allows to specify a set query-per-second load and record latency histograms and other useful stats.</td>
           </tr>
           <tr style="border: 1px dashed #a6b7be; text-align:center;">
-              <td><a href="https://github.com/requests/httpbin" class="orange-text">httpbin</a></td>
+              <td><a href="https://github.com/requests/httpbin">httpbin</a></td>
               <td>Python</td>
               <td>general use</td>
               <td>Kenneth Reitz</td>
               <td style="white-space: pre-wrap;">A simple HTTP request & response service.</td>
           </tr>
           <tr style="border: 1px dashed #a6b7be; text-align:center;">
-            <td><a href="https://github.com/layer5io/meshery" class="orange-text">Meshery</td>
+            <td><a href="https://github.com/layer5io/meshery">Meshery</td>
             <td>Golang</td>
             <td>Istio, Linkerd, Consul, Octarine, Network Service Mesh, App Mesh</td>
             <td>Layer5</td>
             <td style="white-space: pre-wrap;">A service mesh playground to faciliate learning about functionality and performance of different service meshes. Meshery incorporates the collection and display of metrics from applications running in the playground.</td>
         </tr>
           <tr style="border: 1px dashed #a6b7be; text-align:center;">
-              <td><a href="https://github.com/twitter/iago" class="orange-text">lago</a></td>
+              <td><a href="https://github.com/twitter/iago">lago</a></td>
               <td>Scala</td>
               <td>Finagle, general use</td>
               <td>Twitter</td>
               <td style="white-space: pre-wrap;">A load generation tool that replays production or synthetic traffic against a given target. Among other things, it differs from other load generation tools in that it attempts to hold constant the transaction rate.</td>
           </tr>
           <tr style="border: 1px dashed #a6b7be; text-align:center;">
-              <td><a href="https://github.com/buoyantio/slow_cooker" class="orange-text">slow_cooker</a></td>
+              <td><a href="https://github.com/buoyantio/slow_cooker">slow_cooker</a></td>
               <td>Golang</td>
               <td>Linkerd, general use</td>
               <td>Buoyant</td>
               <td style="white-space: pre-wrap;">A load testing tool that produces a predictable load and concurrency level for a long period of time. Provides periodic reports of qps and latency (during testing).</td>
           </tr>
           <tr style="border: 1px dashed #a6b7be; text-align:center;">
-              <td><a href="https://github.com/wg/wrk" class="orange-text">wrk</a></td>
+              <td><a href="https://github.com/wg/wrk">wrk</a></td>
               <td>C</td>
               <td>general use</td>
               <td>Will Glozer</td>
               <td style="white-space: pre-wrap;">A modern HTTP benchmarking tool capable of generating significant load when run on a single multi-core CPU. It combines a multithreaded design with scalable event notification systems such as epoll and kqueue.</td>
           </tr>
           <tr style="border: 1px dashed #a6b7be; text-align:center;">
-              <td><a href="https://github.com/aspenmesh/istio-vet" class="orange-text">istio-vet</a></td>
+              <td><a href="https://github.com/aspenmesh/istio-vet">istio-vet</a></td>
               <td>Golang</td>
               <td>general use</td>
               <td>Aspen Mesh</td>
               <td style="white-space: pre-wrap;">A tool for validating Istio and application configuration installed in a Kubernetes cluster. It detects incompatible or incorrect configuration which might lead to unexpected runtime behaviors.</td>
           </tr>
           <tr style="border: 1px dashed #a6b7be; text-align:center;">
-              <td><a href="https://www.kiali.io" class="orange-text">Kiali</a></td>
+              <td><a href="https://www.kiali.io">Kiali</a></td>
               <td>Golang</td>
               <td>Istio</td>
               <td>Kiali Project, Red Hat</td>
               <td style="white-space: pre-wrap;">A graphical user interface to provide insight into what is happening within you Istio service mesh. Kiali graphs the interaction between service mesh components, handles configuration files, and analyses your mesh for potential issues.</td>
           </tr>
           <tr style="border: 1px dashed #a6b7be; text-align:center;">
-          	<td><a href="https://github.com/xiaomi/naftis" class="orange-text">Naftis</a></td>
+          	<td><a href="https://github.com/xiaomi/naftis">Naftis</a></td>
           	<td>Golang</td>
           	<td>Istio</td>
           	<td>Xiaomi</td>
@@ -75,7 +75,7 @@
           	</td>
           </tr>
               <tr style="border: 1px dashed #a6b7be; text-align:center;">
-              <td><a href="https://github.com/JoeDog/siege" class="orange-text">Siege</td>
+              <td><a href="https://github.com/JoeDog/siege">Siege</td>
               <td>C++</td>
               <td>Reporting the total number of hits recorded, bytes transferred, response time, concurrency, and return status on web</td>
               <td>Jeffrey Fulmer</td>

--- a/_includes/service-meshes.html
+++ b/_includes/service-meshes.html
@@ -25,7 +25,7 @@
         <div class="card-content comparison">
           <ul>Service Mesh
             {% for meshes in site.data.categories.meshes %}
-                <li><div class="tooltip"><a href="{{meshes.link}}" class="orange-text">{{meshes.name}}</a>
+                <li><div class="tooltip"><a href="{{meshes.link}}">{{meshes.name}}</a>
                   <span class="tooltiptext">{{meshes.desc}}</span></div>
                 </li>
             {% endfor %}
@@ -35,7 +35,7 @@
         <div class="card-content comparison">
           <ul>Client Library
             {% for clients in site.data.categories.clients %}
-                <li><div class="tooltip"><a href="{{clients.link}}" class="orange-text">{{clients.name}}</a>
+                <li><div class="tooltip"><a href="{{clients.link}}">{{clients.name}}</a>
                 <span class="tooltiptext">{{clients.desc}}</span></div>
               </li>
               
@@ -46,7 +46,7 @@
         <div class="card-content comparison">
             <ul>API Gateway
               {% for gw in site.data.categories.gw %}
-                  <li><div class="tooltip"><a href="{{gw.link}}" class="orange-text">{{gw.name}}</a>
+                  <li><div class="tooltip"><a href="{{gw.link}}">{{gw.name}}</a>
                     <span class="tooltiptext">{{gw.desc}}</span></div>
                   </li>
 
@@ -57,7 +57,7 @@
         <div class="card-content comparison">
             <ul>Service Proxy
               {% for proxies in site.data.categories.proxies %}
-                  <li><div class="tooltip"><a href="{{proxies.link}}" class="orange-text">{{proxies.name}}</a>
+                  <li><div class="tooltip"><a href="{{proxies.link}}">{{proxies.name}}</a>
                     <span class="tooltiptext">{{proxies.desc}}</span>
                   </div></li>
               {% endfor %}
@@ -67,7 +67,7 @@
         <div class="card-content comparison">
           <ul>Load Balancer
             {% for lbs in site.data.categories.lb %}
-                <li><div class="tooltip"><a href="{{lbs.link}}" class="orange-text">{{lbs.name}}</a>
+                <li><div class="tooltip"><a href="{{lbs.link}}">{{lbs.name}}</a>
                   <span class="tooltiptext">{{lbs.desc}}</span>
                 </div></li>
             {% endfor %}

--- a/_includes/workshops.html
+++ b/_includes/workshops.html
@@ -8,6 +8,11 @@
 
                 margin: auto;" />
             </div>
+            <style>
+            .card .card-action a:not(.btn):not(.btn-large):not(.btn-large):not(.btn-floating) {
+                color: #039be5;
+            }
+            </style>
             <div class="card-action">
                 <span class="card-title activator grey-text text-darken-4">{{workshop.name}}<i class="material-icons right">more_vert</i></span>
                 <p>

--- a/assets/js/table-sort.js
+++ b/assets/js/table-sort.js
@@ -1,0 +1,29 @@
+window.addEventListener("DOMContentLoaded", (event) => {
+  // sort tools tables by descending order on the leftmost column by default
+  sortTable("tools-table",0); // sort asc
+  sortTable("tools-table",0); // sort desc
+});
+
+function sortTable(id, col) {
+  let rows = document.querySelector("#" + id + " > tbody").rows;
+  let asc = true;
+  let didSort = false;
+  let shouldSwap = (a, b) => { return asc ? a > b : a < b; }
+  let text = (n) => { return rows[n].getElementsByTagName("td")[col].textContent.toLowerCase(); }
+  let bubbleSort = () => {
+    for (i = 0; i < rows.length-1; i++) {
+      for (j = 0; j < rows.length-i-1; j++) {
+        if (shouldSwap(text(j), text(j+1))) {
+          rows[j].parentNode.insertBefore(rows[j+1], rows[j]);
+          didSort = true;
+        }
+      }
+    }
+  };
+
+  bubbleSort();
+  if (!didSort) {
+    asc = !asc;
+    bubbleSort();
+  }
+}


### PR DESCRIPTION
Resolves #65:
- By default, all three tables on the [Landscape Page](https://layer5.io/landscape/) are sorted by descending alphabetical order on their leftmost column.
- Clicking on a column name on one of the aforementioned tables causes the table to be sorted by that column (toggling between ascending and descending order).
- The orange font color styling for links on the Landscape Page was removed, leaving the inherited blue font color.