### PR TITLE
[NG] Navbar: remove About menu

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore_task.md
+++ b/.github/ISSUE_TEMPLATE/chore_task.md
@@ -1,36 +1,22 @@
 ---
-name: 🐛 Bug Report
-about: Report an issue to help us improve
+name: 🧹Chore or task
+about: Identify a necessary task to be addressed.
 title: ''
-labels: 'kind/bug'
+labels: 'kind/chore'
 assignees: ''
 ---
-**Description**
-<!-- A brief description of the issue. -->
+**Current Behavior**
+<!-- A brief description of what the current circumstance is. -->
 
-**Expected Behavior**
-<!-- A brief description of what you expected to happen. -->
-
-**Screenshots**
-<!-- Add screenshots, if applicable, to help explain your problem. -->
-
-**Enviroment:**
-- Host OS: 
-- Meshery Version: 
-- Kubernetes Version: 
-- Browser: 
+**Desired Situation**
+<!-- A brief description of the necessary action to take. -->
 
 ---
+[Optional] **Alternatives**
+<!-- A brief description of any alternative solutions or features you've considered. -->
 
-[Optional] **To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
-
-[Optional] **Additional Context**
-<!-- Add any other context about the problem here. -->
+[Optional] **Additional context**
+<!-- Add any other context or screenshots about the chore or task here. -->
 
 ---
 **Contributor Resources**
@@ -41,3 +27,4 @@ If the `layer5-ng` label is absent on this issue, then this issue pertains to th
 
 If the `layer5-ng` label is present on this issue, then this issue pertains to the next-generation of the layer5.io website, which uses Gatsby, Strapi, and GitHub Pages. Site content is found under the [`layer5-ng` branch](https://github.com/layer5io/layer5/tree/layer5-ng).
 - See [`layer5-ng` contributing instructions](https://github.com/layer5io/layer5/blob/layer5-ng/CONTRIBUTING.md)
+

--- a/.github/ISSUE_TEMPLATE/community_member_profile.md
+++ b/.github/ISSUE_TEMPLATE/community_member_profile.md
@@ -1,0 +1,25 @@
+---
+name: 👤 Community Member Profile
+about: Recognize a Layer5 contributor with a community member profile
+title: '[Community] Member Profile:'
+labels: 'area/community'
+assignees: ''
+---
+
+**Current Behaviour**
+
+<@github-username> has been a consistent contributor and community member.
+
+**Desired Situation**
+Let's recognizing <@github-username> as a contributor and community member by creating a profile on https://layer5.io/community/members.
+
+- GitHub: <!-- username only -->
+- Twitter: <!-- handle only -->
+- LinkedIn: <!-- <profilename> only (https://www.linkedin.com/in/<profilename>)-->
+- Link to profile picture:
+
+---
+
+**Contributor Resources**
+
+The layer5.io website, which uses GatsbyJS and GitHub Pages. Site content is found under the <a href="https://github.com/layer5io/layer5/tree/master">`master` branch</a>. See <a href="https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md">`layer5` contributing instructions</a>.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+- name: 🙋🏾 🙋🏼‍ Question
+  url: https://github.com/layer5io/layer5/discussions/new
+  about: Submit your question using GitHub Discussions.

--- a/.github/ISSUE_TEMPLATE/engagement.md
+++ b/.github/ISSUE_TEMPLATE/engagement.md
@@ -1,36 +1,15 @@
 ---
-name: 🐛 Bug Report
-about: Report an issue to help us improve
+name: 👨‍🏫 Engagement Request
+about: Request for a workshop, consulting, or other
 title: ''
-labels: 'kind/bug'
+labels: 'kind/engagement'
 assignees: ''
 ---
-**Description**
-<!-- A brief description of the issue. -->
+**Current Behavior**
+<!-- A brief description of what the problem is. (e.g. I need to be able to...) -->
 
-**Expected Behavior**
-<!-- A brief description of what you expected to happen. -->
-
-**Screenshots**
-<!-- Add screenshots, if applicable, to help explain your problem. -->
-
-**Enviroment:**
-- Host OS: 
-- Meshery Version: 
-- Kubernetes Version: 
-- Browser: 
-
----
-
-[Optional] **To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
-
-[Optional] **Additional Context**
-<!-- Add any other context about the problem here. -->
+**Desired Behavior**
+<!-- A brief description of the enhancement. -->
 
 ---
 **Contributor Resources**

--- a/.github/ISSUE_TEMPLATE/events.md
+++ b/.github/ISSUE_TEMPLATE/events.md
@@ -1,36 +1,17 @@
 ---
-name: 🐛 Bug Report
-about: Report an issue to help us improve
-title: ''
-labels: 'kind/bug'
+name: 🎪 📅 Layer5 Event Update
+about: Upcoming event to be listed on https://layer5.io/news
+title: '[Event]'
+labels: 'area/events'
 assignees: ''
 ---
-**Description**
-<!-- A brief description of the issue. -->
-
-**Expected Behavior**
-<!-- A brief description of what you expected to happen. -->
-
-**Screenshots**
-<!-- Add screenshots, if applicable, to help explain your problem. -->
-
-**Enviroment:**
-- Host OS: 
-- Meshery Version: 
-- Kubernetes Version: 
-- Browser: 
-
----
-
-[Optional] **To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
-
-[Optional] **Additional Context**
-<!-- Add any other context about the problem here. -->
+**Event:**
+- Event Title: 
+- Event Link: 
+- Talk Description: 
+- Talk Link: 
+- Deck: 
+- Video: 
 
 ---
 **Contributor Resources**

--- a/.github/ISSUE_TEMPLATE/landscape.md
+++ b/.github/ISSUE_TEMPLATE/landscape.md
@@ -1,5 +1,5 @@
 ---
-name: Service Mesh Landscape Update
+name: 🏞 Service Mesh Landscape Update
 about: Issues related to the service mesh landscape.
 title: '[Landscape]'
 labels: 'area/landscape'
@@ -7,9 +7,8 @@ assignees: ''
 ---
 **Current State:**
 
-
 **Desired State:**
 
 ---
 **Contributor Resources**
-- [Instructions for updating the landscape](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#updating-the-service-mesh-landscape)
+- [Instructions for updating the landscape](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#updating-the-service-mesh-landscape)Site content is found under the [`master` branch](https://github.com/layer5io/layer5/tree/master).

--- a/.github/ISSUE_TEMPLATE/news.md
+++ b/.github/ISSUE_TEMPLATE/news.md
@@ -1,14 +1,22 @@
 ---
-name: News update
+name: 📰 Layer5 News Update
 about: News items to be listed on https://layer5.io/news
 title: '[News]'
 labels: 'area/news'
 assignees: ''
 ---
+We're in the news! Using the contributing instructions for [adding news](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#adding-news), please add the following article to the Layer5 Newsroom.
+
 **Article:**
-- Title:
-- Link:
+- Title: 
+- Link: 
 
 ---
 **Contributor Resources**
-- [Instructions for updating news items](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#news)
+The `layer5` repo contains two websites. The current generation and the next-generation of the layer5.io site.
+
+If the `layer5-ng` label is absent on this issue, then this issue pertains to the current generation of the layer5.io website, which uses Jekyll and GitHub Pages. Site content is found under the [`master` branch](https://github.com/layer5io/layer5/tree/master).
+- See [`layer5` contributing instructions](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md)
+
+If the `layer5-ng` label is present on this issue, then this issue pertains to the next-generation of the layer5.io website, which uses Gatsby, Strapi, and GitHub Pages. Site content is found under the [`layer5-ng` branch](https://github.com/layer5io/layer5/tree/layer5-ng).
+- See [`layer5-ng` contributing instructions](https://github.com/layer5io/layer5/blob/layer5-ng/CONTRIBUTING.md)

--- a/src/sections/Navigation/utility/ScrollspyMenu.js
+++ b/src/sections/Navigation/utility/ScrollspyMenu.js
@@ -8,7 +8,7 @@ const ScrollspyMenu = ({ menuItems, ...props }) => {
     const addAllClasses = [""];
 
     const [state, setState] = useState({
-        active: menuItems[5]
+        active: menuItems[4]
     });
 
     const wrapRef = useRef(null);

--- a/src/sections/Navigation/utility/menu-items.js
+++ b/src/sections/Navigation/utility/menu-items.js
@@ -210,12 +210,7 @@ const Data = {
             //     src: img2,
             //     descr: "Service Mesh Istio patterns for multilatency"
             // }
-        },
-        {
-            name: "About",
-            path: "/company/about",
-            offset: "-50"
-        },
+        }
         // {
         //     name: "Contact",
         //     path: "/#contact",

--- a/src/sections/Navigation/utility/menu-items.js
+++ b/src/sections/Navigation/utility/menu-items.js
@@ -212,6 +212,11 @@ const Data = {
             // }
         }
         // {
+        //     name: "About",
+        //     path: "/company/about",
+        //     offset: "-50"
+        // },
+        // {
         //     name: "Contact",
         //     path: "/#contact",
         //     offset: "-50"


### PR DESCRIPTION
**Notes for Reviewers**

This PR removes the About menu. We will let users navigate to this page from the footer, reserving precious navbar space for other forthcoming links.

I also included some updates to GH issue templates.



**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->