### PR TITLE
[Handbook] Fixed SideNav Links Overwidth Issue

### DIFF
--- a/src/components/handbook-navigation/index.js
+++ b/src/components/handbook-navigation/index.js
@@ -13,35 +13,52 @@ const TOC = () => {
         </Link>
       </div>
       <div className="toc-list">
-        <ul>
-          <Link to="/handbook/about">
-            <h5 className="toc-sub-heading">About</h5>
-          </Link>
-
-          <Link to="/handbook/community">
-            <h5 className="toc-sub-heading">Community</h5>
-          </Link>
-          <Link to="/handbook/contribution">
-            <h5 className="toc-sub-heading">Contribution</h5>
-          </Link>
-          <Link to="/handbook/repository-overview">
-            <h5 className="toc-sub-heading">Repository Overview</h5>
-          </Link>
-          <Link to="/handbook/projects">
-            <h5 className="toc-sub-heading">Projects</h5>
-          </Link>
-          <Link to="/handbook/mentorship-programs">
-            <h5 className="toc-sub-heading">Mentorship Programs</h5>
-          </Link>
-          <Link to="/handbook/learn-layer5">
-            <h5 className="toc-sub-heading">Learn Layer5</h5>
-          </Link>
-          <Link to="/handbook/connect-with-us">
-            <h5 className="toc-sub-heading">Connect with us</h5>
-          </Link>
-          <Link to="/handbook/code-of-conduct">
-            <h5 className="toc-sub-heading">Code of Conduct</h5>
-          </Link>
+        <ul className="toc-ul">
+          <li>
+            <Link to="/handbook/about">
+              <h5 className="toc-sub-heading toc-sub-inline">About</h5>
+            </Link>
+          </li>
+          <li>
+            <Link to="/handbook/community">
+              <h5 className="toc-sub-heading toc-sub-inline">Community</h5>
+            </Link>
+          </li>
+          <li>
+            <Link to="/handbook/contribution">
+              <h5 className="toc-sub-heading toc-sub-inline">Contribution</h5>
+            </Link>
+          </li>
+          <li>
+            <Link to="/handbook/repository-overview">
+              <h5 className="toc-sub-heading toc-sub-inline">Repository Overview</h5>
+            </Link>
+          </li>
+          <li>
+            <Link to="/handbook/projects">
+              <h5 className="toc-sub-heading toc-sub-inline">Projects</h5>
+            </Link>
+          </li>
+          <li>
+            <Link to="/handbook/mentorship-programs">
+              <h5 className="toc-sub-heading toc-sub-inline">Mentorship Programs</h5>
+            </Link>
+          </li>
+          <li>
+            <Link to="/handbook/learn-layer5">
+              <h5 className="toc-sub-heading toc-sub-inline">Learn Layer5</h5>
+            </Link>
+          </li>
+          <li>
+            <Link to="/handbook/connect-with-us">
+              <h5 className="toc-sub-heading toc-sub-inline">Connect with us</h5>
+            </Link>
+          </li>
+          <li>
+            <Link to="/handbook/code-of-conduct">
+              <h5 className="toc-sub-heading toc-sub-inline">Code of Conduct</h5>
+            </Link>
+          </li>
         </ul>
       </div>
     </TOCWrapper>

--- a/src/components/handbook-navigation/toc.style.js
+++ b/src/components/handbook-navigation/toc.style.js
@@ -6,6 +6,7 @@ const TOCWrapper = styled.div`
   left: 0rem;
   margin-left: 3rem;
   margin-top: 3rem;
+  width:15rem;
 
   .go-back {
     margin-left: 1rem;
@@ -39,6 +40,18 @@ const TOCWrapper = styled.div`
     font-weight: 300;
     font-size: 1.15rem;
   }
+  
+  .toc-sub-inline{
+    display: inline-block;
+  }
+
+  .toc-ul{
+    display: flex;
+    flex-direction: column;
+    margin-top: 0rem;
+    list-style: none;
+  }
+
   .toc-sub-heading:hover {
     color: ${(props) => props.theme.secondaryColor};
   }

--- a/src/sections/Community/Handbook/about.js
+++ b/src/sections/Community/Handbook/about.js
@@ -10,6 +10,7 @@ import TOC from "../../../components/handbook-navigation/index";
 const IntroWrapper = styled.div`
     padding: 3rem 20rem;
     margin-top: -25rem; 
+    padding-top: 0.5rem;
     h2{
       color:black;
       margin-bottom: 1rem;


### PR DESCRIPTION
Signed-off-by: Nikhil Sharma <nikhilsharmamusic2000@gmail.com>

**Description**
- There was an issue with sidenav links as those were over width and were clickable from the whole area.

https://user-images.githubusercontent.com/58226527/129706345-51b58a42-2d47-4ca6-b904-3e25e7b602f4.mp4

<br/>

# After Changes

https://user-images.githubusercontent.com/58226527/129706398-402d3f8a-2d01-47d2-8945-ce910f1fe36a.mp4



This PR fixes #2091 

**Notes for Reviewers**
- Let me know if there are any other changes we can make.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
