### PR TITLE
make meshmate-of-the-year-blog responsive

### DIFF
--- a/src/collections/blog/2021-04-05-meshmate-of-the-year-2020-nikhil-ladha/index.mdx
+++ b/src/collections/blog/2021-04-05-meshmate-of-the-year-2020-nikhil-ladha/index.mdx
@@ -185,6 +185,7 @@ import MMOYNikhil from "./MeshMate-of-the-Year-2020-Nihkil-Ladha.png";
 
 <div style="text-align: center;">
   <img
+    className="meshmate-img"
     src={MMOYNikhil}
     style="width:40%; margin: auto;"
     alt="Meshmate of the year"

--- a/src/collections/blog/2021-04-05-meshmate-of-the-year-2020-nikhil-ladha/index.mdx
+++ b/src/collections/blog/2021-04-05-meshmate-of-the-year-2020-nikhil-ladha/index.mdx
@@ -184,12 +184,7 @@ import MMOYNikhil from "./MeshMate-of-the-Year-2020-Nihkil-Ladha.png";
 </p>
 
 <div style="text-align: center;">
-  <img
-    className="meshmate-img"
-    src={MMOYNikhil}
-    style="width:40%; margin: auto;"
-    alt="Meshmate of the year"
-  />
+  <img className="meshmate-img" src={MMOYNikhil} alt="Meshmate of the year" />
 </div>
 
 <p>

--- a/src/collections/blog/2021-04-05-meshmate-of-the-year-2020-nikhil-ladha/index.mdx
+++ b/src/collections/blog/2021-04-05-meshmate-of-the-year-2020-nikhil-ladha/index.mdx
@@ -10,7 +10,7 @@ tags:
 published: true
 ---
 
-import { BlogWrapper } from '../Blog.style.js';
+import { BlogWrapper } from "../Blog.style.js";
 import MMoY2020 from "./meshmate-of-the-year-2020.png";
 import Blockquote from "../../../reusecore/Blockquote";
 import BlockquoteAlt from "../../../reusecore/Blockquote/Blockquote-alt-style";
@@ -21,74 +21,184 @@ import MMOYNikhil from "./MeshMate-of-the-Year-2020-Nihkil-Ladha.png";
 
 <BlogWrapper>
 
-<p>If you are in the Layer5 Community, no doubt, you've met <Link to="/community/members/nikhil-ladha" className="blog">Nikhil Ladha</Link>. If not, I recommend that you join the community and get to know Nikhil. He's the Layer5 MeshMate of the Year and here's why: Nikhil consistently volunteers to uplift and support others in the community, freely sharing of his time and knowledge. His actions embody and espouse the pay-it-forward culture of Layer5.</p>
+<p>
+  If you are in the Layer5 Community, no doubt, you've met
+  <Link to="/community/members/nikhil-ladha" className="blog">
+    Nikhil Ladha
+  </Link>. If not, I recommend that you join the community and get to know Nikhil.
+  He's the Layer5 MeshMate of the Year and here's why: Nikhil consistently volunteers
+  to uplift and support others in the community, freely sharing of his time and knowledge.
+  His actions embody and espouse the pay-it-forward culture of Layer5.
+</p>
 
-<Blockquote quote="It is beautiful how you always respond to messages in the newcomer's channel and try to sort out issues or questions asked. I can personally relate to your kind heart, on the particular times you got on a call with me as a newcomer then and helped me sort out my problems while being so patient and amazing. You really deserve this award Nikhil, and a big congratulations to you!" person="Prateek Tripathy" />
+<Blockquote
+  quote="It is beautiful how you always respond to messages in the newcomer's channel and try to sort out issues or questions asked. I can personally relate to your kind heart, on the particular times you got on a call with me as a newcomer then and helped me sort out my problems while being so patient and amazing. You really deserve this award Nikhil, and a big congratulations to you!"
+  person="Prateek Tripathy"
+/>
 
 2020 was a noteworthy year in many ways. Nikhil's committment to the people and projects of the Layer5 community will forever be at the top of list of mentionables I and others will recall of last year. It was in 2019, though, that <Link to="/blog/community/my-journey-from-a-contributor-to-a-maintainer">Nikhil's journey</Link> in the Layer5 community started and where he first began helping build our healthy, inclusive, and <Link to="/community" className="blog">diverse community</Link> and our industry-leading, innovate <Link to="/projects" className="blog">open source projects</Link>. Nikhil's natural disposition to mentoring others and his stewardship on various projects make him a successful MeshMate.
 
-<h3>What is a Layer5 MeshMate?</h3>
-<img src={MeshMate} className="left" alt="Meshmate" /><p><Link className="blog" to="/community/meshmates">MeshMate</Link> is a distinction that Layer5 awards select members of the community who innately align with our culture of helping others, paying it forward, and a commitment to knowledge sharing. MeshMates are Layer5 mentors and ambassadors (not employees).
+<h3 style="padding:2rem 0;">What is a Layer5 MeshMate?</h3>
+
+<img src={MeshMate} className="left" alt="Meshmate" />
+<p>
+  <Link className="blog" to="/community/meshmates">
+    MeshMate
+  </Link>
+  is a distinction that Layer5 awards select members of the community who innately
+  align with our culture of helping others, paying it forward, and a commitment to
+  knowledge sharing. MeshMates are Layer5 mentors and ambassadors (not employees).
 </p>
 
-<Blockquote style="position:relative; float:right; width:45%;"  quote="Congratulations on the MeshMate of the Year Award, Nikhil, a well-deserved honor for a distinguished gentleman. When I was having a look at the Layer5 community, your member experience blog post stood out and was one of the main reasons for me to join the community. Within the community, it is apparent that your guidance, support, and contributions are very much appreciated. Keep up the excellent work!" person="Michael Gfeller" />
+<Blockquote
+  style="position:relative;"
+  quote="Congratulations on the MeshMate of the Year Award, Nikhil, a well-deserved honor for a distinguished gentleman. When I was having a look at the Layer5 community, your member experience blog post stood out and was one of the main reasons for me to join the community. Within the community, it is apparent that your guidance, support, and contributions are very much appreciated. Keep up the excellent work!"
+  person="Michael Gfeller"
+/>
 
-<p>A Layer5 MeshMate is individual who has consistently demonstrated their commitment to helping community members. The MeshMate program pairs experienced Layer5  community members with community newcomers to ensure a smooth onboarding experience. Helping community members takes all forms from ensuring the member has access to resources, is introduced to others, understands the vision and goals of projects, can build and contribute to projects, can use projects and have their feedback heard. MeshMates aid in identifying areas of projects and activities within the community to engage within, which working groups to join, and in help community members grow in their open source and cloud native knowledge. </p>
+<p>
+  A Layer5 MeshMate is individual who has consistently demonstrated their
+  commitment to helping community members. The MeshMate program pairs
+  experienced Layer5 community members with community newcomers to ensure a
+  smooth onboarding experience. Helping community members takes all forms from
+  ensuring the member has access to resources, is introduced to others,
+  understands the vision and goals of projects, can build and contribute to
+  projects, can use projects and have their feedback heard. MeshMates aid in
+  identifying areas of projects and activities within the community to engage
+  within, which working groups to join, and in help community members grow in
+  their open source and cloud native knowledge.
+</p>
 
-<p>There is a lot going in the Layer5 community. Projects and working groups move fast. By connecting one-on-one, MeshMates share tips on how to have the best community experience possible, but also build a relationship with the community member inevitably leaving a lasting mark as is evident from member comments about Nikhil.</p>
+<p>
+  There is a lot going in the Layer5 community. Projects and working groups move
+  fast. By connecting one-on-one, MeshMates share tips on how to have the best
+  community experience possible, but also build a relationship with the
+  community member inevitably leaving a lasting mark as is evident from member
+  comments about Nikhil.
+</p>
 
-<h3>It's not easy being a MeshMate</h3>
+<h3 style="padding:2rem 0;">It's not easy being a MeshMate</h3>
 
-<p>With thousands of members in the Layer5 community, many come and go. Many take and many give. While we hope that each and every individual that joins will find a fit in the community and/or on a project, this isn't always the case. <BlockquoteAlt style="width:100%;" style="position:relative;float:left;width:40%;" quote="The dedication you have shown on the way to this achievement is impressive, Nikhil. People like you are the key to the great community at Layer5." person="Rodolfo" />Engaging with and investing in community members can be taxing on mentors in terms of both their time and their emotional investment in seeing the newcomer plant roots, grow, and blossom.</p>
+<p>
+  With thousands of members in the Layer5 community, many come and go. Many take
+  and many give. While we hope that each and every individual that joins will
+  find a fit in the community and/or on a project, this isn't always the case.
+  <BlockquoteAlt
+    style="width:100%;"
+    style="position:relative;"
+    quote="The dedication you have shown on the way to this achievement is impressive, Nikhil. People like you are the key to the great community at Layer5."
+    person="Rodolfo"
+  />
+  Engaging with and investing in community members can be taxing on mentors in
+  terms of both their time and their emotional investment in seeing the newcomer
+  plant roots, grow, and blossom.
+</p>
 
-<p>One of the goals MeshMates have is that of enabling the newcomer's passion and finding their sweetspot in the community and on a project, so that the newcomer ultimately achieves their goals - goals that are often similar, but different for each person. To help them acheive their goals, each individual is engaged 1:1 by their Meshmate, supporting them in becoming a landstanding Layer5 community member and contributor. MeshMates understand that many mentees start out with the best of intentions, but that not all overcome their hurdles in finding an area of the community to call home or aspect of a project to own.</p>
+<p>
+  One of the goals MeshMates have is that of enabling the newcomer's passion and
+  finding their sweetspot in the community and on a project, so that the
+  newcomer ultimately achieves their goals - goals that are often similar, but
+  different for each person. To help them acheive their goals, each individual
+  is engaged 1:1 by their Meshmate, supporting them in becoming a landstanding
+  Layer5 community member and contributor. MeshMates understand that many
+  mentees start out with the best of intentions, but that not all overcome their
+  hurdles in finding an area of the community to call home or aspect of a
+  project to own.
+</p>
 
-<Blockquote quote="Congratulations on being our community maintainer superstar, Nikhil. You has done a great job on our new Layer5 site and your infinite patience on communicating with everyone sets you apart as an awesome community ambassador." person="Aisuko Li" />
+<Blockquote
+  quote="Congratulations on being our community maintainer superstar, Nikhil. You has done a great job on our new Layer5 site and your infinite patience on communicating with everyone sets you apart as an awesome community ambassador."
+  person="Aisuko Li"
+/>
 
-<h3>MeshMates are a massive force</h3>
-<p>In just a year's time, with thousands of people in the Layer5 community and 500+ contributors to our projects, it's clear that Layer5 MeshMates significantly uplift our collaborative efforts and are steady force in the community. In process of confirming Nikhil as the winner of the inaugural MeshMate of the Year award, we looked to the community for validation. Little did I realize that meant reaching out to nearly a hundred people whom Nikhil has mentored or supported in the Layer5 community. More than a few of them had something to say about their time with Nikhil:</p>
+<h3 style="padding:2rem 0;">MeshMates are a massive force</h3>
+<p>
+  In just a year's time, with thousands of people in the Layer5 community and
+  500+ contributors to our projects, it's clear that Layer5 MeshMates
+  significantly uplift our collaborative efforts and are steady force in the
+  community. In process of confirming Nikhil as the winner of the inaugural
+  MeshMate of the Year award, we looked to the community for validation. Little
+  did I realize that meant reaching out to nearly a hundred people whom Nikhil
+  has mentored or supported in the Layer5 community. More than a few of them had
+  something to say about their time with Nikhil:
+</p>
 
-<div style="display:flex;">
+<div className="responsive-blog">
   <Blockquote quote="Nikhil, your Meshery journey probably started in an unbuilt way. Each time you help others to start this awesome journey, you construct a better journey for all, a better way to help others. Thanks for everything!"
   person="Jesus" />
 
-  <Blockquote quote="Congratulations Nikhil. You deserve this title and more. You've been a continuous and steady force in the community and one of the sole reasons why any of our website codebases are still readable :) I admire you both, as an engineer and as a person for the sheer amount of patience you show towards any new member. Thank you for always being a dependable pillar in the community!" person="Shriti" />
+<Blockquote
+  quote="Congratulations Nikhil. You deserve this title and more. You've been a continuous and steady force in the community and one of the sole reasons why any of our website codebases are still readable :) I admire you both, as an engineer and as a person for the sheer amount of patience you show towards any new member. Thank you for always being a dependable pillar in the community!"
+  person="Shriti"
+/>
 
   <Blockquote quote="Nikhil has been a great guide for me throughout my journey from a contributor to a maintainer. He truly deserves the MeshMate of the Year award." person="Jash" />
 </div>
 
-<div style="display:flex;">
+<div className="responsive-blog">
   <Blockquote quote="Nikhil has been a strong positive force driving the community in the right direction, most generous with the crowd. He not only does take initiative but also gets it done with perfection. His support has made the Layer5 community stronger and we are forever grateful for your contribution. Your commitment to excellence has inspired others." person="Abishek" />
 
-  <Blockquote quote="Congratulations Mate. It's been a long time coming. Honestly, how do you manage your time. I think it's safe to say that if it weren't for your reviews, half of the codebase in the Meshery UI would be unreadable for new contributors, including my initial commits. Even though we haven't interacted much, you have been a great inspiration and I hope that you keep being that inspiration for others joining Layer5." person="Dhruv" />
+<Blockquote
+  quote="Congratulations Mate. It's been a long time coming. Honestly, how do you manage your time. I think it's safe to say that if it weren't for your reviews, half of the codebase in the Meshery UI would be unreadable for new contributors, including my initial commits. Even though we haven't interacted much, you have been a great inspiration and I hope that you keep being that inspiration for others joining Layer5."
+  person="Dhruv"
+/>
 
   <Blockquote quote="Hi Mate! Thank you for all your extra effort. Like the alpha wolf, you look after everyone in your pack. The MeshMate of the Year is just a small term, you are the star of the Layer5 community who shines and inspires us every single day. You deserve this recognition and I hope you experience both happiness and comfort. Thanks for always being willing to lend a hand and deliver high-quality work, your work ethic is enviable." person="Kelechi" />
 </div>
 
-<div style="display:flex;">
+<div className="responsive-blog">
   <Blockquote quote="A big congratulations on being the MeshMate of the Year. You have been absolutely fantastic, I am so privileged to get in touch with you. I cannot count the number of times you have helped nervous and inexperienced newcomers like me get their first contributions to Layer5 and make it feel like one big family. Your name is a testimony for being 'complete' and you truly are a complete person. Thank you for everything you have done." person="Ruth" />
 
-  <Blockquote quote="Nikhil is a really great maintainer and all the interactions with him have always been super great!" person="Vinayak" />
+<Blockquote
+  quote="Nikhil is a really great maintainer and all the interactions with him have always been super great!"
+  person="Vinayak"
+/>
 
   <Blockquote quote="Nikhil Ladha is a very knowledgeable person considering all the various contributions that he made to Meshery. He was also very kind to review something that I had written and provided feedback and suggestions to improve it. He once exhibited to the team one of his creations for which he had won an award. He is certainly a very great asset to the team both as a contributor and as a MeshMate." person="Vijay" />
 </div>
 
-<div style="display:flex;">
+<div className="responsive-blog">
   <Blockquote quote="Congratulations Nikhil for getting the MeshMate of the Year Award. Thanks for your extremely valuable contributions and also thank you for your patient guidance to the newcomers :)" person="Utkarsh" />
 
-  <Blockquote quote="Great working with Nikhil, great guy, always up and doing. Congratulations on the MeshMate of the Year" person="Augustine" />
+<Blockquote
+  quote="Great working with Nikhil, great guy, always up and doing. Congratulations on the MeshMate of the Year"
+  person="Augustine"
+/>
 
   <Blockquote quote="Congratulations Nikhil! No one deserves this more than you. Thank you, for always helping me and helping me become a contributor to MeshMate myself :)" person="Tanuj" />
 </div>
 
-<img style="width:130px;" className="right" src={MMoY2020} alt="MeshMate of the Year 2020: Nikhil Ladha"/><p>In recognition a year's worth of paying it forward, and for the inaugural award, a new badge identifies our MeshMate of the Year award winner. Only one person carries this badge today. I can only guess as to who this ribbon may be awarded to for 2021. In the year and a half that Nikhil has been in the community, he has touched the lives of many people, including mine. Nikhil is my friend. He is the Layer5 MeshMate of the Year.</p>
+<img
+  style="width:130px;"
+  className="right"
+  src={MMoY2020}
+  alt="MeshMate of the Year 2020: Nikhil Ladha"
+/>
+<p>
+  In recognition a year's worth of paying it forward, and for the inaugural
+  award, a new badge identifies our MeshMate of the Year award winner. Only one
+  person carries this badge today. I can only guess as to who this ribbon may be
+  awarded to for 2021. In the year and a half that Nikhil has been in the
+  community, he has touched the lives of many people, including mine. Nikhil is
+  my friend. He is the Layer5 MeshMate of the Year.
+</p>
 
 <div style="text-align: center;">
-  <img src={MMOYNikhil} style="width:40%; margin: auto;" alt="Meshmate of the year" />
+  <img
+    src={MMOYNikhil}
+    style="width:40%; margin: auto;"
+    alt="Meshmate of the year"
+  />
 </div>
 
-<p>The MeshMate badge is a point of pride for individuals participating in the program and looked upon with admiration and veneration by many within and external to the Layer5 community.</p>
+<p>
+  The MeshMate badge is a point of pride for individuals participating in the
+  program and looked upon with admiration and veneration by many within and
+  external to the Layer5 community.
+</p>
 
-<p style="text-align:center;">Wear your MeshMate of the Year badge proudly, Nikhil.</p>
+<p style="text-align:center;">
+  Wear your MeshMate of the Year badge proudly, Nikhil.
+</p>
 
 </BlogWrapper>

--- a/src/collections/blog/2021-04-05-meshmate-of-the-year-2020-nikhil-ladha/meshmate-of-the-year.css
+++ b/src/collections/blog/2021-04-05-meshmate-of-the-year-2020-nikhil-ladha/meshmate-of-the-year.css
@@ -1,0 +1,3 @@
+.responsive__blog {
+  display: none;
+}

--- a/src/collections/blog/2021-04-05-meshmate-of-the-year-2020-nikhil-ladha/meshmate-of-the-year.css
+++ b/src/collections/blog/2021-04-05-meshmate-of-the-year-2020-nikhil-ladha/meshmate-of-the-year.css
@@ -1,3 +1,0 @@
-.responsive__blog {
-  display: none;
-}

--- a/src/collections/blog/Blog.style.js
+++ b/src/collections/blog/Blog.style.js
@@ -216,6 +216,14 @@ styles for meshmate-of-the-year-2020
   }
 
   .meshmate-img {
-    display: none;
+    width: 100%;
+    margin: auto;
+  }
+
+  @media screen and (min-width: 768px) {
+    .meshmate-img {
+      width: 40%;
+      margin: auto;
+    }
   }
 `;

--- a/src/collections/blog/Blog.style.js
+++ b/src/collections/blog/Blog.style.js
@@ -214,4 +214,8 @@ styles for meshmate-of-the-year-2020
       display: flex;
     }
   }
+
+  .meshmate-img {
+    display: none;
+  }
 `;

--- a/src/collections/blog/Blog.style.js
+++ b/src/collections/blog/Blog.style.js
@@ -1,209 +1,217 @@
 import styled from "styled-components";
 export const BlogWrapper = styled.div`
-    color:#000;
-    .sub-heading {
-      color:gray;
-      position:relative;
-      top:-10px;
+  color: #000;
+  .sub-heading {
+    color: gray;
+    position: relative;
+    top: -10px;
+  }
+  a.invert {
+    text-decoration: none;
+    color: ${(props) => props.theme.tertiaryColor};
+    &:hover {
+      color: ${(props) => props.theme.keppelColor};
     }
-    a.invert {
-      text-decoration: none;
-      color: ${(props) => props.theme.tertiaryColor};
-      &:hover{
-          color: ${(props) => props.theme.keppelColor};
-      }
-    }
-    
-    a.blog {
-        color: ${props => props.theme.primaryColor};
-        background-color: #eeeeee;
-        border-radius: 8px;
-        padding-left: .5rem;
-        padding-right: .5rem;
-        &:hover {
-            color: ${props => props.theme.keppelColor}; 
-        }
-    }
-    div.intro {
-        padding-left: 3rem;
-        padding-right: 3rem;
-        font-style: italic;
-        font-size: .8rem;
-        border-top: 1px dashed ${props => props.theme.primaryLightColor};
-        border-bottom: 1px dashed ${props => props.theme.primaryLightColor};
-        margin-bottom: 1rem;
-        padding-top: 1rem;
-        background-color: ${props => props.theme.secondaryLightColorTwo};
-        span {
-            font-style: normal;
-        }
-    }
-    .to-uppercase {
-      text-transform: uppercase;
-    }
+  }
 
-    .content-left-margin {
-      margin-left:.5em;
+  a.blog {
+    color: ${(props) => props.theme.primaryColor};
+    background-color: #eeeeee;
+    border-radius: 8px;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+    &:hover {
+      color: ${(props) => props.theme.keppelColor};
     }
+  }
+  div.intro {
+    padding-left: 3rem;
+    padding-right: 3rem;
+    font-style: italic;
+    font-size: 0.8rem;
+    border-top: 1px dashed ${(props) => props.theme.primaryLightColor};
+    border-bottom: 1px dashed ${(props) => props.theme.primaryLightColor};
+    margin-bottom: 1rem;
+    padding-top: 1rem;
+    background-color: ${(props) => props.theme.secondaryLightColorTwo};
+    span {
+      font-style: normal;
+    }
+  }
+  .to-uppercase {
+    text-transform: uppercase;
+  }
 
-    .table-1 {
-      white-space: nowrap;
-      max-width:290px;
-    }
+  .content-left-margin {
+    margin-left: 0.5em;
+  }
 
-    .table-2 {
-      width:40%;
-      margin-left:1.8em;
-    }
+  .table-1 {
+    white-space: nowrap;
+    max-width: 290px;
+  }
 
-    .table-box {
-      margin-top:2em;
-      margin-bottom:2em;
-      width:50%;
-      border: 2px solid gray;
-    }
-    .text-centre {
-      text-align:center;
-    }
-    .table-adapters {
-      float: right;
-      width: auto;
+  .table-2 {
+    width: 40%;
+    margin-left: 1.8em;
+  }
+
+  .table-box {
+    margin-top: 2em;
+    margin-bottom: 2em;
+    width: 50%;
+    border: 2px solid gray;
+  }
+  .text-centre {
+    text-align: center;
+  }
+  .table-adapters {
+    float: right;
+    width: auto;
+    vertical-align: middle;
+    border: 1px solid darkgray;
+    .adapter-logo {
       vertical-align: middle;
-      border: 1px solid darkgray;
-      .adapter-logo {
-        vertical-align: middle;
-        margin-right: 5px;
-        height: 30px;
-        width: 30px;
-      }
-      .stable-adapters {
-        width: auto;
-        background-color: #3C494F;
-        text-align: center;
-        color: #fff;
-      }
-      .beta-adapters {
-        width: auto;
-        background-color: #00D3A9;
-        text-align: center;
-        color: #fff;
-      }
-      .alpha-adapters {
-        width: auto;
-        background-color: lightgray;
-        text-align: center;
-        color: black;
-      }
+      margin-right: 5px;
+      height: 30px;
+      width: 30px;
     }
+    .stable-adapters {
+      width: auto;
+      background-color: #3c494f;
+      text-align: center;
+      color: #fff;
+    }
+    .beta-adapters {
+      width: auto;
+      background-color: #00d3a9;
+      text-align: center;
+      color: #fff;
+    }
+    .alpha-adapters {
+      width: auto;
+      background-color: lightgray;
+      text-align: center;
+      color: black;
+    }
+  }
 
-    .starting-letter {
-      margin-left:.75em;
-      font-size: 2em;
-    }
+  .starting-letter {
+    margin-left: 0.75em;
+    font-size: 2em;
+  }
 
-    .pull-right {
-      float:right;
-    }
+  .pull-right {
+    float: right;
+  }
 
-    .hidden {
-      display:none;
-    }
+  .hidden {
+    display: none;
+  }
 
-    .fit-content {
-      width:fit-content;
-    }
+  .fit-content {
+    width: fit-content;
+  }
 
-    .embed-dimension {
-      min-height: 315px;
-      min-width: 280px;
-    }
+  .embed-dimension {
+    min-height: 315px;
+    min-width: 280px;
+  }
 
-    .pa-20{
-      padding: 20px;
-    }
+  .pa-20 {
+    padding: 20px;
+  }
 
-    .image-left {
-      width: 40%;
-      float: left;
-      margin: 1rem 1.25rem 1rem 0rem;
-      box-shadow: 0px 5px 10px 1px rgba(0, 179, 159, 0.50);
-    }
+  .image-left {
+    width: 40%;
+    float: left;
+    margin: 1rem 1.25rem 1rem 0rem;
+    box-shadow: 0px 5px 10px 1px rgba(0, 179, 159, 0.5);
+  }
 
-    .image-right {
-      width: 40%;
-      float: right;
-      margin: 1rem 0rem 1rem 1.25rem;
-      box-shadow: 0px 5px 10px 1px rgba(0, 179, 159, 0.50);
-    }
-    .image-center {
-        display: block;
-        margin-left: auto;
-        margin-right: auto;
-        width: 90%;
-        padding-bottom: 10px;
-        padding-top: 10px;
-    }
+  .image-right {
+    width: 40%;
+    float: right;
+    margin: 1rem 0rem 1rem 1.25rem;
+    box-shadow: 0px 5px 10px 1px rgba(0, 179, 159, 0.5);
+  }
+  .image-center {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    width: 90%;
+    padding-bottom: 10px;
+    padding-top: 10px;
+  }
 
-    .align-right{
-      display: block;
-      margin-left: auto;
-      margin-right: auto;
-      width: 22%;
-      height: 22%;
-      float: right;
-      border-radius: 50%;
-    }
+  .align-right {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    width: 22%;
+    height: 22%;
+    float: right;
+    border-radius: 50%;
+  }
 
-    .gsoc-image{
-        max-width: 100%;
-        height: auto;
-    }
-    .smp-image{
-      height:40%;
-      width:40%;
-    }
-    .date{
-      color:gray;
-    }
+  .gsoc-image {
+    max-width: 100%;
+    height: auto;
+  }
+  .smp-image {
+    height: 40%;
+    width: 40%;
+  }
+  .date {
+    color: gray;
+  }
 
-    .centered-text{
-      color:#3c494f;
-      text-align:center;
-    }
-    .kubecon-header{
-      color:#00b39f;
-    }
-    .kubecon-img1{
-      width:28%;
-    }
-    .kubecon-img2{
-      padding-top:8px;
-      width:28%;
-    }
-    .kubecon-img3{
-      padding-top:15px;
-      width:28%;
-    }
-    img.right {
-        width: 25%;
-        display: inline;
-        position: relative;
-        float: right;
-    }
-    img.left {
-        width: 25%;
-        display: inline;
-        position: relative;
-        float: left;
-        margin: 1rem 1rem 1rem 0rem;
- 
-    }
-    div.intro {
-        padding-left: 3rem;
-        padding-right: 3rem;
-        font-style: italic;
-        font-size: .8rem;
-        border-bottom: 1px dashed ${props => props.theme.primaryLightColor};
+  .centered-text {
+    color: #3c494f;
+    text-align: center;
+  }
+  .kubecon-header {
+    color: #00b39f;
+  }
+  .kubecon-img1 {
+    width: 28%;
+  }
+  .kubecon-img2 {
+    padding-top: 8px;
+    width: 28%;
+  }
+  .kubecon-img3 {
+    padding-top: 15px;
+    width: 28%;
+  }
+  img.right {
+    width: 25%;
+    display: inline;
+    position: relative;
+    float: right;
+  }
+  img.left {
+    width: 25%;
+    display: inline;
+    position: relative;
+    float: left;
+    margin: 1rem 1rem 1rem 0rem;
+  }
+  div.intro {
+    padding-left: 3rem;
+    padding-right: 3rem;
+    font-style: italic;
+    font-size: 0.8rem;
+    border-bottom: 1px dashed ${(props) => props.theme.primaryLightColor};
+  }
 
+  /* ==============
+styles for meshmate-of-the-year-2020 
+=======================*/
+
+  @media screen and (min-width: 768px) {
+    .responsive-blog {
+      display: flex;
     }
+  }
 `;


### PR DESCRIPTION
[Blog] Fix responsiveness of blog

This PR fixes: #1773 

Issue Description
The blog Meshmate of the Year 2020 is not responsive for mobile view.

Current Behavior
The blog is now responsive across all view sizes

Snippets
![blog responsive two](https://user-images.githubusercontent.com/58997189/114922446-95405f80-9e23-11eb-8347-adee98d4f848.png)
![responsive blog one](https://user-images.githubusercontent.com/58997189/114922478-a0938b00-9e23-11eb-95f1-4bb60ef9d882.png)

Notes for Reviewers
Responsiveness can be tested for multiple devices [here](http://www.responsinator.com/)

Signed commits

[* ] Yes, I signed my commits.
