### PR TITLE
Fix: Overlapping text in Handbook (about us section)

### DIFF
--- a/src/sections/Community/Handbook/Handbook.style.js
+++ b/src/sections/Community/Handbook/Handbook.style.js
@@ -214,6 +214,11 @@ export const HandbookWrapper = styled.div`
     display: flex;
     align-items: center;
     margin: 2.5rem 5rem 3rem 0rem;
+
+    
+    @media only screen and (max-width: 992px){
+      width: 100%;
+      }
     
     h2{
       margin-bottom: 2rem;
@@ -223,9 +228,6 @@ export const HandbookWrapper = styled.div`
     display: flex;
     flex-direction: column;
     align-items: center;
-    h2{
-      margin-top: -5.5rem;
-    }
   }
   .heading-start{
     display: flex;


### PR DESCRIPTION
Signed-off-by: toth2000 <tothagata.bhattacharjee@gmail.com>

**Description**
Add gap between two sections.

![image](https://user-images.githubusercontent.com/65480420/138306227-1525a211-f850-4280-b071-9c895b1166d8.png)


This PR fixes #2277 

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
