### PR TITLE
Move new partners button to bottom

### DIFF
--- a/src/sections/Partners/index.js
+++ b/src/sections/Partners/index.js
@@ -40,20 +40,7 @@ const Partner = () => {
                     <Col xs={12} sm={1} lg={1}>
                     </Col>
                 </Row>
-                <Row>
-                    <Col xs={12} sm={4} lg={4}>
-                    </Col>
 
-                    <Col xs={12} sm={4} lg={4}>
-                        <div>
-                            <div style={{textAlign:"center"}}>
-                                <Button title={<h3>BECOME A PARTNER</h3>} url="mailto:partners@layer5.io" external="true" />
-                            </div>
-                        </div>
-                    </Col>
-                    <Col xs={12} sm={4} lg={4}>
-                    </Col>
-                </Row>
                 <h1 className="heading">Academic Partners</h1>
                 <Row>
                     <Col xs={12} sm={2} lg={2}>
@@ -89,7 +76,6 @@ const Partner = () => {
                             </div>
                         </div>
                     </Col>
-
                 </Row>
                 <Row>
                     <Col xs={12} sm={2} lg={2}>
@@ -243,6 +229,13 @@ const Partner = () => {
                             <div>
                                 The Service Mesh Interface (SMI) is a specification for service meshes that run on Kubernetes. It defines a common standard that can be implemented by a variety of providers. This allows for both standardization for end-users and innovation by providers of Service Mesh Technology. It enables flexibility and interoperability.
                             </div>
+                        </div>
+                    </Col>
+                </Row>
+                <Row className='partner-button-row'>
+                    <Col xs={12} sm={4} lg={4}>
+                        <div className="container partner-button">
+                            <Button title={<h3>BECOME A PARTNER</h3>} url="mailto:partners@layer5.io" external="true" />
                         </div>
                     </Col>
                 </Row>

--- a/src/sections/Partners/partner.style.js
+++ b/src/sections/Partners/partner.style.js
@@ -108,6 +108,12 @@ const PartnerWrapper = styled.section`
         max-width: 300px;
         width: 100%;
     }
+    .partner-button-row {
+        justify-content: center;
+    }
+    .partner-button {
+        text-align: center;
+    }
 
     @media only screen and (max-width: 420px) {
         .img1 {


### PR DESCRIPTION
Signed-off-by: Colin Fendrick <colin.fendrick@gmail.com>

**Description**

This PR fixes #1191

Note: The buttons on the bottom are misaligned (they were always misaligned but it is noticable now). I would recommend replacing `display: inline-block` with `width: 100%` on `.btn-section` styles. Further styling may be desired to adjust the form input widths to make it more visually pleasing.

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->