### PR TITLE
Fixed 'invalid' link and 'scrollbar' issue for chrome'

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -38,9 +38,9 @@
           <li><a class="black-text" href="/subscribe">Mailing list</a></li>
           <li><a class="black-text" href="/careers/internships">Internships</a></li>
           <ul>
-            <li><a class="black-text " href="/gsoc/2020">GSoC 2020</a></li>
-            <li><a class="black-text " href="/gsod/2020">GSoD 2020</a></li>
-            <li><a class="black-text " href="/communitybridge/2020">CommunityBridge</a></li>
+            <li><a class="black-text " href="/programs//gsoc/2020">GSoC 2020</a></li>
+            <li><a class="black-text " href="/programs/gsod/2020">GSoD 2020</a></li>
+            <li><a class="black-text " href="/programs/communitybridge/2020">CommunityBridge</a></li>
 
           </ul>
         </ul>

--- a/index.html
+++ b/index.html
@@ -6,15 +6,6 @@ image:
 ---
 
 <head>
-  <style>
-    /* html {
-      overflow:   scroll;
-    } */
-    ::-webkit-scrollbar {
-      width: 0px;
-      background: transparent; /* make scrollbar transparent */
-    }
-  </style>
 </head>
 <body>
   <div class="container no-pad-top">


### PR DESCRIPTION
The link for the 'gsoc', 'gsod' and 'communitybridge' in the footer was left out in the last update.
And, somehow the scrollbar again disappeared from chrome, so a fix for that too!
Signed-off-by: Nikhil-Ladha <nikhilladha1999@gmail.com>
