### PR TITLE
Update meshery.html

### DIFF
--- a/_includes/meshery.html
+++ b/_includes/meshery.html
@@ -36,12 +36,6 @@
           performance tests run!
       </div>
     </div>
-    <!-- add a link to the Meshery docs site -->      
-      <div class="card" style="z-index: 1;">
-        <div class="docsitelink">
-            <p><a href = "https://meshery.layer5.io/docs">Playground instructions here!</a></p>
-      </div>
-    </div>
   </div>
 
   <div class="col s12 m6">
@@ -60,6 +54,12 @@
         <p>Learn about the functionality of different service meshes
           and visually manipulate mesh configuration.<br />
           </p>
+      </div>
+    </div>
+    <!-- add a link to the Meshery docs site -->      
+      <div class="card" style="z-index: 1;">
+        <div class="docsitelink">
+            <p><a href = "https://meshery.layer5.io/docs">Playground instructions here!</a></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
moving the docs site link to row2column2

Correction to the misaligned docs-site-link on the project page, merged via #208 (per #162).