### PR TITLE
Fix safari contact form issue

### DIFF
--- a/src/sections/Company/Contact/index.js
+++ b/src/sections/Company/Contact/index.js
@@ -8,13 +8,42 @@ import Contact_Icon from "../../../assets/images/contact/contact.svg";
 import CardOutline from "../../../components/Card-Outline";
 import ContactPageWrapper from "./contactpage.style";
 
+const CONTACT_FORM_URL = "https://us15.list-manage.com/contact-form?u=6b50be5aea3dfe1fd4c041d80&form_id=d0ffe17c92d8014ede6b721aa16096e8";
+
 const ContactPage = () => {
 
   const expandForm = useRef();
 
   const toggleForm = () => {
+
+    if(detectSafari() || !navigator.cookieEnabled) {
+      window.open(CONTACT_FORM_URL);
+      return;
+    }
+
     expandForm.current.classList.toggle("showForm");
   };
+
+  /**
+   * Finds if the given agent is the 
+   * browser's agent
+   * @param {string} agent
+   * @returns {boolean}
+   */
+  const findAgent = (agent) => navigator.userAgent.indexOf(agent) > -1;
+
+  
+  const detectSafari = () => {
+    
+    let safariAgent = findAgent("Safari");
+    let chromeAgent = findAgent("Chrome");
+  
+    // Discard Safari since it also matches Chrome
+    if ((chromeAgent) && (safariAgent)) safariAgent = false;
+
+    return safariAgent;
+  };
+
 
   return (
     <ContactPageWrapper>
@@ -62,7 +91,7 @@ const ContactPage = () => {
           <div className="contact-form" ref={expandForm}>
             <iframe
               scrolling="no"
-              src="https://us15.list-manage.com/contact-form?u=6b50be5aea3dfe1fd4c041d80&form_id=d0ffe17c92d8014ede6b721aa16096e8"
+              src= {CONTACT_FORM_URL}
               className="form-frame"
             />
           </div>


### PR DESCRIPTION


**Description**


User will be seeing the contact form in a new window rather than in the same page, if any of the following two conditions are met,

1. Safari browser is being used
2. Cookies are disabled by the user

This PR fixes #1953 

**Notes for Reviewers**
If we think about it, this is not the perfect solution. Because, the case when the user has set only 'third-party-cookies' disabled is not being handled here. And that is because, in order to check if the browser has 'third-party-cookies' enabled or not, we have to make use of a server. There are some CDN's which does this, but i am not sure if we can take their authenticity for granted.  

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
