### PR TITLE
Breadcrumb Relocate Fix

### DIFF
--- a/src/sections/Learn-Layer5/Course-Overview/courseoverview.style.js
+++ b/src/sections/Learn-Layer5/Course-Overview/courseoverview.style.js
@@ -1,11 +1,11 @@
 import styled from "styled-components";
 
 export const CourseOverviewWrapper = styled.div`
-
   .course-back-btn {
-    margin: 1rem 0;
+    margin: 4.5rem 0 0rem 3rem;
     display: flex;
     align-items: center;
+    padding-bottom: 1rem;
     a {
       display: flex;
       align-items: center;
@@ -19,6 +19,10 @@ export const CourseOverviewWrapper = styled.div`
     }
     svg {
       font-size: 1.15rem;
+    }
+    @media(max-width: 745px)
+    {
+      margin: 4rem 0 0 1rem;
     }
   }
   .course-overview-hero {

--- a/src/sections/Learn-Layer5/Course-Overview/index.js
+++ b/src/sections/Learn-Layer5/Course-Overview/index.js
@@ -19,50 +19,51 @@ import SubscribeLearnPath from "../../subscribe/SubscribeLearnPath";
 const CourseOverview = ({ course, chapters, serviceMeshesList }) => {
   const serviceMeshImages = course.frontmatter.meshesYouLearn;
   const getChapterTitle = (chapter, chapterList) => {
-    for(let i=0; i < chapterList.length; i++) {
-      if (chapterList[i].fields.chapter === chapter)
-        return chapterList[i];
+    for (let i = 0; i < chapterList.length; i++) {
+      if (chapterList[i].fields.chapter === chapter) return chapterList[i];
     }
   };
 
   const getAvailableServiceMeshes = () => {
     let serviceMeshes = [];
-    serviceMeshesList.forEach(item => {
-      if(serviceMeshes.indexOf(item["fields"]["section"]) === -1)
+    serviceMeshesList.forEach((item) => {
+      if (serviceMeshes.indexOf(item["fields"]["section"]) === -1)
         serviceMeshes.push(item["fields"]["section"]);
     });
     return serviceMeshes;
   };
 
   const findServiceMeshImage = (images, serviceMesh) => {
-    return images.find(image => image.name.toLowerCase() == serviceMesh);
+    return images.find((image) => image.name.toLowerCase() == serviceMesh);
   };
 
-  const ServiceMeshesAvailable = ({serviceMeshes}) => serviceMeshes.map((sm, index) => {
-    return(  
-      <>
-        <div className="service-mesh-courses" key={index}>
-          <Image
-            {...findServiceMeshImage(serviceMeshImages, sm).imagepath}
-            className="docker"
-            alt={sm}
-          />
-        </div>
-      </>);
-  });
+  const ServiceMeshesAvailable = ({ serviceMeshes }) =>
+    serviceMeshes.map((sm, index) => {
+      return (
+        <>
+          <div className="service-mesh-courses" key={index}>
+            <Image
+              {...findServiceMeshImage(serviceMeshImages, sm).imagepath}
+              className="docker"
+              alt={sm}
+            />
+          </div>
+        </>
+      );
+    });
 
   return (
     <CourseOverviewWrapper>
+      <div className="course-back-btn">
+        <Link to={`/learn/learning-paths/${course.fields.learnpath}`}>
+          <IoChevronBackOutline /> <h4>Learning Paths/Courses</h4>
+        </Link>
+      </div>
       <div
         style={{ backgroundColor: course.frontmatter.themeColor }}
         className="course-overview-hero"
       >
         <div className="course-info-content">
-          <div className="course-back-btn">
-            <Link to={`/learn/learning-paths/${course.fields.learnpath}`}>
-              <IoChevronBackOutline /> <h4>Learning Paths/Courses</h4>
-            </Link>
-          </div>
           <div className="course-hero-head">
             <h2>{course.frontmatter.courseTitle}</h2>
             <p>{course.frontmatter.description}</p>
@@ -76,7 +77,10 @@ const CourseOverview = ({ course, chapters, serviceMeshesList }) => {
               <span>{course.frontmatter.toc.length} Chapters</span>
             </div>
           </div>
-          <Button title="Get Started" url={`istio/${course.frontmatter.toc[0]}`} />
+          <Button
+            title="Get Started"
+            url={`istio/${course.frontmatter.toc[0]}`}
+          />
         </div>
         <div className="course-hero-head-image">
           <Image
@@ -94,19 +98,20 @@ const CourseOverview = ({ course, chapters, serviceMeshesList }) => {
             </SRLWrapper>
             <h2 className="course-toc">Table Of Contents</h2>
             {course.frontmatter.toc.map((item, index) => (
-              <Link
-                key={index}
-                to={`istio/${item}`}
-                className="chapter-link"
-              >
-                <ChapterCard chapterNum={index+1} chapter={getChapterTitle(item, chapters)} />
+              <Link key={index} to={`istio/${item}`} className="chapter-link">
+                <ChapterCard
+                  chapterNum={index + 1}
+                  chapter={getChapterTitle(item, chapters)}
+                />
               </Link>
             ))}
           </Col>
           <Col md={12} lg={4} xl={5}>
             <div className="service-meshes-you-can-learn">
               <h2>Service Meshes You can Learn</h2>
-              <ServiceMeshesAvailable serviceMeshes={getAvailableServiceMeshes()}/>
+              <ServiceMeshesAvailable
+                serviceMeshes={getAvailableServiceMeshes()}
+              />
             </div>
             {/* <div className="join-community_text-and_button">
               <h2>Contribute to Layer5</h2>


### PR DESCRIPTION
**Description**
1. Changed the location of the element containing class .course-back-btn. (To separate from Course Hero)
2. Added margin, padding and media query to that element.
This PR fixes #2307

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
