### PR TITLE
[contributing.md] Update with instructions for modifying community member profiles 

### DIFF
--- a/.github/ISSUE_TEMPLATE/community_member_profile.md
+++ b/.github/ISSUE_TEMPLATE/community_member_profile.md
@@ -18,6 +18,9 @@ Let's recognize <@github-username> as a contributor and community member by crea
 - LinkedIn: <!-- <profilename> only (https://www.linkedin.com/in/<profilename>)-->
 - Link to profile picture:
 
+A detailed explanation on how to set up a community member profile can be found in the [CONTRIBUTING.md](https://github.com/layer5io/layer5/issues/1736)
+
+The CONTRIBUTING.md file has a "Common Types of Site Updates" section with detailed examples to follow.
 ---
 
 **Contributor Resources**

--- a/.github/ISSUE_TEMPLATE/community_member_profile.md
+++ b/.github/ISSUE_TEMPLATE/community_member_profile.md
@@ -18,9 +18,9 @@ Let's recognize <@github-username> as a contributor and community member by crea
 - LinkedIn: <!-- <profilename> only (https://www.linkedin.com/in/<profilename>)-->
 - Link to profile picture:
 
-A detailed explanation on how to set up a community member profile can be found in the [CONTRIBUTING.md](https://github.com/layer5io/layer5/issues/1736)
+A detailed explanation on how to set up a community member profile can be found in the [CONTRIBUTING.md](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md)
 
-The CONTRIBUTING.md file has a "Common Types of Site Updates" section with detailed examples to follow.
+The CONTRIBUTING.md file has a "Common Types of Site Updates" section with detailed examples to follow here.[CONTRIBUTING.md](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md)
 ---
 
 **Contributor Resources**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,7 @@ When adding a new or updating an existing community member profile be sure to fo
 
 #### Badges for Community Members
 
-Badges are a way to identify projects community members have made contributions to. These badges are assigned to a contributor to acknowledge the contributions made to the respective project. An example of how a badge is written can be found [here](https://github.com/layer5io/layer5/blob/master/src/collections/members/abishek-kumar/index.mdx), and it will be displayed like [this](https://layer5.io/community/members/abishek-kumar) on the community project.
-
+Badges offer recognition of the efforts and works of community members.  Badges are assigned to a community member in acknowledgement of their engagement within and/or contribution to the representative project or (sub-)community. A variety of badges exist so that community members and their efforts may be affiliated with a particular project or community initiative. An example of how a badge assigned using markdown can be found [here](https://github.com/layer5io/layer5/blob/master/src/collections/members/abishek-kumar/index.mdx), and it will be appear [this way](https://layer5.io/community/members/abishek-kumar) on a member profile.
 ##### Possible badges include
 
 - <img src="https://github.com/layer5io/layer5/blob/master/src/sections/Community/Member-single/community-green.svg" width="25px" height="25px"/> community

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Layer5 community members are an integral part of what makes Layer5 and it's proj
 
 #### Source code for Community Member Profiles
 
-When adding a new or updating an existing community member profile be sure to follow the existing template which can be found here [Community Member Profile template](https://github.com/layer5io/layer5/tree/master/src/collections/members/_member-profile-template). You can easily understand the template by referrring to this example [here](https://github.com/layer5io/layer5/blob/master/src/collections/members/abishek-kumar/index.mdx)
+When adding a new or updating an existing community member profile be sure to follow the existing template which can be found here [Community Member Profile template](https://github.com/layer5io/layer5/tree/master/src/collections/members/_member-profile-template). You can easily understand the template by checking out one of the profiles [here](https://github.com/layer5io/layer5/blob/master/src/collections/members/abishek-kumar/index.mdx)
 
 
 #### Badges for Community Members

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,14 @@ When submitting a pull request a preview deployment will be built and made avail
 
 Layer5 community members are an integral part of what makes Layer5 and it's projects successful. Prominently highlighting our members and their works is important. When adding a new or updating an existing community member profile, be sure to use the [Community Member Profile issue template](https://github.com/layer5io/layer5/issues/new?assignees=&labels=area%2Fcommunity&template=New+Member+Profile.md&title=%5BCommunity%5D+Member+Profile%3A), which has all the instructions needed. 
 
+#### Source code for Community Member Profiles
+
+When adding a new or updating an existing community member profile be sure to follow the existing template which can be found here [Community Member Profile template](https://github.com/layer5io/layer5/tree/master/src/collections/members/_member-profile-template). You can easily understand the template by referrring to this example [here](https://github.com/layer5io/layer5/blob/master/src/collections/members/abishek-kumar/index.mdx)
+
+
+#### Badges for Community Members
+
+Badges are a way to identify projects community members have made contributions to. When a community member successfully completes a project, they get the badge of that community. An example of how a badge is written can be found [here](https://github.com/layer5io/layer5/blob/master/src/collections/members/abishek-kumar/index.mdx), and it will be displayed like [this](https://layer5.io/community/members/abishek-kumar) on the community project.
 
 
 #### <a name="updating-the-service-mesh-landscape">Updating the Service Mesh Landscape ([create new issue](https://github.com/layer5io/layer5/issues/new?assignees=&labels=area%2Flandscape&template=landscape.md&title=%5BLandscape%5D))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,14 @@ When submitting a pull request a preview deployment will be built and made avail
 
 Layer5 community members are an integral part of what makes Layer5 and it's projects successful. Prominently highlighting our members and their works is important. When adding a new or updating an existing community member profile, be sure to use the [Community Member Profile issue template](https://github.com/layer5io/layer5/issues/new?assignees=&labels=area%2Fcommunity&template=New+Member+Profile.md&title=%5BCommunity%5D+Member+Profile%3A), which has all the instructions needed. 
 
+#### Source code for Community Member Profiles
+
+When adding a new or updating an existing community member profile be sure to follow the existing template which can be found here [Community Member Profile template](https://github.com/layer5io/layer5/tree/master/src/collections/members/_member-profile-template). You can easily understand the template by referrring to this example [here](https://github.com/layer5io/layer5/blob/master/src/collections/members/abishek-kumar/index.mdx)
+#### Badges for Community Members
+
+Badges are a way to identify projects community members have made contributions to. When a community member successfully completes a project, they get the badge of that community. An example of how a badge is written can be found [here](https://github.com/layer5io/layer5/blob/master/src/collections/members/abishek-kumar/index.mdx), and it will be displayed like [this](https://layer5.io/community/members/abishek-kumar) on the community project.
+
+
 #### <a name="updating-the-service-mesh-landscape">Updating the Service Mesh Landscape ([create new issue](https://github.com/layer5io/layer5/issues/new?assignees=&labels=area%2Flandscape&template=landscape.md&title=%5BLandscape%5D))
 
 The service mesh landscape is powered by Gatsbyjs. In order to add/update the landscape, fork this repository, clone it, create a branch and navigate to the **src/collections/landscape** folder. Edit these js files (if appropriate):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,17 @@ When adding a new or updating an existing community member profile be sure to fo
 
 #### Badges for Community Members
 
-Badges are a way to identify projects community members have made contributions to. When a community member successfully completes a project, they get the badge of that community. An example of how a badge is written can be found [here](https://github.com/layer5io/layer5/blob/master/src/collections/members/abishek-kumar/index.mdx), and it will be displayed like [this](https://layer5.io/community/members/abishek-kumar) on the community project.
+Badges are a way to identify projects community members have made contributions to. These badges are assigned to a contributor to acknowledge the contributions made to the respective project. An example of how a badge is written can be found [here](https://github.com/layer5io/layer5/blob/master/src/collections/members/abishek-kumar/index.mdx), and it will be displayed like [this](https://layer5.io/community/members/abishek-kumar) on the community project.
 
+##### Possible badges include
+
+- <img src="https://github.com/layer5io/layer5/blob/master/src/sections/Community/Member-single/community-green.svg" width="25px" height="25px"/> community
+- <img src="https://github.com/layer5io/layer5/blob/master/src/sections/Community/Member-single/landscape-green.png" width="25px" height="25px"/> Landscape
+- <img src="https://github.com/layer5io/layer5/blob/master/src/sections/Community/Member-single/layer5-image-hub.svg" width="25px" height="25px"/> Layer5
+- <img src="https://github.com/layer5io/layer5/blob/master/src/sections/Community/Member-single/meshery-logo-light.svg" width="25px" height="25px"/> Meshery
+- <img src="https://github.com/layer5io/layer5/blob/master/src/sections/Community/Member-single/meshery-operator-dark.svg" width="25px" height="25px"/> Meshery Operator
+- <img src="https://github.com/layer5io/layer5/blob/master/src/sections/Community/Member-single/smp-dark-text.svg" width="25px" height="25px"/> smp
+- <img src="https://github.com/layer5io/layer5/blob/master/src/sections/Community/Member-single/smp-dark.svg" width="25px" height="25px"/> smp
 
 #### <a name="updating-the-service-mesh-landscape">Updating the Service Mesh Landscape ([create new issue](https://github.com/layer5io/layer5/issues/new?assignees=&labels=area%2Flandscape&template=landscape.md&title=%5BLandscape%5D))
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,12 +12,6 @@ When submitting a pull request a preview deployment will be built and made avail
 
 Layer5 community members are an integral part of what makes Layer5 and it's projects successful. Prominently highlighting our members and their works is important. When adding a new or updating an existing community member profile, be sure to use the [Community Member Profile issue template](https://github.com/layer5io/layer5/issues/new?assignees=&labels=area%2Fcommunity&template=New+Member+Profile.md&title=%5BCommunity%5D+Member+Profile%3A), which has all the instructions needed. 
 
-#### Source code for Community Member Profiles
-
-When adding a new or updating an existing community member profile be sure to follow the existing template which can be found here [Community Member Profile template](https://github.com/layer5io/layer5/tree/master/src/collections/members/_member-profile-template). You can easily understand the template by referrring to this example [here](https://github.com/layer5io/layer5/blob/master/src/collections/members/abishek-kumar/index.mdx)
-#### Badges for Community Members
-
-Badges are a way to identify projects community members have made contributions to. When a community member successfully completes a project, they get the badge of that community. An example of how a badge is written can be found [here](https://github.com/layer5io/layer5/blob/master/src/collections/members/abishek-kumar/index.mdx), and it will be displayed like [this](https://layer5.io/community/members/abishek-kumar) on the community project.
 
 
 #### <a name="updating-the-service-mesh-landscape">Updating the Service Mesh Landscape ([create new issue](https://github.com/layer5io/layer5/issues/new?assignees=&labels=area%2Flandscape&template=landscape.md&title=%5BLandscape%5D))


### PR DESCRIPTION
{contributing.md] Update with instructions for modifying community member profiles

This PR fixes: #1736 

The CONTRIBUTING.md file has a "Common Types of Site Updates" section. Two new sections were added under this:

where to find source code for profiles
what badges are and when to assign what badges to whom.
The GitHub Issue template for Member Profile updates was also updated with a link to this new section.

Notes for Reviewers
Do let me know what can be improved on or rewritten if any

Signed commits

[* ] Yes, I signed my commits.
