### PR TITLE
Latest post section gets populated dynamically.

### DIFF
--- a/src/sections/Blog-sidebar/index.js
+++ b/src/sections/Blog-sidebar/index.js
@@ -70,7 +70,7 @@ const Sidebar = ( ) => {
                             <div className="recent-post-block" key={post.fields.slug}>
                                 <img src={post.frontmatter.thumbnail.publicURL} 
                                     alt="prime-app" 
-                                    height="80" width="80"/>
+                                    width="80px"/>
                                 <div className="recent-post-content-block">
                                     <Link to={post.fields.slug}>
                                         <h3> {post.frontmatter.title} </h3>

--- a/src/sections/Blog-sidebar/index.js
+++ b/src/sections/Blog-sidebar/index.js
@@ -6,17 +6,14 @@ import { FaSearch } from "react-icons/fa";
 
 import Button from "../../reusecore/Button";
 
-import WdThumb1 from "../../assets/images/blog/widgets-thumb/01.png";
-import WdThumb2 from "../../assets/images/blog/widgets-thumb/02.png";
-import WdThumb3 from "../../assets/images/blog/widgets-thumb/03.png";
 
 import BlogSideBarWrapper from "./blogSidebar.style";
 
 const Sidebar = ( ) => {
     const data = useStaticQuery(
         graphql`
-            query allTags {
-                allMdx(
+            query allTagsAndLatestPosts {
+                allTags: allMdx(
                     filter: { fields: { collection: { eq: "blog" } }, frontmatter: { published: { eq: true } } }
                 ){
                     group(field: frontmatter___tags) {
@@ -24,11 +21,33 @@ const Sidebar = ( ) => {
                         totalCount
                     }
                 }
+
+                latestPosts: allMdx(
+                    sort: { fields: [frontmatter___date], order: DESC}
+                    filter: { fields: { collection: { eq: "blog" } }, frontmatter: { published: { eq: true } } }
+                    limit: 4      
+                ) {
+                    nodes {
+                        frontmatter {
+                            title
+                            date(formatString: "Do MMMM YYYY")
+                            author
+                            thumbnail{
+                                extension
+                                publicURL
+                            }
+                        }
+                        fields {
+                            slug
+                        }
+                    }
+                }         
             }
         `
     );
 
-    const tags= data.allMdx.group;
+    const tags = data.allTags.group;
+    const latestPosts = data.latestPosts.nodes;
 
     return (
         <BlogSideBarWrapper>
@@ -45,57 +64,27 @@ const Sidebar = ( ) => {
                 <div className="widgets-title">
                     <h3>Latest Post</h3>
                 </div>
-                <div className="recent-post-block">
-                    <img src={WdThumb1} alt="prime-app" />
-                    <div className="recent-post-content-block">
-                        <Link to="#">
-                            <h3> Now led tedious shy. </h3>
-                        </Link>
-                        <div className="post-meta-block">
-                            By: <Link to="#">Admin</Link>
-                            <Link to="#">Aug 07, 2020</Link>
-                        </div>
-                    </div>
-                </div>
+                { 
+                    latestPosts.map(post => {
+                        return (
+                            <div className="recent-post-block" key={post.fields.slug}>
+                                <img src={post.frontmatter.thumbnail.publicURL} 
+                                    alt="prime-app" 
+                                    height="80" width="80"/>
+                                <div className="recent-post-content-block">
+                                    <Link to={post.fields.slug}>
+                                        <h3> {post.frontmatter.title} </h3>
+                                    </Link>
+                                    <div className="post-meta-block">
+                                        By: <Link to={post.fields.slug}>{post.frontmatter.author}</Link>
+                                        <Link to={post.fields.slug}>{post.frontmatter.date}</Link>
+                                    </div>
+                                </div>
+                            </div>
+                        );
+                    })
+                }
 
-                <div className="recent-post-block">
-                    <img src={WdThumb2} alt="prime-app" />
-                    <div className="recent-post-content-block">
-                        <Link to="#">
-                            <h3> Now led tedious shy. </h3>
-                        </Link>
-                        <div className="post-meta-block">
-                            By: <Link to="#">Admin</Link>
-                            <Link to="#">Aug 07, 2020</Link>
-                        </div>
-                    </div>
-                </div>
-
-                <div className="recent-post-block">
-                    <img src={WdThumb3} alt="prime-app" />
-                    <div className="recent-post-content-block">
-                        <Link to="#">
-                            <h3> Now led tedious shy. </h3>
-                        </Link>
-                        <div className="post-meta-block">
-                            By: <Link to="#">Admin</Link>
-                            <Link to="#">Aug 07, 2020</Link>
-                        </div>
-                    </div>
-                </div>
-
-                <div className="recent-post-block">
-                    <img src={WdThumb1} alt="prime-app" />
-                    <div className="recent-post-content-block">
-                        <Link to="#">
-                            <h3> Now led tedious shy. </h3>
-                        </Link>
-                        <div className="post-meta-block">
-                            By: <Link to="#">Admin</Link>
-                            <Link to="#">Aug 07, 2020</Link>
-                        </div>
-                    </div>
-                </div>
             </div>
 
             <div className="sidebar-widgets catagorie">


### PR DESCRIPTION
**Description**
Added graphql query to fetch latest 4 posts

This PR fixes #1125 

**Notes for Reviewers**
- Removed thumbnail images used earlier from latest posts section.
- Width of post thumbnails set to 80px and height maintaining aspect ratio. You might suggest some other improvements. 
- Suggestion to remove latest post section from  [all blogs page](https://layer5ng.netlify.app/blog) as it is irrelevant there.


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->