### PR TITLE
Smooth transition for installation steps component

### DIFF
--- a/src/sections/Meshery/Meshery-platforms/index.js
+++ b/src/sections/Meshery/Meshery-platforms/index.js
@@ -174,13 +174,27 @@ const supported_platforms = [
 
 const MesheryPlatforms = () => {
   const [currentPlatform, setCurrentPlatform] = useState({});
+  const [installationStepsHeight,setInstallationStepsHeight] = useState(currentPlatform.name ? "200px" : 0);
 
-  const changeCurrentPlatform = (index) => {
-    if (currentPlatform.name && currentPlatform.name === supported_platforms[index].name)
+  const hasSelectedSamePlatform = (index) => currentPlatform.name === supported_platforms[index].name;
+
+  const changeCurrentPlatformState = (index) => {
+    if (currentPlatform.name && hasSelectedSamePlatform(index))
       setCurrentPlatform({});
     else
       setCurrentPlatform(supported_platforms[index]);
+
   };
+
+  const changeCurrentPlatform = (index) => {
+    if(currentPlatform.name && !hasSelectedSamePlatform(index)) {
+      changeCurrentPlatformState(index);
+      return;
+    }
+    setTimeout(() => changeCurrentPlatformState(index), 500);
+    setInstallationStepsHeight(currentPlatform.name ? 0 : "200px");
+  };
+
 
   return (
     <MesheryPlatformsWrapper>
@@ -201,13 +215,11 @@ const MesheryPlatforms = () => {
             </Col>
           ))}
         </Row>
-        {currentPlatform.name && (
-          <Container>
-            <Row className="installation-steps">
-              {currentPlatform.steps}
-            </Row>
-          </Container>
-        )}
+        <Container style={{transition: "height 0.5s ease-in-out", height: installationStepsHeight, overflow: "hidden"}}>
+          <Row className="installation-steps" >
+            {currentPlatform.name && currentPlatform.steps}
+          </Row>
+        </Container>
         <Row Hcenter className="step-2">
           <Col>
             <h2><span>Step 2:</span> Manage your mesh</h2>


### PR DESCRIPTION
Signed-off-by: suod-NithishKarthik <nithishkarthik01@gmail.com>

fix[site] : Add smooth transition for platform installation component



**Description**
Change the height of the component based on the state of platform
availability and add transition property to the component

This PR fixes #1752

**Notes for Reviewers**
The height has been set to `200px` which i am not totally OK with. I am afraid that in some cases, the the height of the content might become more than that and because `overflow` is set to `hidden`, it might not be fully visible. 

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
