### PR TITLE
fixed video iframe on GSOC page 

### DIFF
--- a/collections/_programs/gsoc_2020.html
+++ b/collections/_programs/gsoc_2020.html
@@ -17,6 +17,19 @@ excerpt: "Layer5 - Google Summer of Code"
   li.gsoc {
     margin-left: 15px;
   }
+
+  ul.layer5 {
+    margin: 0px;
+    padding: 0px;
+  }
+
+  ol.layer5 {
+    margin-left: 0px;
+    margin-right: 0px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    padding: 0px;
+  }
 </style>
 <div style="z-index: 20;">
   <h3 class="black-text">Google Summer of Code and Layer5</h3>
@@ -153,11 +166,11 @@ Kush Trivedi (<a href="https://github.com/kushthedude">@kushthedude</a>)
       allowfullscreen
     ></iframe>
   </div>
-  <ul>
-    <ol>
+  <ul class="layer5">
+    <ol class="layer5">
       <b>What is Layer5?</b>
     </ol>
-    <ol>
+    <ol class="layer5">
       While small, the Layer5 community represents the largest collection of
       service mesh projects and their maintainers in the world. We build
       projects to provide learning environments, deployment and operational best
@@ -166,22 +179,22 @@ Kush Trivedi (<a href="https://github.com/kushthedude">@kushthedude</a>)
       pushes Layer5 projects forward. New members are always welcome.
     </ol>
   </ul>
-  <ul>
-    <ol>
+  <ul class="layer5">
+    <ol class="layer5">
       <b>Is it Open Source?</b>
     </ol>
-    <ol>
+    <ol class="layer5">
       Layer5 projects are open source software. Anyone can download, use, work
       on, and share it with others. It's built on principles like collaboration,
       globalism, and innovation. Layer5 projects are distributed under the terms
       of Apache v2.
     </ol>
   </ul>
-  <ul>
-    <ol>
+  <ul class="layer5">
+    <ol class="layer5">
       <b>Google Summer of Code Participation?</b>
     </ol>
-    <ol>
+    <ol class="layer5">
       The key component of these projects is our Community. This community,
       which you will join as an participant in Google Summer of Code, is
       improving the world of diverse cloud native systems. Your contributions
@@ -191,8 +204,8 @@ Kush Trivedi (<a href="https://github.com/kushthedude">@kushthedude</a>)
       started.
     </ol>
   </ul>
-  <ul>
-    <ol>
+  <ul class="layer5">
+    <ol class="layer5">
       We believe that all contributors should expect and be part of a safe and
       friendly environment for constructive contribution. We can more
       effectively and successfully compare and challenge different ideas to find

--- a/collections/_programs/gsoc_2020.html
+++ b/collections/_programs/gsoc_2020.html
@@ -145,8 +145,8 @@ Kush Trivedi (<a href="https://github.com/kushthedude">@kushthedude</a>)
     style="position: relative; float: right;margin-left:20px;"
   >
     <iframe
-      width="392"
-      height="220.5"
+      width="100%"
+      height="100%"
       src="https://www.youtube.com/embed/0yN5T5LB9ps"
       frameborder="0"
       allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"

--- a/collections/_programs/gsoc_2020.html
+++ b/collections/_programs/gsoc_2020.html
@@ -23,6 +23,11 @@ excerpt: "Layer5 - Google Summer of Code"
     padding: 0px;
   }
 
+  ul.aligned {
+    margin: 15px;
+    padding: 0px;
+  }
+
   ol.layer5 {
     margin-left: 0px;
     margin-right: 0px;
@@ -44,7 +49,7 @@ excerpt: "Layer5 - Google Summer of Code"
   </div>
   <h5 class="black-text">2020 Program Timeline</h5>
   <div class="gsoc">
-    <ul>
+    <ul class="aligned">
       <li class="gsoc">January 14 - Organization applications open</li>
       <li class="gsoc">February 20 - Accepted GSoC Organizations announced</li>
       <li class="gsoc">March 16-March 31 - Students submit their proposals</li>
@@ -57,8 +62,8 @@ excerpt: "Layer5 - Google Summer of Code"
     </ul>
   </div>
   <h5 class="black-text">Statistics</h5>
-  <div style="margin-left: 25px;">
-    <ul>
+  <div class="gsoc">
+    <ul class="aligned">
       <li class="gsoc">
         In 15 years 15,926 students from 109 countries have been accepted into
         GSoC
@@ -73,9 +78,9 @@ excerpt: "Layer5 - Google Summer of Code"
     </ul>
   </div>
   <h5 class="black-text">Project Ideas</h5>
-  <div style="margin-left: 25px;">
+  <div style="margin-left: 25px; margin-right: 25px;">
     <b>SMI Conformance Testing</b>
-    <ul>
+    <ul class="aligned">
       <li class="gsoc">
         <b>Description</b>: Ensure that a service mesh is properly configured
         and that its behavior conforms to official SMI specifications.
@@ -106,9 +111,9 @@ Naveen Jain (<a href="https://github.com/nveenjain">@nveenjain</a>)
 </li>
     </ul>
   </div>
-  <div style="margin-left: 25px;">
+  <div style="margin-left: 25px; margin-right: 25px;">
     <b>Distributed Load Testing of Service Meshes</b>
-    <ul>
+    <ul class="aligned">
       <li class="gsoc">
         <b>Description</b>: Many performance benchmarks are limited to single
         instance load generation (single pod load generator). This limits the


### PR DESCRIPTION
Signed-off-by: Navendu Pottekkat <navendupottekkat@gmail.com>

**Description**

The YouTube video is out of the page when viewed on a mobile device as shown below:

![Screenshot from 2020-11-06 11-33-45](https://user-images.githubusercontent.com/49474499/98332059-f453aa00-2023-11eb-9487-5396cd887373.png)

This is fixed by setting the iframe size to percentages instead of pixel values. And the fixed version is shown below:

![Screenshot from 2020-11-06 11-25-23](https://user-images.githubusercontent.com/49474499/98332138-15b49600-2024-11eb-84b4-6d2b371a669c.png)

And on the web:

![Screenshot from 2020-11-06 11-25-12](https://user-images.githubusercontent.com/49474499/98332167-249b4880-2024-11eb-951a-2c0fa0469080.png)

This PR fixes #1076 

- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->