### PR TITLE
Docs: Removed `sudo` from `mesheryctl` command

### DIFF
--- a/_includes/meshery.html
+++ b/_includes/meshery.html
@@ -209,13 +209,13 @@
       <div id="start" class="highlight highlight-source-shell">
       <div style="width:auto; height:auto; padding:0px; position:relative;">
             <pre><code>
- $ curl -L https://git.io/meshery | sudo bash -    
+ $ curl -L https://git.io/meshery | bash -    
         </code></pre>
             <!-- copy to clipboard -->
             <a class="btn waves-effect waves-dark white-text darken-2 l5-light-blue z-depth-4"
               style="position: absolute; top: 0px; right: 0px; border: 0;"
               data-clipboard-target="#start"
-              data-clipboard-text="curl -L https://git.io/meshery | sudo bash -  ">
+              data-clipboard-text="curl -L https://git.io/meshery | bash -  ">
               <img src="/assets/images/buttons/clippy.svg" width="18px" height="18px" style="vertical-align: middle;" />
             </a>
         </div> 


### PR DESCRIPTION
`sudo` is no longer required in script for installation of `mesheryctl`.

Signed-off-by: nidhinmahesh <nidhinmahesh1@gmail.com>