### PR TITLE
#219: replace Slack badge link w/ link from Meshery README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![GitHub contributors](https://img.shields.io/github/contributors/layer5io/layer5.svg)
 ![GitHub](https://img.shields.io/github/license/layer5io/layer5.svg) 
 ![GitHub issues by-label](https://img.shields.io/github/issues/layer5io/layer5/help%20wanted.svg?color=%23DDDD00)
-[![Slack](https://img.shields.io/badge/slack-311-lightgrey)](http://slack.layer5.io)
+[![Slack](http://slack.layer5.io/badge.svg)](http://slack.layer5.io)
 ![Twitter Follow](https://img.shields.io/twitter/follow/layer5.svg?label=Follow&style=social)
 
 # About


### PR DESCRIPTION
This PR corrects the Slack badge link in the README.md to show the correct member counts, following the example of the Meshery README.md file.