### PR TITLE
Updated Service Mesh Standards section on Meshery page

### DIFF
--- a/_includes/meshery.html
+++ b/_includes/meshery.html
@@ -211,7 +211,7 @@
     <h6 style="color:#111111;text-align: left;">Service Mesh Performance </h6><a name="smp"></a>
     <img src="/assets/images/buttons/smp-dark-text.png" 
     class="light-shadow" width="25%" style="display:inline;float:left;margin-right:1%;padding:5px;" />
-    The <a href="https://github.com/layer5io/service-mesh-performance">Service Mesh Performance (SMP)</a>
+    The <a href="https://smp-spec.io">Service Mesh Performance (SMP)</a>
      is a vendor-neutral specification to aid operators in assessing the overhead of their service mesh in context of the value it provides.
      Layer5's MeshDex provides a universal performance index to gauge your mesh’s efficiency against deployments in other organizations’ environments.
     <p style="text-align:center;">Learn more about <a href="/performance">this open standard</a> as a partnership of Layer5, UT Austin, and Google.</p>


### PR DESCRIPTION
**Info**

- The link in this section now points to the new `https://smp-spec.io` website.
- The SMPS has already been upgraded to SMP (Service Mesh Performance) in the Service Mesh Standards section.
- SMPS logo has already been updated by SMP logo.

This PR fixes #574 

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.