### PR TITLE
removed thursday from meshmap

### DIFF
--- a/src/sections/Community/Calendar/meetLinksData.js
+++ b/src/sections/Community/Calendar/meetLinksData.js
@@ -18,7 +18,7 @@ export const meet_links_data = [
     meeting_recordings: "https://www.youtube.com/playlist?list=PL3A-A6hPO2IOur7idhSAUf6hySLn-hdVD",
   },
   {
-    day: "Tuesdays & Thursdays",
+    day: "Tuesdays",
     meeting: "Meshery MeshSync/MeshMap Meeting",
     slack_channel: "#meshery-ci",
     slack_link: "https://layer5io.slack.com/archives/C010LFFGFFA",


### PR DESCRIPTION
Signed-off-by: Aditya Chaterjee <speak2adi@gmail.com>

**Description**
Removed thursdays from the meshmap meetings section.
This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
