### PR TITLE
removed the note on make command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,7 @@ Please contribute! The Layer5 site uses Gatsby. The process of contributing to d
 `vi <specific page>.md` # or use your favorite IDE
 1. Run site locally to preview changes.
 `make site` # this will run a local web server with "live reload" conveniently enabled.
+(NOTE: while using `make` command on windows, there sometimes arises an error in identifying the command even after it is installed(unrecognized command), this is because the PATH for the binary might not be set correctly.)
 1. Commit your changes to your remote branch.
 `git commit --signoff -m"<commit subject>`
 1. Push your changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,6 @@ Please contribute! The Layer5 site uses Gatsby. The process of contributing to d
 `vi <specific page>.md` # or use your favorite IDE
 1. Run site locally to preview changes.
 `make site` # this will run a local web server with "live reload" conveniently enabled.
-(NOTE make is a linux command , if you are using windows you can install wsl , and then run command `sudo apt install make` )
 1. Commit your changes to your remote branch.
 `git commit --signoff -m"<commit subject>`
 1. Push your changes


### PR DESCRIPTION
Signed-off-by: Aditya Chaterjee <speak2adi@gmail.com>

**Description**
Removed the note on `make` command from the contributing.md file
This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
