### PR TITLE
fixed disabled learning path

### DIFF
--- a/src/sections/Learn/LearnPage-Sections/learning-path.js
+++ b/src/sections/Learn/LearnPage-Sections/learning-path.js
@@ -45,6 +45,7 @@ const LearningPaths = () => {
             description
             themeColor
             courses
+            disabled
             cardImage {
               childImageSharp {
                 gatsbyImageData(width: 200, layout: CONSTRAINED)
@@ -87,7 +88,7 @@ const LearningPaths = () => {
         </div>
         <Row className="learning-path-cards">
           {data.learnPaths.nodes.map((tutorial) => (
-            <Col sm={12} key={tutorial.id}>
+            <Col sm={6} key={tutorial.id}>
               <CardComponent tutorial={tutorial} path={`learning-paths/${tutorial.fields.learnpath}`} courseCount={getCoursesOfaLearningPath(tutorial.fields.learnpath).length} />
             </Col>
           ))}


### PR DESCRIPTION
Signed-off-by: Aditya Chaterjee <speak2adi@gmail.com>

**Description**
"Mastering Service-meshes for operators" card is not disabled on the [learn ](https://layer5.io/learn)page. 
<img width="1440" alt="Screenshot 2021-11-16 at 1 27 32 AM" src="https://user-images.githubusercontent.com/53532328/141845905-e5144a10-e4a8-4e87-aa6e-2aa543b5c5be.png">

This PR fixes the above problem. 


This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
