### PR TITLE
Add blog post drafts to /collections/_drafts

### DIFF
--- a/collections/_drafts/2019-10-02-hacktoberfest-2019-documenting-my-first-ever-hacktoberfest-contribution.md
+++ b/collections/_drafts/2019-10-02-hacktoberfest-2019-documenting-my-first-ever-hacktoberfest-contribution.md
@@ -1,0 +1,123 @@
+---
+layout: post
+title:  "#Hacktoberfest 2019: documenting my first-ever Hacktoberfest contribution"
+date:   2019-10-02 18:19:00 +0000
+image: https://raungar.files.wordpress.com/2019/10/hacktoberfest-pr-1-1.png
+author: Rafi Ungar
+permalink: /blog/hacktoberfest-2019-documenting-my-first-ever-hacktoberfest-contribution
+---
+In [my last post](https://raungar.wordpress.com/2019/09/27/planning-for-hacktoberfest-2019/), I identified three GitHub issues to kick off my participation in Hacktoberfest 2019. Today, I am happy to showcase my resolution of one of those issues, marking my first-ever Hacktoberfest contribution!
+
+## [Layer5.io](https://github.com/layer5io/layer5)
+
+Before I continue on, I want to acknowledge the project that I have contributed to. In [an article](https://layer5.io/gsoc/2019) discussing their participating in the Google Summer of Code 2019 program, [**Layer5**](https://github.com/layer5io/layer5) is described as a community which represents "the largest collection of _service mesh_ projects and their maintainers in the world". [RedHat.com](https://www.redhat.com/en/topics/microservices/what-is-a-service-mesh) helpfully defines a service mesh as "a dedicated infrastructure layer" of an application that controls how different parts of that application ("services") share data with one another (i.e. 'mesh together').
+
+* * *
+
+## Selecting my first Hacktoberfest issue
+
+As I mentioned my last post, I came into contact with Layer5 after discovering (through the [Hacktoberfest Issue Finder](https://hacktoberfest-finder.netlify.com/)) its [issue regarding table filtering](https://github.com/layer5io/layer5/issues/65)—and subsequently discovered an unreported styling issue:
+
+[![A styling issue with a collection of lists hosted on Layer5's Landscape page.](https://user-images.githubusercontent.com/13500769/66007380-2d643700-e480-11e9-8bda-e81dd0e166d9.png)](https://layer5.io/landscape/)
+
+A styling issue affected a collection of lists hosted on Layer5's [Landscape page](https://layer5.io/landscape/).
+
+Of the three GitHub issues I've scoped out, the resolution of this styling issue (i.e. tweaking CSS) represents the simplest of tasks that I have lined up—and an ideal candidate for a first-time Hacktoberfest contribution!
+
+As far as I could tell, no open issues concerned the styling problem that I discovered. So, as instructed both Layer5's website (and encouraged its extremely-welcoming development team), [I opened _my own issue_](https://github.com/layer5io/layer5/issues/191):
+
+[![https://github.com/layer5io/layer5/issues/191](https://raungar.files.wordpress.com/2019/10/image-1.png?w=1024)](https://github.com/layer5io/layer5/issues/191)
+
+Issue – [Enhance landscape categories section wrapping (#191)](https://github.com/layer5io/layer5/issues/191)
+
+## Identifying a solution
+
+To address this issue, I came up with the idea of realigning the category list items horizontally, transforming the poorly-behaving columns of category 'cards' into rows in a responsive and easily-scalable vertical stack.
+
+Implementating this idea proved quite simple, requiring only [a few added CSS rules](https://github.com/layer5io/layer5/issues/191#issuecomment-537304508), which I first accomplished by tinkering with the live webpage's styling (with the help of the [Stylish](https://addons.mozilla.org/en-US/firefox/addon/stylish/) browser extension):
+```css
+.card .card-content li {
+  float: right;
+  width: 200px;
+}
+.card .card-content {
+  border-right: unset;
+  padding: 0 0 5px 0;
+}
+.card .card-content:not(:last-child) {
+  border-bottom-width: 1px;
+  border-bottom-style: dashed;
+  border-bottom-color: var(--main-dark-grey);
+}
+```
+The vertical stack is implemented by the rules in the first selector: list items are floated right and assigned a fixed width, which aligns them neatly. The dashed borders and padding used to separate category lists was also adjusted to accomodate the new design (pictured below):
+
+![https://github.com/layer5io/layer5/issues/191#issuecomment-537304508](https://user-images.githubusercontent.com/13500769/66013483-5e049a80-e499-11e9-8920-52c3da81ece7.png)
+
+The above image is one of the [two mockups of the redesign](https://github.com/layer5io/layer5/issues/191#issuecomment-537304508) that I produced for the consideration of the project's developers. As luck would have it, Layer5 project lead [Lee Calcote](https://github.com/leecalcote) provided [a lightning-quick response](https://github.com/layer5io/layer5/issues/191#issuecomment-537310179), welcoming a pull request to it!
+
+![https://github.com/layer5io/layer5/issues/191#issuecomment-537310179](https://raungar.files.wordpress.com/2019/10/image-2.png?w=1024)
+
+#### Future research area: Materialize CSS
+
+I discovered that the 'cards' comprising the category section are styled using [Materialize CSS](https://materializecss.com/). I considered using this framework in my solution, but ultimately decided to opt for a simple, intuitive solution. This framework appears interesting, and would definitely merits research were this a more-involved styling task.
+
+## Implementing the solution
+
+While using my browser's developer tools to tinker with styling, I discovered an inline `style` tag that serviced the categories section. I determined that this tag would present the best place to add the styling rules that I wrote (following the coding style of a prior contributor).
+
+Finding the location of this `style` tag (i.e. of the "Service Mesh Landscape" page) in the source code was a lot more trouble than I thought it would be. After paging through too many HTML documents, I gave in and used Visual Studio's global search functionality to locate it.
+
+## Testing the solution
+
+Although I knew that my styling worked well when loaded from a browser extension, before I could contribute code, I needed to ensure that the styling worked equally-well when loaded inline from an HTML document. Little did I know, at that time, what I would be getting myself into...
+
+#### Ruby, Gems and Jekyll? `rvm`, `bundle` and `make`?
+
+Picking through my ~/.bash\_history file, here is the sequence of Bash shell commands that I issued (via WSL Ubuntu) in order to execute a local copy of the layer5 website (annotated for your convenience):
+```sh
+\## Install dependency packages ##
+sudo apt-get install build-essential
+sudo apt-get install software-properties-common
+
+## Install specific version of Ruby via Ruby Version Manager ## 
+sudo apt-add-repository -y ppa:rael-gc/rvm
+sudo apt-get update
+sudo apt-get install rvm
+rvm install "ruby-2.6.3" # install specific version of Ruby specified in Layer5's Gemfile
+                         # (Yes, it must be that exact version.)
+
+## Configure RubyGems ##
+echo 'export GEM\_HOME="$HOME/gems"' >> ~/.bashrc
+echo 'export PATH="$HOME/gems/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+
+## Install Jekyll and dependencies ## 
+gem install jekyll bundler
+bundle install           # install dependencies listed in Gemfile
+
+## Execute project! ## 
+make site                # references Layer5's Makefile
+                         # alias for "bundle exec jekyll serve --drafts --livereload"
+```
+#### Stray thoughts on documentation
+
+Reflecting back on the process, a question has stuck with me: how much should projects hold the hands of novice contributors? Setting up the means to run `make site` is not included within Layer5's [CONTRIBUTING.md file](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md). As such, for the most novice of contributors, like myself (who have never even heard of `make` before), setting up the prerequisite development environment presented a lengthy and piecemeal (albeit ultimately valuable) learning experience.
+
+How much documentation is too little? Too much? How high should the bar be set for contribution? I suppose it is up to the project's community to decide upon the answers to these questions themselves (and write documentation, accordingly).
+
+## Creating a pull request
+
+After successfully testing and fixing the styling on my local fork, I created [a pull request](https://github.com/layer5io/layer5/pull/192):
+
+![https://github.com/layer5io/layer5/pull/192](https://raungar.files.wordpress.com/2019/10/image-3.png?w=1024)
+
+Pull request – [Restyle landscape categories (#192)](https://github.com/layer5io/layer5/pull/192)
+
+...and it got merged! First Hacktoberfest contribution, completed!
+
+## Up next!
+
+I ended [my last post](https://raungar.wordpress.com/2019/09/27/planning-for-hacktoberfest-2019/) by stating that I have yet to gain any experience with makefiles. Well, thanks to my work on Layer5, that is no longer true: I have since used a makefile (to launch a Jekyll executable)! This experience will undoubtedly save me some time with resolving [the Comcast issue I found](https://github.com/Comcast/RestfulHttpsProxy/issues/5)! However, the next Hacktoberfest issue I resolve will be [_the first one I blogged about_](https://github.com/layer5io/layer5/issues/65).
+
+Stay tuned!

--- a/collections/_drafts/2019-10-12-hacktoberfest-2019-is-heating-up.md
+++ b/collections/_drafts/2019-10-12-hacktoberfest-2019-is-heating-up.md
@@ -1,0 +1,76 @@
+---
+layout: post
+title:  "#Hacktoberfest 2019 is heating up!"
+date:   2019-10-12 21:58:00 +0000
+image: https://raungar.files.wordpress.com/2019/10/hacktoberfestw2.png
+author: Rafi Ungar
+permalink: /blog/hacktoberfest-2019-is-heating-up
+---
+_(ICYMI: [I've made my first-ever Hacktoberfest contribution](https://raungar.wordpress.com/2019/10/02/hacktoberfest-2019-documenting-my-first-ever-hacktoberfest-contribution/)!)_
+
+[Hacktoberfest 2019](https://hacktoberfest.digitalocean.com/) is now well underway, and I am happy to report that I have made my second contribution to my new favorite open source community, [**Layer5**](https://layer5.io/) ([on GitHub](https://github.com/layer5io))!
+
+_Before I continue on, I want to extend a huge thank-you to Layer5's lead developer, Lee Calcote, as well as the Layer5 community managers for welcoming me into the Layer5 Slack channel, allowing me to introduce myself in their weekly community meeting, and even giving my blog [an awesome shout out on Twitter](https://twitter.com/layer5/status/1180317604168306688?s=12)!_
+
+* * *
+
+This week, I helped resolve the very first issue that I outlined in my [Planning for #Hacktoberfest 2019](https://raungar.wordpress.com/2019/09/27/planning-for-hacktoberfest-2019/) post:
+
+![](https://raungar.files.wordpress.com/2019/10/image-4.png?w=1024)
+
+Issue [layerio#65](https://github.com/layer5io/layer5/issues/65): enhancements for the [Layer5 Landscape page](https://layer5.io/landscape/)
+
+At the time I found this issue, the second requested enhancement (concerning table row coloration) [was already handled](https://github.com/layer5io/layer5/commit/b313268cb578e762d1212c9910b522af2869b57b) by another contributor, leaving me with two tasks:
+
+1. Implementing the specified sorting functionalities (for the three tables on the [Landscape page](https://layer5.io/landscape/))
+2. Restyling the font color of site hyperlinks (an enhancement [requested later on](https://github.com/layer5io/layer5/issues/65#issuecomment-483912458) in the issue)
+
+### The strange case of Jekyll
+
+Fortunately, thanks to my previous work with Layer5's website, I was already all set up with an offline development environment. However, going into my first task, I knew very little about Jekyll except how to install it.
+
+_[Jekyll](https://jekyllrb.com/) and [Liquid](https://shopify.github.io/liquid/)... it's got to be like React or Angular, right? I mean, all I need to do is slap in [sort](https://shopify.github.io/liquid/filters/sort/) and [reverse filters](https://shopify.github.io/liquid/filters/reverse/) and toggle them onclick, right_...?  
+  
+_...Wait, what's a "static site generator"?_
+
+* * *
+
+After discovering what Jekyll and Liquid actually were, I determined that I would have to resort to DOM manipulation to fully accomplish my first task. However, I did succeed in accomplishing the default sorting behaviour by enhancing the Liquid tags being used by several tables.
+
+To do so, I followed coding style on the issue's previous contributor by encapsulating my work within a new JavaScript file in the project's assets folder: a simple bubble sort function.
+
+I chose to implement the [simplest of sorting algorithms](https://github.com/layer5io/layer5/blob/master/assets/js/table-sort.js#L13) in JavaScript (which I count as study for my _Data Structures and Algorithms_ midterm):
+
+```js
+// Excerpted from https://github.com/layer5io/layer5/blob/master/assets/js/table-sort.js
+let bubbleSort = () => {
+  for (i = 0; i < rows.length-1; i++) {
+    for (j = 0; j < rows.length-i-1; j++) {
+      if (shouldSwap(text(j), text(j+1))) {
+        rows\[j\].parentNode.insertBefore(rows\[j+1\], rows\[j\]);
+        didSort = true;
+      }
+    }
+  }
+};
+```
+
+### Painting over Pumpkin Bread
+
+[Encycolorpedia.com](https://encycolorpedia.com) lists the hex color code `#fdac40` as "[Valspar Paint Pumpkin Bread](https://encycolorpedia.com/fdac40)". Although Layer5.io's then-difficult-to-read hyperlinks were colored `#ffa_b_40`, I'd still like to think that the second task of my second Hacktoberfest contribution was festively-themed!
+
+In [my last blog post](https://raungar.wordpress.com/2019/10/02/hacktoberfest-2019-documenting-my-first-ever-hacktoberfest-contribution/), I mentioned that [Materialize CSS](https://materializecss.com) was worth further research. Well, after some poking around, I discovered that all of Layer5.io's pumpkin-colored hyperlink styling (both [deliberate](https://github.com/layer5io/layer5/blob/master/assets/css/materialize.css#L1751), and [incidental](https://github.com/layer5io/layer5/blob/master/assets/css/materialize.css#L5149)) originated from its [materialize.css](https://github.com/layer5io/layer5/blob/master/assets/css/materialize.css) asset.
+
+Although this asset has been [frequently modified](https://github.com/layer5io/layer5/commits/master/assets/css/materialize.css), I was still hesitant to globally alter the site's styling (in case a return to Pumpkin Bread was desired in the future), so I instead opted to [add a new inline style tag](https://github.com/layer5io/layer5/pull/209/files#diff-48443fc170100677376b7ee11324494b) to override [a styling rule](https://github.com/layer5io/layer5/blob/master/assets/css/materialize.css#L5149) (on top of removing the 'orange-text' class from individual anchor elements).
+
+* * *
+
+All of the changes I've made can be viewed through [my (merged) pull request](https://github.com/layer5io/layer5/pull/209):
+
+![](https://raungar.files.wordpress.com/2019/10/image-6.png?w=1024)
+
+Pull request [layer5io#209](https://github.com/layer5io/layer5/pull/209): resolved the remainder of issue [layerio#65](https://github.com/layer5io/layer5/issues/65)
+
+* * * 
+
+I am very fortunate to be so well-supported by the open source communities I have worked with so far, both on-campus and abroad. With their support behind me, I feel equipped to start learning what I need to know to resolve the next two more-difficult issues that lie ahead of me!

--- a/collections/_drafts/2019-11-15-introducing-comparative-spectrums-to-the-layer5-landscape.md
+++ b/collections/_drafts/2019-11-15-introducing-comparative-spectrums-to-the-layer5-landscape.md
@@ -1,0 +1,84 @@
+---
+layout: post
+title: "Introducing Comparative Spectrums to the Layer5 Landscape"
+date:   2019-11-15 5:43:00 +0000
+author: Rafi Ungar
+permalink: /blog/introducing-comparative-spectrums-to-the-layer5-landscape
+---
+During [Hacktoberfest 2019](https://raungar.wordpress.com/tag/layer5/), I worked on the website of [Layer5](https://layer5.io/), _the_ service mesh community. More specifically, my contributions concerned one specific page of that website: its [Service Mesh Landscape page](https://layer5.io/landscape/).
+
+Shortly after making these contributions, I was graciously welcomed into the Layer5 community by its lead developer [Lee Calcote](https://twitter.com/lcalcote?lang=en), who later directly approached me to assist him in furthering his vision for the Landscape page by implementing "comparative spectrums". Wishing to focus on my remaining two Hacktoberfest contributions at the time, I suggested surveying the interest of other potential contributors for this project. As such, an informative issue was opened:
+
+![](https://raungar.files.wordpress.com/2019/11/screenshot_2019-11-15-landscape-create-comparative-spectrums-for-ease-of-contrasting-service-meshes-c2b7-issue-211-c2b7-layer5io....png?w=773)
+
+Issue [layer5#211](https://github.com/layer5io/layer5/issues/211): add comparative spectrums to the Landscape page
+
+A month later, I fortunately found time enough to make some major progress into this issue.
+
+* * *
+
+This issue is quite highly conceptual, much moreso than any other issue I have thus far worked on. I decided that the best way to approach this issue would be to focus on establishing a set of tools that could be used by more-knowledgeable contributors to later construct comparative spectrums—opinionated data visualizations. As such, my first step was to build a set of responsive graphical elements that resembled [those provided as examples](https://docs.google.com/presentation/d/1P6LzzG0_alAxshpdfLnix53S9WU4vjbpSCrHJQoWPqc/edit#slide=id.p6). These include:
+
+#### (1) _Sleek information cards:_
+
+![](https://raungar.files.wordpress.com/2019/11/image-4.png?w=247)
+
+_or this:_
+
+![](https://raungar.files.wordpress.com/2019/11/image-5.png?w=238)
+
+_(Source: [ONIF Container Networking Panel, slides 5 and 6](https://docs.google.com/presentation/d/1P6LzzG0_alAxshpdfLnix53S9WU4vjbpSCrHJQoWPqc/edit#slide=id.p6))_
+
+#### (2) _Gradiented, labelable double-arrow banners:_
+
+![](https://raungar.files.wordpress.com/2019/11/image-3.png?w=886)
+
+_(Source: [ONIF Container Networking Panel, slide 5](https://docs.google.com/presentation/d/1P6LzzG0_alAxshpdfLnix53S9WU4vjbpSCrHJQoWPqc/edit#slide=id.p6))_
+
+#### (3) _Graphically-augmented tables:_
+
+![](https://raungar.files.wordpress.com/2019/11/image-7.png?w=1024)
+
+_(Source: [ONIF Container Networking Panel, slide 8](https://docs.google.com/presentation/d/1P6LzzG0_alAxshpdfLnix53S9WU4vjbpSCrHJQoWPqc/edit#slide=id.p12))_
+
+#### (4) _Spectrum-like graphical comparisons:_
+
+![](https://raungar.files.wordpress.com/2019/11/image-6.png?w=1024)
+
+_(Source: [ONIF Container Networking Panel, slide 7](https://docs.google.com/presentation/d/1P6LzzG0_alAxshpdfLnix53S9WU4vjbpSCrHJQoWPqc/edit#slide=id.p6))_
+
+* * *
+
+(1) Although there may exist libraries that may help construct such graphical elements, I did not want to introduce additional libraries to accomplish my work. Instead, I wanted to make good use of Layer5io's preexisting [Materialize](https://materializecss.com/) library. Fortunately, Materialize strongly supports the design of card-like structures, allowing me to more easily [implement some](https://github.com/layer5io/layer5/pull/238/files#diff-20fc098534d6aab31ad8e5c9db51bde0R10).
+
+(2) Unfortunately, it does not seem that Materialize supports the creation of graphical arrows, so I just ended up [styling my own](https://github.com/layer5io/layer5/pull/238/files#diff-1d5fe92e61759723c94b009b32e9e1b7R2).
+
+(3) These tables can be quite easily implemented and styled with or without the use of `<table>` tags. I anticipate these will be given a proper fleshing out after the other graphical elements are further developed.
+
+(4) These unique spectrum graphics present the most challenging, of all the comparison tools, to implement. Snaking spectrum bar aside, I needed to develop a _responsive_ solution that (a) allowed contributors to programmatically place image thumbnails at preset horizontal positions, while (b) ensuring those thumbnails placed at the same position do not overlap with one another (and instead align vertically atop each other).
+
+This presented a problem to solve: I required a means to 'float' elements toward a horizontal line; to 'stack' thumbnails atop one another, without overlap, if they are given the same horizontal position. After researching quite deeply into potential solutions to this problem, I ended up stumbling across some CSS property-value pairings that I had never heard of before: [`display: grid`](https://www.w3schools.com/css/css_grid.asp) and [`grid-auto-flow: row dense`](https://www.w3schools.com/cssref/pr_grid-auto-flow.asp). Miraculously, I discovered that these could actually function as [a basis for a solution](https://github.com/layer5io/layer5/pull/238/files#diff-1d5fe92e61759723c94b009b32e9e1b7R76).
+
+* * *
+
+After styling the graphical elements, I continued the website's trend of using [Liquid](https://help.shopify.com/en/themes/liquid) tags (e.g. [`for`](https://help.shopify.com/en/themes/liquid/tags/iteration-tags#for)) and [YAML lists](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html) to help modularize my solutions, which should aid future contributors in generalizing them.
+
+* * *
+
+I opened [a pull request](https://github.com/layer5io/layer5/pull/238) to share my work as well as invite collaboration:
+
+![](https://raungar.files.wordpress.com/2019/11/screenshot_2019-11-15-initial-work-towards-comparative-spectrums-211-by-silvyre-c2b7-pull-request-238-c2b7-layer5io-layer5-copy.png?w=768)
+
+Pull request [layer5#238](https://github.com/layer5io/layer5/pull/238): description of tooling introduced  
+
+![](https://raungar.files.wordpress.com/2019/11/screenshot_2019-11-15-initial-work-towards-comparative-spectrums-211-by-silvyre-c2b7-pull-request-238-c2b7-layer5io-layer5-copy-2.png?w=700)
+
+Pull request [layer5#238](https://github.com/layer5io/layer5/pull/238): example images of tooling introduced
+
+The pull request was quite well-recieved:
+
+![](https://raungar.files.wordpress.com/2019/11/screenshot_2019-11-15-initial-work-towards-comparative-spectrums-211-by-silvyre-c2b7-pull-request-238-c2b7-layer5io-layer5-2.png?w=753)
+
+[Comment](https://github.com/layer5io/layer5/pull/238#issuecomment-554181763) by Layer5 team lead on pull request [layer5#238](https://github.com/layer5io/layer5/pull/238)
+
+As I mentioned in a recent Layer5 community meeting, I am very excited to continue working with Layer5; to refine and expand upon this set of new, visionary tooling for their landscape!

--- a/collections/_drafts/2019-12-04-layer5-landscape-spectrums-revisited.md
+++ b/collections/_drafts/2019-12-04-layer5-landscape-spectrums-revisited.md
@@ -1,0 +1,52 @@
+---
+layout: post
+title: "Layer5: Landscape Spectrums Revisited"
+date:   2019-12-04 18:10:00 +0000
+author: Rafi Ungar
+permalink: /blog/layer5-landscape-spectrums-revisited
+---
+Several weeks ago, I wrote [a blog post](https://raungar.wordpress.com/2019/11/15/introducing-comparative-spectrums-to-the-layer5-landscape/) about introducing "comparative spectrum" tools to [the Layer5 landscape](https://layer5.io/landscape/)—a webpage which I have transformed multiple times, now!
+
+Up until now, the contents of each blog post I have written were centered upon a freshly-opened pull request. Shortly before writing my last post, I did open [one such pull request (layer5#238)](https://github.com/layer5io/layer5/pull/238). However, since my PR remains open, and since I am still working on the same issue my PR addresses, I have opted to instead push [a new commit](https://github.com/layer5io/layer5/pull/238/commits/4d396aaa6d3ca46add71531daedc8c0e2a5d2495) to the aformentioned (but, now, renamed) PR instead of creating a whole new one. This newest commit introduces a major step towards resolving the issue at hand, and will be the subject of this blog post!
+
+![](https://raungar.files.wordpress.com/2019/11/screenshot_2019-11-15-landscape-create-comparative-spectrums-for-ease-of-contrasting-service-meshes-c2b7-issue-211-c2b7-layer5io....png?w=773)
+
+The issue at hand: [layer5#211](https://github.com/layer5io/layer5/issues/211) - add comparative spectrums to the Landscape page
+
+* * *
+
+_**Note:** this blog post will frequently reference [the update and documentation comment that I made](https://github.com/layer5io/layer5/pull/238#issuecomment-561613644) to accompany my last commit to my PR. I consider this hefty comment to be an extension of this blog post, so I strongly recommend giving it a read!_
+
+* * *
+
+My initial commit towards introducing comparative spectrum tooling did not represent a full solution. Thinking about what might constitute a full solution for the issue at hand, I came up with three criteria:
+
+## What was still needed:
+
+#### 1\. A complete toolset
+
+Within [Issue #211](https://github.com/layer5io/layer5/issues/211), Layer5 lead developer Lee indicates [four slides](https://docs.google.com/presentation/d/1P6LzzG0_alAxshpdfLnix53S9WU4vjbpSCrHJQoWPqc/edit#slide=id.p6) upon which comparative spectrum graphics may be based upon. During my initial commit, I created graphics that emulated those found within the first three of those four slides, but I had yet to implement the graphic found in [the fourth](https://docs.google.com/presentation/d/1P6LzzG0_alAxshpdfLnix53S9WU4vjbpSCrHJQoWPqc/edit#slide=id.p12): a table. I was also less-than-satisfied with the 'grid' design I had implemented in response to [slide 7](https://docs.google.com/presentation/d/1P6LzzG0_alAxshpdfLnix53S9WU4vjbpSCrHJQoWPqc/edit#slide=id.p10).
+
+#### 2\. A modular design
+
+The designs I am implementing are meant to be used to present opinionated information. As I am not nearly knowledgeable to form opinionated comparisons between service meshes and related technologies, I have instead made my goal to make it as easy as possible for other Layer5 contributors to utilize the graphics ("\[comparative\] spectrums") that I am designing. Doing so would require encapsulating (templating) the spectrums I design (new and old), within their own HTML files, and providing a means to easily invoke (and customize) instances of those templates into the Landscape page.
+
+#### 3\. Documentation
+
+Because the templates I design are intended to be implemented and customized by other contributors, it is _especially_ critical that those contributors have access to complete and thorough documentation detailing the intended use of each templated design.
+
+* * *
+
+## What I delivered:
+
+#### 1\. A complete toolset
+
+As documented in my [update comment](https://github.com/layer5io/layer5/pull/238#issuecomment-561613644), I designed a table that very closely resembles that of Lee's slides. Implementing the table was interesting, as it ended up requiring [quite a few nested Liquid for-loops](https://github.com/layer5io/layer5/blob/4d396aaa6d3ca46add71531daedc8c0e2a5d2495/_includes/partials/spectrum/table.html#L23). Also as documented, I revamped the grid-based tooling and am quite pleased with the improvements made. The end result of these efforts is a complete set of comparative spectrums.
+
+#### 2, 3. A modular design and documentation
+
+The bulk of the documentation I wrote details how to deal with the modular solution that I designed and implemented to enable comparative spectrums to be included into the Landscape page (through the use of Liquid `include` tags). The documentation speaks for itself; [check it out!](https://github.com/layer5io/layer5/pull/238#issuecomment-561613644)
+
+## What's next?
+
+I would not have considered the documentation I delivered to be complete if I did not report on the issues still present in the work I delivered. I denoted these as 'Current issues' in the documentation, and they represent work that still remains to be done. I know that I can count on the Layer5 community to assist me with small issues like these, and, once this pull request receives some forward motion, I hope to start zeroing in on its smaller issues. Fortunately, I have made plans to continue working with open source well into the new year!


### PR DESCRIPTION
I've converted [my first Layer5-related blog post on Wordpress](https://raungar.wordpress.com/2019/10/02/hacktoberfest-2019-documenting-my-first-ever-hacktoberfest-contribution/) into Markdown (using [wordpress-export-to-markdown](https://github.com/lonekorean/wordpress-export-to-markdown)) and have added it as a new .md file within [`/collections/_drafts`](https://github.com/layer5io/layer5/tree/master/collections/_drafts).

If everything looks good, here, I'll do the same with my other Layer5-related blog posts.