### PR TITLE
Add hyperlink to category text on single blog page

### DIFF
--- a/src/reusecore/PageHeader/index.js
+++ b/src/reusecore/PageHeader/index.js
@@ -53,7 +53,11 @@ const PageHeader = ({ category, title, subtitle,  author, thumbnail }) => {
           <div className="breadcrumbs">
             <span>
               <h5>Category:</h5>
-              <p key={category}>{category}</p>
+              <p key={category}>
+                <Link to={`/blog/category/${slugify(category)}`}>
+                  <span>{category}</span>
+                </Link>
+              </p>
             </span>
             {author && (
               <>


### PR DESCRIPTION
**Description**
Add Hyperlink to category text on a single blog post
This PR fixes #1613

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
