### PR TITLE
[Cl] Improve Newcomers Alert Workflow

### DIFF
--- a/.github/workflows/newcomers-alert.yml
+++ b/.github/workflows/newcomers-alert.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, labeled]
 jobs:
   good-first-issue-notify:
-    if: contains(github.event.issue.labels.*.name, 'good first issue') || contains(github.event.issue.labels.*.name, 'first-timers-only') 
+    if: github.event.label.name == 'good first issue') || github.event.label.name == 'newcomers-only' 
     name: Notify Slack for new good-first-issue
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/newcomers-alert.yml
+++ b/.github/workflows/newcomers-alert.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, labeled]
 jobs:
   good-first-issue-notify:
-    if: github.event.label.name == 'good first issue') || github.event.label.name == 'newcomers-only' 
+    if: github.event.label.name == 'good first issue') || github.event.label.name == 'first-timers-only' 
     name: Notify Slack for new good-first-issue
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Signed-off-by: Pranav Singh <pranavsingh02@hotmail.com>

**Description**
- In this PR, I've improved the working of the newcomers-alert workflow. 

*Why workflow was commenting multiple times on Slack?*
- The workflow is triggered on the following scenarios: opening a new issue or adding labels to existing issues (allowed labels: `good first issue` or `first-timers-only`). 
- Initially, I wasn't comparing the labels with the right metadata (I was comparing with an array that contains data for all the labels added to the issue which triggered the workflow) but since that array was the updated one, with our specified label already there so the each of the triggered passes the workflow checks and the message was being printed multiple times.
- Now, instead of checking with the array, I'm checking with the label name of the event itself which triggered the workflow. So, only the one which contains our specified label would pass the if condition and print the message on slack

This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
