### PR TITLE
Improve syntax highlighting within active Hacktoberfest posts

### DIFF
--- a/_sass/_syntax-highlighting.scss
+++ b/_sass/_syntax-highlighting.scss
@@ -38,12 +38,12 @@
     .s     { color: #d14 } // Literal.String
     .na    { color: #008080 } // Name.Attribute
     .nb    { color: #0086B3 } // Name.Builtin
-    .nc    { color: #458; font-weight: bold } // Name.Class
+    .nc,.nd    { color: #458; font-weight: bold } // Name.Class
     .no    { color: #008080 } // Name.Constant
     .ni    { color: #800080 } // Name.Entity
     .ne    { color: #900; font-weight: bold } // Name.Exception
-    .nf    { color: #900; font-weight: bold } // Name.Function
-    .nn    { color: #555 } // Name.Namespace
+    .nf,.nl    { color: #900; font-weight: bold } // Name.Function
+    .nn,.n,.p,.o    { color: #555 } // Name.Namespace
     .nt    { color: #000080 } // Name.Tag
     .nv    { color: #008080 } // Name.Variable
     .ow    { font-weight: bold } // Operator.Word

--- a/collections/_blogs/2019-10-02-hacktoberfest-2019-documenting-my-first-ever-hacktoberfest-contribution.md
+++ b/collections/_blogs/2019-10-02-hacktoberfest-2019-documenting-my-first-ever-hacktoberfest-contribution.md
@@ -34,6 +34,12 @@ To address this issue, I came up with the idea of realigning the category list i
 
 Implementating this idea proved quite simple, requiring only [a few added CSS rules](https://github.com/layer5io/layer5/issues/191#issuecomment-537304508), which I first accomplished by tinkering with the live webpage's styling (with the help of the [Stylish](https://addons.mozilla.org/en-US/firefox/addon/stylish/) browser extension):
 
+<style>
+  code, kbd, pre, samp {
+    color: mediumblue;
+  }
+</style>
+
 ```css
 .card .card-content li {
   float: right;
@@ -76,7 +82,7 @@ Although I knew that my styling worked well when loaded from a browser extension
 
 Picking through my ~/.bash\_history file, here is the sequence of Bash shell commands that I issued (via WSL Ubuntu) in order to execute a local copy of the layer5 website (annotated for your convenience):
 ```sh
-\## Install dependency packages ##
+## Install dependency packages ##
 sudo apt-get install build-essential
 sudo apt-get install software-properties-common
 

--- a/collections/_blogs/2019-10-12-hacktoberfest-2019-is-heating-up.md
+++ b/collections/_blogs/2019-10-12-hacktoberfest-2019-is-heating-up.md
@@ -41,6 +41,11 @@ To do so, I followed coding style on the issue's previous contributor by encapsu
 
 I chose to implement the [simplest of sorting algorithms](https://github.com/layer5io/layer5/blob/master/assets/js/table-sort.js#L13) in JavaScript (which I count as study for my _Data Structures and Algorithms_ midterm):
 
+<style>
+  code, kbd, pre, samp {
+    color: mediumblue;
+  }
+</style>
 ```js
 // Excerpted from https://github.com/layer5io/layer5/blob/master/assets/js/table-sort.js
 let bubbleSort = () => {


### PR DESCRIPTION
Fixes #318:
- Modifies syntax highlighting styling within `_sass/_syntax-highlighting.scss` to make up for missing styling classes
- Adds `<style>` tags to Markdown blog post files to override default white text color within code blocks.