### PR TITLE
add Go kit to client library list

### DIFF
--- a/_data/categories/clients.yml
+++ b/_data/categories/clients.yml
@@ -10,24 +10,24 @@
 - name: Ribbon
   link: https://github.com/Netflix/Ribbon
   desc: "Ribbon - an open source Inter-Process Communication (remote procedure calls) library with built-in software load balancers. Ribbon is written in Java."
-- name:  
-  link: 
-  desc: 
-- name:  
-  link: 
-  desc: 
-- name:  
-  link: 
-  desc: 
-- name:  
-  link: 
-  desc: 
-- name:  
-  link: 
-  desc: 
-- name:  
-  link: 
-  desc: 
-- name:  
-  link: 
+- name: Go kit
+  link: https://gokit.io
+  desc: "Go kit - a collection of Go packages that help you build robust, reliable, maintainable microservices (or elegant monoliths)."
+- name:
+  link:
+  desc:
+- name:
+  link:
+  desc:
+- name:
+  link:
+  desc:
+- name:
+  link:
+  desc:
+- name:
+  link:
+  desc:
+- name:
+  link:
   desc:


### PR DESCRIPTION
Adds Go kit to client library list.

Not sure if it makes sense to place Go kit under Service Mesh offerings although it is certainly possible to create a service mesh with Go kit using its resiliency, service discovery, observability and load balancer packages but it is up to the package consumer to wire it as such.