### PR TITLE
Fix menu item in service mesh labs page

### DIFF
--- a/src/sections/Learn/Service-Mesh-Labs/LabsWrapper.style.js
+++ b/src/sections/Learn/Service-Mesh-Labs/LabsWrapper.style.js
@@ -34,6 +34,7 @@ export const LabsWrapper = styled.div`
 	.course-tab-list {
 		padding: 0rem;
 		text-align: center;
+		width: 5.1rem;
 		/* border: 3px purple solid; */
 	}
 	.course-tab {


### PR DESCRIPTION
Signed-off-by: Nikhil-Ladha <nikhilladha1999@gmail.com>

**Description**
This PR fixes the alignment of the menu on the service mesh labs page. Though the fix is not the best one, there was a better way to use `flex` but to satisfy the design in terms of the width of the lab's section, used this hack.


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->