### PR TITLE
Margin added for intra-page table of contents hyperlinks

### DIFF
--- a/src/sections/Community/Handbook/Handbook.style.js
+++ b/src/sections/Community/Handbook/Handbook.style.js
@@ -29,6 +29,14 @@ export const HandbookWrapper = styled.div`
     }
 
     .page-section{
+      h2{
+        padding-top: 7rem;
+        margin-top: -7rem;
+      }
+      h3{
+        padding-top: 7rem;
+        margin-top: -7rem;
+      }
       margin-top: -36rem;
       margin-left: 20rem;
       display: flex;


### PR DESCRIPTION
Signed-off-by: YashKamboj <75125203+YashKamboj@users.noreply.github.com>

**Description**
The intra-page was scrolling  a little below than the heading on /community/handbook
This PR fixes #2438 

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
