### PR TITLE
Fixed Back Navigation to course overview page from chapter page

### DIFF
--- a/src/components/Learn-Components/TOC-Chapters/index.js
+++ b/src/components/Learn-Components/TOC-Chapters/index.js
@@ -20,7 +20,7 @@ const TOC = ({ courseData, chapterData, location }) => {
   return (
     <TOCWrapper>
       <div className="chapter-back">
-        <Link to={`/learn-ng${courseData.fields.slug}`}>
+        <Link to={`/${courseData.fields.slug}`}>
           <HiOutlineChevronLeft />
           <h4>{courseData.frontmatter.courseTitle}</h4>
         </Link>


### PR DESCRIPTION
Fixed Navigation to course overview page from chapter page.

There was a typo in the back navigation Link.
Fixed the typo.

This PR fixes # [1959](https://github.com/layer5io/layer5/issues/1959)

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
