### PR TITLE
Updates to Istio data

### DIFF
--- a/_data/landscape/meshes.yml
+++ b/_data/landscape/meshes.yml
@@ -115,11 +115,11 @@
   tcp-web: "Yes"
   grpc: "Yes"
   h2: "Yes"
-  multi-cluster: "Experimental"
-  multi-tenant: "Experimental"
-  desc: "An open platform to connect, monitor, and secure microservices. Governed by Google and IBM."
+  multi-cluster: "Yes"
+  multi-tenant: "Yes"
+  desc: "An open platform to connect, monitor, and secure microservices. Created by Google and IBM; now with maintainers from 14 companies and implementations from over 15 vendors."
   prometheus: "Yes"
-  tracing: "Jaeger"
+  tracing: "OpenTracing, Zipkin, Jaeger, Lightstep"
   encryption: "Yes"
   multi-tenant-score: 5
   netdev-persona-score: 1

--- a/_data/landscape/non-functional.yml
+++ b/_data/landscape/non-functional.yml
@@ -65,7 +65,7 @@
   primary-lang: Go
   announce-date: May 2017
   ga-1-date: July 2018
-  commercial: AspenMesh
+  commercial: AspenMesh, Layer5, Solo.io, Tetrate
   category: Service Mesh
   timeline-order: 5
   icon: assets/images/service-mesh-icons/istio.png


### PR DESCRIPTION
There are probably more; I'm not sure what the various scores are.

I would also update the "commercial offerings" section.  You can get OSS Istio support from Aspen Mesh, Tetrate and Solo.io.  You can get hosted Istio or products built on Istio from Google, IBM, Red Hat, Cisco, VMware, Cloud Foundry, Banzai Cloud, Rancher Labs, Mulesoft, Alibaba, Huawei, Oracle, Mirantis, D2IQ, Kubesphere and Nutanix
