### PR TITLE
Added Subscribe component to the Service Mesh Pattern Book

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -33,6 +33,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
   createRedirect({ fromPath: '/workshops', toPath: '/learn/workshops', redirectInBrowser: true, isPermanent: true })
   createRedirect({ fromPath: '/meshery', toPath: '/projects/meshery', redirectInBrowser: true, isPermanent: true })
   createRedirect({ fromPath: '/landscape', toPath: '/projects/landscape', redirectInBrowser: true, isPermanent: true })
+  createRedirect({ fromPath: '/events', toPath: '/community/events', redirectInBrowser: true, isPermanent: true })
 
   // Create Pages
   const { createPage } = actions;

--- a/src/collections/books/2020-04-08-service-mesh-patterns/index.mdx
+++ b/src/collections/books/2020-04-08-service-mesh-patterns/index.mdx
@@ -8,6 +8,7 @@ published: true
 ---
 
 import { BookWrapper } from "../Book.style.js";
+import Contact from "../../../sections/Contact/index.js"
 
 <BookWrapper>
 
@@ -24,6 +25,8 @@ A service mesh is a layer in your infrastructure that facilitates communication 
 
 Identifying who this book is for has been one of the hardest challenges in writing it. The power of a service mesh is vast, and therefore, empowers individuals of many different roles. In short, this book is for anyone delivering workloads enabled by a service mesh and who wants to ensure their use of a service mesh provides the most possible value to the workloads and teams that rely on it.
 
-<p><i><a href="https://layer5.io/subscribe"> Subscribe us </a> for updates on this book.</i></p>
+<p>Subscribe us for updates on this book.</p>
+
+<Contact />
 
 </BookWrapper>

--- a/src/sections/Contact/index.js
+++ b/src/sections/Contact/index.js
@@ -12,7 +12,7 @@ const Contact = () => {
     return (
         <ContactWrapper id="contact">
             <div className="parentcard">
-                <form name="contactform" method="post" action="#">
+                <form name="contactform" method="post" action="https://calcotestudios.us15.list-manage.com/subscribe/post?u=6b50be5aea3dfe1fd4c041d80&amp;id=6bb65defeb">
                     <SectionTitle className="section-title" UniWidth="100%">
                         <h2><span>Stay meshy and subscribe</span></h2>
                     </SectionTitle>
@@ -23,16 +23,16 @@ const Contact = () => {
                                 <Col className="nopad" md={1} xs={1}><MdPermContactCalendar className="contact-icon" size={30}></MdPermContactCalendar></Col>
                                 <Col md={11} xs={11}>
                                     <Row>
-                                        <Col className="firstcol" md={6} xs={6}><input className="inputrow" type="First Name" placeholder="First Name" /></Col>
-                                        <Col className="lastcol" md={6} xs={6}><input className="inputrow" type="Last Name" placeholder="Last Name" /></Col>
+                                        <Col className="firstcol" md={6} xs={6}><input className="inputrow" type="text" placeholder="First Name" name="FNAME" id="mce-FNAME" /></Col>
+                                        <Col className="lastcol" md={6} xs={6}><input className="inputrow" type="text" placeholder="Last Name" name="LNAME" id="mce-LNAME" /></Col>
                                     </Row>
                                 </Col>
                             </Row>
                             <Row>
                                 <Col className="nopad" md={1} xs={1}><MdEmail className="contact-icon" size={30}></MdEmail></Col>
-                                <Col md={11} xs={11}><input className="inputrow" type="email" placeholder="Email Address" /></Col>
+                                <Col md={11} xs={11}><input className="inputrow" type="email" placeholder="Email Address" name="EMAIL" id="mce-EMAIL" required /></Col>
                             </Row>
-                            <Button title="Subscribe" />
+                            <Button title="Subscribe" id="mc-embedded-subscribe" />
                         </Col>
                     </Row>
                 </form>


### PR DESCRIPTION
Signed-off-by: kishore007k <kishorekumarstar07@gmail.com>

**Description**

This PR fixes #1217 &  #1185 

**Notes for Reviewers**
- [x] In this PR I have implemented the `redirect` to the `/community/events` to `/events`.
- [x] Added `subscribe component` to the **Service Mesh Pattern** in the `learn/service-mesh-pattern` in the books page.
- [x] Changed the `form action` of the subscribe component to the [Subscribe Form Link](https://calcotestudios.us15.list-manage.com/subscribe/post?u=6b50be5aea3dfe1fd4c041d80&amp;id=6bb65defeb)

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.