### PR TITLE
[NG] Pointer to persistent site preview

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 ## Contributing to Layer5
 You want to contribute to the project? Yay! We want you to! Visit our centralized instructions for [contributing](https://github.com/layer5io/meshery/blob/master/CONTRIBUTING.md#contributing). Contributions, updates, [discrepancy reports](/../../issues) and [pull requests](/../../pulls) are welcome! Layer5 is community-built and warmly welcomes collaboration. Contributors are expected to adhere to our [Code of Conduct](.CODE_OF_CONDUCT.md).
 
-# Layer5 Site
-This repository is for development of the next generation of layer5.io using Gatsby and Strapi.
+# Layer5-NG Site
+This repository is for development of the next generation of layer5.io using Gatsby and Strapi. A persistent deployment of the site is available at https://layer5ng.netlify.app
 
 See the [design document](https://docs.google.com/document/d/1rvUZy2_S1a2_14BAQIg6b9cMhUuu04kYzkOPDPaPptI/edit#) for more information and the [#layer5-ng](https://layer5io.slack.com/archives/C015QJKUMPU) channel.
 


### PR DESCRIPTION
A quick update to point contributors to the https://layer5ng.netlify.app URL.