### PR TITLE
[Learn-ng] Refactor service mesh switcher and Table of Contents

### DIFF
--- a/content-learn/mastering-meshery-istio/introduction-to-service-meshes/istio/circuit-breaking.mdx
+++ b/content-learn/mastering-meshery-istio/introduction-to-service-meshes/istio/circuit-breaking.mdx
@@ -4,6 +4,7 @@ chapterTitle: "Circuit Breaking"
 description: "Meshery is the service mesh managemen plane which offers lifecycle, configuration, and performance management of service meshes and their workloads."
 videos: 4
 lectures: 12
+order: 7
 ---
 
 import { ChapterStyle } from "../../../../src/components/Learn-Components/Chapters-Style/chapters.style.js";

--- a/content-learn/mastering-meshery-istio/introduction-to-service-meshes/istio/deploy-an-application.mdx
+++ b/content-learn/mastering-meshery-istio/introduction-to-service-meshes/istio/deploy-an-application.mdx
@@ -4,6 +4,7 @@ chapterTitle: "Deploy a sample application"
 description: "Meshery is the service mesh managemen plane which offers lifecycle, configuration, and performance management of service meshes and their workloads."
 videos: 4
 lectures: 12
+order: 2
 ---
 
 import { ChapterStyle } from "../../../../src/components/Learn-Components/Chapters-Style/chapters.style.js";

--- a/content-learn/mastering-meshery-istio/introduction-to-service-meshes/istio/expose-services.mdx
+++ b/content-learn/mastering-meshery-istio/introduction-to-service-meshes/istio/expose-services.mdx
@@ -4,6 +4,7 @@ chapterTitle: "Exposing services through Istio Ingress Gateway"
 description: "Meshery is the service mesh managemen plane which offers lifecycle, configuration, and performance management of service meshes and their workloads."
 videos: 4
 lectures: 12
+order: 3
 ---
 
 import { ChapterStyle } from "../../../../src/components/Learn-Components/Chapters-Style/chapters.style.js";

--- a/content-learn/mastering-meshery-istio/introduction-to-service-meshes/istio/fault-injection.mdx
+++ b/content-learn/mastering-meshery-istio/introduction-to-service-meshes/istio/fault-injection.mdx
@@ -4,6 +4,7 @@ chapterTitle: "Fault Injection"
 description: "Meshery is the service mesh managemen plane which offers lifecycle, configuration, and performance management of service meshes and their workloads."
 videos: 4
 lectures: 12
+order: 6
 ---
 
 import { ChapterStyle } from "../../../../src/components/Learn-Components/Chapters-Style/chapters.style.js";

--- a/content-learn/mastering-meshery-istio/introduction-to-service-meshes/istio/getting-started.mdx
+++ b/content-learn/mastering-meshery-istio/introduction-to-service-meshes/istio/getting-started.mdx
@@ -4,6 +4,7 @@ chapterTitle: "Getting Started"
 description: "Meshery is the service mesh managemen plane which offers lifecycle, configuration, and performance management of service meshes and their workloads."
 videos: 4
 lectures: 12
+order: 1
 ---
 
 import { ChapterStyle } from "../../../../src/components/Learn-Components/Chapters-Style/chapters.style.js";

--- a/content-learn/mastering-meshery-istio/introduction-to-service-meshes/istio/mutual-tls.mdx
+++ b/content-learn/mastering-meshery-istio/introduction-to-service-meshes/istio/mutual-tls.mdx
@@ -4,6 +4,7 @@ chapterTitle: "Mutual TLS & Identity Verification"
 description: "Meshery is the service mesh managemen plane which offers lifecycle, configuration, and performance management of service meshes and their workloads."
 videos: 4
 lectures: 12
+order: 7
 ---
 
 import { ChapterStyle } from "../../../../src/components/Learn-Components/Chapters-Style/chapters.style.js";

--- a/content-learn/mastering-meshery-istio/introduction-to-service-meshes/istio/observability.mdx
+++ b/content-learn/mastering-meshery-istio/introduction-to-service-meshes/istio/observability.mdx
@@ -4,6 +4,7 @@ chapterTitle: "Observability"
 description: "Meshery is the service mesh managemen plane which offers lifecycle, configuration, and performance management of service meshes and their workloads."
 videos: 4
 lectures: 12
+order: 4
 ---
 
 import { ChapterStyle } from "../../../../src/components/Learn-Components/Chapters-Style/chapters.style.js";

--- a/content-learn/mastering-meshery-istio/introduction-to-service-meshes/istio/routing-and-canary.mdx
+++ b/content-learn/mastering-meshery-istio/introduction-to-service-meshes/istio/routing-and-canary.mdx
@@ -4,6 +4,7 @@ chapterTitle: "Request Routing and Canary Testing"
 description: "Meshery is the service mesh managemen plane which offers lifecycle, configuration, and performance management of service meshes and their workloads."
 videos: 4
 lectures: 12
+order: 5
 ---
 
 import { ChapterStyle } from "../../../../src/components/Learn-Components/Chapters-Style/chapters.style.js";

--- a/content-learn/mastering-meshery-istio/introduction-to-service-meshes/linkerd/dashboard.mdx
+++ b/content-learn/mastering-meshery-istio/introduction-to-service-meshes/linkerd/dashboard.mdx
@@ -4,6 +4,7 @@ chapterTitle: "Linkerd Dashboard"
 description: "Meshery is the service mesh managemen plane which offers lifecycle, configuration, and performance management of service meshes and their workloads."
 videos: 4
 lectures: 12
+order: 4
 ---
 
 import { ChapterStyle } from "../../../../src/components/Learn-Components/Chapters-Style/chapters.style.js";

--- a/content-learn/mastering-meshery-istio/introduction-to-service-meshes/linkerd/debugging.mdx
+++ b/content-learn/mastering-meshery-istio/introduction-to-service-meshes/linkerd/debugging.mdx
@@ -4,6 +4,7 @@ chapterTitle: "Debugging (Optional)"
 description: "Meshery is the service mesh managemen plane which offers lifecycle, configuration, and performance management of service meshes and their workloads."
 videos: 4
 lectures: 12
+order: 5
 ---
 
 import { ChapterStyle } from "../../../../src/components/Learn-Components/Chapters-Style/chapters.style.js";

--- a/content-learn/mastering-meshery-istio/introduction-to-service-meshes/linkerd/deploy-an-application.mdx
+++ b/content-learn/mastering-meshery-istio/introduction-to-service-meshes/linkerd/deploy-an-application.mdx
@@ -4,6 +4,7 @@ chapterTitle: "Deploy a sample application"
 description: "Meshery is the service mesh managemen plane which offers lifecycle, configuration, and performance management of service meshes and their workloads."
 videos: 4
 lectures: 12
+order: 2
 ---
 
 import { ChapterStyle } from "../../../../src/components/Learn-Components/Chapters-Style/chapters.style.js";

--- a/content-learn/mastering-meshery-istio/introduction-to-service-meshes/linkerd/expose-services.mdx
+++ b/content-learn/mastering-meshery-istio/introduction-to-service-meshes/linkerd/expose-services.mdx
@@ -4,6 +4,7 @@ chapterTitle: "Exposing services through Linkerd Ingress"
 description: "Meshery is the service mesh managemen plane which offers lifecycle, configuration, and performance management of service meshes and their workloads."
 videos: 4
 lectures: 12
+order: 3
 ---
 
 import { ChapterStyle } from "../../../../src/components/Learn-Components/Chapters-Style/chapters.style.js";

--- a/content-learn/mastering-meshery-istio/introduction-to-service-meshes/linkerd/fault-injection.mdx
+++ b/content-learn/mastering-meshery-istio/introduction-to-service-meshes/linkerd/fault-injection.mdx
@@ -4,6 +4,7 @@ chapterTitle: "Fault Injection"
 description: "Meshery is the service mesh managemen plane which offers lifecycle, configuration, and performance management of service meshes and their workloads."
 videos: 4
 lectures: 12
+order: 8
 ---
 
 import { ChapterStyle } from "../../../../src/components/Learn-Components/Chapters-Style/chapters.style.js";

--- a/content-learn/mastering-meshery-istio/introduction-to-service-meshes/linkerd/getting-started.mdx
+++ b/content-learn/mastering-meshery-istio/introduction-to-service-meshes/linkerd/getting-started.mdx
@@ -4,6 +4,7 @@ chapterTitle: "Getting Started"
 description: "Meshery is the service mesh managemen plane which offers lifecycle, configuration, and performance management of service meshes and their workloads."
 videos: 6
 lectures: 8
+order: 1
 ---
 
 import { ChapterStyle } from "../../../../src/components/Learn-Components/Chapters-Style/chapters.style.js";

--- a/content-learn/mastering-meshery-istio/introduction-to-service-meshes/linkerd/observability.mdx
+++ b/content-learn/mastering-meshery-istio/introduction-to-service-meshes/linkerd/observability.mdx
@@ -4,6 +4,7 @@ chapterTitle: "Observability"
 description: "Meshery is the service mesh managemen plane which offers lifecycle, configuration, and performance management of service meshes and their workloads."
 videos: 4
 lectures: 12
+order: 6
 ---
 
 import { ChapterStyle } from "../../../../src/components/Learn-Components/Chapters-Style/chapters.style.js";

--- a/content-learn/mastering-meshery-istio/introduction-to-service-meshes/linkerd/traffic-splitting.mdx
+++ b/content-learn/mastering-meshery-istio/introduction-to-service-meshes/linkerd/traffic-splitting.mdx
@@ -4,6 +4,7 @@ chapterTitle: "Traffic Splitting using SMI and Linkerd"
 description: "Meshery is the service mesh managemen plane which offers lifecycle, configuration, and performance management of service meshes and their workloads."
 videos: 4
 lectures: 12
+order: 7
 ---
 
 import { ChapterStyle } from "../../../../src/components/Learn-Components/Chapters-Style/chapters.style.js";

--- a/src/components/Learn-Components/TOC-Chapters/index.js
+++ b/src/components/Learn-Components/TOC-Chapters/index.js
@@ -3,7 +3,8 @@ import { HiOutlineChevronLeft } from "react-icons/hi";
 import { Link } from "gatsby";
 import TOCWrapper from "./toc.style";
 
-const TOC = ({ courseData, chapterData, location }) => {
+const TOC = ({ TOCData,courseData, chapterData, location }) => {
+
   const reformatTOC= (data) => {
     let newData = data.split("-").join(" ");
     let firstLetter = newData.charAt(0).toUpperCase();
@@ -20,6 +21,8 @@ const TOC = ({ courseData, chapterData, location }) => {
 
   const getActiveServiceMesh = () => chapterData.fields.slug.split("/")[3];
 
+  const availableChapters = TOCData.filter(toc => toc.fields.section === getActiveServiceMesh()).map(toc => toc.fields.chapter);
+
   return (
     <TOCWrapper>
       <div className="chapter-back">
@@ -30,7 +33,7 @@ const TOC = ({ courseData, chapterData, location }) => {
       </div>
       <div className="toc-list">
         <ul>
-          {courseData.frontmatter.toc.map((item) => (
+          {availableChapters.map((item) => (
             <li key={item} className={item === getCurrentPage(location)? "active-link" : ""}>
               <p className="toc-item">
                 <a href={`/learn-ng/${chapterData.fields.learnpath}/${chapterData.fields.course}/${getActiveServiceMesh()}/${item}/`}>

--- a/src/sections/Learn-Layer5/Chapters/index.js
+++ b/src/sections/Learn-Layer5/Chapters/index.js
@@ -7,62 +7,82 @@ import Image from "../../../components/image";
 import { ChapterWrapper } from "./chapters.style";
 import ReactTooltip from "react-tooltip";
 
-const Chapters = ({chapterData, courseData, location, serviceMeshesList}) => {
+const Chapters = ({chapterData, courseData, location, serviceMeshesList, TOCData}) => {
+
   const { frontmatter, body } = chapterData;
   const serviceMeshImages = courseData.frontmatter.meshesYouLearn;
-  
+  const tableOfContents = TOCData
+    .filter(node => !!node.fields.section)
+    .map( toc => ({section: toc.fields.section, chapter: toc.fields.chapter}) );
+
+
   const replaceSlugPart = (index) => (oldSlug) => (replacement) => {
     let parts = oldSlug.split("/");
     parts[index] = replacement;
     return parts.join("/");
   };
-    
   const replaceServiceMeshInSlug = replaceSlugPart(3)(chapterData.fields.slug);
+  const replaceChapterInSlug = (slugWithReplacedMesh) => replaceSlugPart(4)(slugWithReplacedMesh);
 
 
   const isMeshActive = (sm) => chapterData.fields.slug.split("/")[3] === sm;
 
+  const mapMeshWithFormattedSlug = (sm, serviceMeshes) => {
+    let chapterFound = false;
+    tableOfContents.forEach(toc => {
+      if(toc.section === sm.fields.section){
+        if(toc.chapter === chapterData.fields.slug.split("/")[4]) chapterFound = true;
+      }
+    });
+
+    if(!serviceMeshes.map(sm => sm.section).includes(sm.fields.section)) 
+      serviceMeshes.push({section: sm.fields.section, slug: chapterFound ? 
+        replaceServiceMeshInSlug( sm.fields.section)
+        : replaceChapterInSlug(replaceServiceMeshInSlug(sm.fields.section))(tableOfContents[0].chapter)});
+
+  }; 
+
   const getAvailableServiceMeshes = () => {
     let serviceMeshes = [];
     serviceMeshesList.forEach(sm => {
-      if(!serviceMeshes.map(sm => sm.section).includes(sm.fields.section)) 
-        serviceMeshes.push({section: sm.fields.section, slug: replaceServiceMeshInSlug( sm.fields.section)}); 
+      mapMeshWithFormattedSlug(sm, serviceMeshes);    
     });
     return serviceMeshes;
   };
 
   const findServiceMeshImage = (images, serviceMesh) => images.find(image => image.name.toLowerCase() == serviceMesh);
 
-  const ServiceMeshesAvailable = ({serviceMeshes}) => serviceMeshes.map((sm, index) => 
-    <>
-      <a  href={`/${sm.slug}`} data-for="mesh-name" data-tip={sm.section} className="course" key={sm+index}>
-        <div className={`service-mesh-image ${isMeshActive(sm.section) ? "service-mesh-image-active" : ""}`}>
-          <Image
-            {...findServiceMeshImage(serviceMeshImages, sm.section).imagepath}
-            className="docker"
-            alt={sm.section}
-          />
-        </div>
-      </a>
-      <ReactTooltip 
-        id="mesh-name"
-        place="bottom"
-        effect="solid"
-        backgroundColor="rgb(60,73,79)"
-        className="mesh-tooltip"
-      />
-    </>
+  const ServiceMeshesAvailable = ({serviceMeshes}) => serviceMeshes.map((sm, index) => {
+
+    return(  
+      <>
+        <a  href={`/${sm.slug}`} data-for="mesh-name" data-tip={sm.section} className="course" key={sm+index}>
+          <div className={`service-mesh-image ${isMeshActive(sm.section) ? "service-mesh-image-active" : ""}`}>
+            <Image
+              {...findServiceMeshImage(serviceMeshImages, sm.section).imagepath}
+              className="docker"
+              alt={sm.section}
+            />
+          </div>
+        </a>
+        <ReactTooltip 
+          id="mesh-name"
+          place="bottom"
+          effect="solid"
+          backgroundColor="rgb(60,73,79)"
+          className="mesh-tooltip"
+        />
+      </>);
+  }
   ); 
 
-
-  
 
   return (
     <ChapterWrapper>
       <Container className="chapter-container">
         <Row>
           <Col sm={12} md={3}>
-            <TOC courseData={courseData} chapterData={chapterData} location={location} />
+            <TOC courseData={courseData} TOCData={TOCData} chapterData={chapterData} location={location} />
             <div className="service-mesh-switch-container">
               <h4>Service Meshes Available</h4>
               <div className="service-mesh-switcher">

--- a/src/templates/learn-chapter.js
+++ b/src/templates/learn-chapter.js
@@ -20,7 +20,6 @@ export const query = graphql`
         frontmatter {
           chapterTitle
           description
-
                  }
         fields {
           slug
@@ -53,6 +52,21 @@ export const query = graphql`
         }
     }
 
+    TOC: allMdx(
+      filter: {fields: {course: {eq: $course}, pageType: {eq: "chapter"}}}
+    ) {
+        nodes {
+          frontmatter{
+            order
+      }
+          fields {
+            section
+            chapter
+          }
+        }
+    }
+
+
   serviceMeshesList: allMdx(
     filter: {fields: {course: {eq: $course}, pageType: {eq: "chapter"}}}
   ){
@@ -68,13 +82,19 @@ export const query = graphql`
 `;
 
 const SingleChapter = ({data, location}) => {
+
+  const sortedTOCData = data.TOC.nodes.sort((first, second) => {
+    let firstOrder = first.frontmatter?.order ? first.frontmatter.order : 100;
+    let secondOrder = second.frontmatter?.order ? second.frontmatter.order : 100;
+    return firstOrder - secondOrder;
+  }); 
   return (
     <ThemeProvider theme={theme}>
       <Layout>
         <GlobalStyle />
         <SEO title={data.chapter.frontmatter.chapterTitle} />
         <Navigation />
-        <Chapters chapterData={data.chapter} courseData={data.course.nodes[0]} location={location} serviceMeshesList={data.serviceMeshesList.nodes}/>
+        <Chapters chapterData={data.chapter} TOCData={sortedTOCData} courseData={data.course.nodes[0]} location={location} serviceMeshesList={data.serviceMeshesList.nodes}/>
         <Footer />
       </Layout>
     </ThemeProvider>


### PR DESCRIPTION


**Description**
This pr introduces, 

- Dynamic rendering of Table of Contents based on the available chapters rather than using frontmatter from Mdx file
- Fallback for redirection when requested chapter is not available for a different service mesh
- Ability to declare the order in which chapters should be shown in table of contents

 

https://user-images.githubusercontent.com/75248557/128693710-5e26d66a-7d37-467e-bf71-b72bf32c597d.mov




**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
