### PR TITLE
fix: toc component links are active when they shouldn’t be in mobile

### DIFF
--- a/src/components/handbook-navigation/toc.style.js
+++ b/src/components/handbook-navigation/toc.style.js
@@ -98,6 +98,11 @@ const TOCWrapper = styled.div`
     opacity:0;
     height:0;
     transition:none;
+    visibility:hidden;
+   }
+
+   .toc-ul-open{
+    visibility:visible;
    }
   }
 `;


### PR DESCRIPTION
Signed-off-by: Stephanie Nathai-Cueter <stephanie.nathaicueter@aexp.com>

**Description**
Defect fix for active table of content component links for mobile
This PR fixes [#2138](https://github.com/layer5io/layer5/issues/2138)

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
