### PR TITLE
Removed extra padding from single news template

### DIFF
--- a/src/sections/News-single/NewsSingle.style.js
+++ b/src/sections/News-single/NewsSingle.style.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 const NewsPageWrapper = styled.div`
  color: #000;     
 .single-post-wrapper{
-    padding: 50px 0 180px 0;
+    padding: 50px 0;
 }
 .single-post-block{
     p{
@@ -15,12 +15,6 @@ const NewsPageWrapper = styled.div`
     p+p{
         margin-top: 30px;  
     }
-}
-
-@media only screen and (max-width: 912px) {
-     .single-post-block{
-         padding-bottom: 120px;
-     }
 }
 `;
 export default NewsPageWrapper;


### PR DESCRIPTION
Signed-off-by: Steven Budinata <stevenbudinata@gmail.com>

**Description**

This PR fixes #

**Notes for Reviewers**
Removed extra padding from single news template

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->