### PR TITLE
Included blogs as resource type

### DIFF
--- a/src/collections/blog/2021-09-20-service-mesh-specifications-and-why-they-matter/index.mdx
+++ b/src/collections/blog/2021-09-20-service-mesh-specifications-and-why-they-matter/index.mdx
@@ -3,6 +3,8 @@ title: "Service Mesh Specifications and Why They Matter"
 date: 2021-09-20 10:30:05 -0530
 author: Debopriya Bhattacharjee
 thumbnail: ./Cover-image.png
+type: Blog
+product: Service Mesh Performance
 category: "Service Mesh Specifications"
 tags:
  - Projects
@@ -10,6 +12,7 @@ tags:
  - SMP
 featured: true 
 published: true
+resource: true
 ---
 
 import { BlogWrapper } from "../Blog.style.js";

--- a/src/collections/blog/2021-10-01-pipelining-service-mesh-specifications/index.mdx
+++ b/src/collections/blog/2021-10-01-pipelining-service-mesh-specifications/index.mdx
@@ -4,12 +4,15 @@ subtitle: "Using SMI and SMP specs on your CI/CD pipelines with Meshery's GitHub
 date: 2021-11-09 10:30:05 -0530
 author: Layer5 Team
 thumbnail: ./service-mesh-specifications.png
+type: Blog
+product: Service Mesh Performance
 category: "Service Mesh Specifications"
 tags:
  - SMI
  - SMP
  - Meshery
 published: true
+resource: true
 ---
 
 import { Link } from "gatsby";

--- a/src/collections/blog/2021-10-09-an-introduction-to-meshery/index.mdx
+++ b/src/collections/blog/2021-10-09-an-introduction-to-meshery/index.mdx
@@ -3,11 +3,14 @@ title: "An Introduction to Meshery (Webinar-on-Demand) "
 date: 2021-10-09 10:30:05 -0530
 author: Debopriya Bhattacharjee
 thumbnail: ./meshery-webinar.png
+type: Blog
+product: Meshery
 category: "Meshery"
 tags:
  - Projects
  - Meshery
 published: true
+resource: true
 ---
 
 import { BlogWrapper } from "../Blog.style.js";

--- a/src/collections/blog/2021-12-22-how-to-write-unit-and-integeration-tests-for-mesheryctl/index.mdx
+++ b/src/collections/blog/2021-12-22-how-to-write-unit-and-integeration-tests-for-mesheryctl/index.mdx
@@ -3,12 +3,15 @@ title: "How to write unit and integration tests for mesheryctl"
 date: 2021-12-22 19:32:05 -0530
 author: Piyush Singariya
 thumbnail: ./integration-test.png
+type: Blog
+product: Meshery
 category: "Meshery"
 tags:
  - Projects
  - Meshery
  - mesheryctl
 published: true
+resource: true
 ---
 
 import { BlogWrapper } from "../Blog.style.js";

--- a/src/collections/resources/adoption/index.mdx
+++ b/src/collections/resources/adoption/index.mdx
@@ -10,6 +10,7 @@ technology: Docker
 mesh: Istio
 featured: false
 published: true
+resource: true
 ---
 
 import { Link } from "gatsby";

--- a/src/collections/resources/analyzing-service-mesh-performance/analyzing-service-mesh-performance.mdx
+++ b/src/collections/resources/analyzing-service-mesh-performance/analyzing-service-mesh-performance.mdx
@@ -9,6 +9,7 @@ tags:
  - Meshery
 featured: false
 published: true
+resource: true
 ---
 
 import { Link } from "gatsby";

--- a/src/collections/resources/api-gateways/index.mdx
+++ b/src/collections/resources/api-gateways/index.mdx
@@ -9,6 +9,7 @@ product: Meshery
 technology: Docker
 featured: false
 published: true
+resource: true
 ---
 
 import { Link } from "gatsby";

--- a/src/collections/resources/choosing-the-perfect-proxy/index.mdx
+++ b/src/collections/resources/choosing-the-perfect-proxy/index.mdx
@@ -10,6 +10,7 @@ technology: Kubernetes
 mesh: Istio
 featured: false
 published: true
+resource: true
 ---
 
 import { Link } from "gatsby";

--- a/src/collections/resources/client-libraries/index.mdx
+++ b/src/collections/resources/client-libraries/index.mdx
@@ -10,6 +10,7 @@ technology: Docker
 mesh: Linkerd
 featured: false
 published: true
+resource: true
 ---
 
 import { Link } from "gatsby";

--- a/src/collections/resources/how-to-write-webassembly-filters-for-envoy/learn-how-to-write-wasm-filters.mdx
+++ b/src/collections/resources/how-to-write-webassembly-filters-for-envoy/learn-how-to-write-wasm-filters.mdx
@@ -11,6 +11,7 @@ technology: WebAssembly
 mesh: Linkerd
 featured: false
 published: true
+resource: true
 ---
 
 import { Link } from "gatsby";

--- a/src/collections/resources/network-planes/index.mdx
+++ b/src/collections/resources/network-planes/index.mdx
@@ -8,6 +8,7 @@ tags:
  - Network Planes
 featured: false
 published: true
+resource: true
 ---
 
 import { Link } from "gatsby";

--- a/src/sections/Resources/Resources-grid/DataWrapper.js
+++ b/src/sections/Resources/Resources-grid/DataWrapper.js
@@ -11,8 +11,8 @@ const DataWrapper = (WrappedComponent) => {
             allMdx(
                 sort: {fields: [frontmatter___date], order: DESC}
                 filter: {
-                    fields: { collection: { eq: "resources" } }
-                    frontmatter: { published: { eq: true } }
+                    fields: { collection: { in: ["blog", "resources"] } }
+                    frontmatter: { published: { eq: true } , resource: { eq: true} }
                   }
           ) {
             nodes {

--- a/src/sections/Resources/Resources-grid/filters.js
+++ b/src/sections/Resources/Resources-grid/filters.js
@@ -13,7 +13,7 @@ const Navigation = (props) => {
     graphql`
             query allFilters {
                 type: allMdx(
-                    filter: { fields: { collection: { eq: "resources" } }, frontmatter: { published: { eq: true } } }
+                    filter: { fields: { collection: { in: ["blog", "resources"] } }, frontmatter: { published: { eq: true } , resource: { eq: true} }}
                 ){
                     group(field: frontmatter___type) {
                         fieldValue
@@ -21,7 +21,7 @@ const Navigation = (props) => {
                     }
                 }
                 product: allMdx(
-                  filter: { fields: { collection: { eq: "resources" } }, frontmatter: { published: { eq: true } } }
+                  filter: { fields: { collection: { in: ["blog", "resources"] } }, frontmatter: { published: { eq: true } , resource: { eq: true} }}
               ){
                   group(field: frontmatter___product) {
                       fieldValue
@@ -29,7 +29,7 @@ const Navigation = (props) => {
                   }
               }
               technology: allMdx(
-                filter: { fields: { collection: { eq: "resources" } }, frontmatter: { published: { eq: true } } }
+                filter: { fields: { collection: { in: ["blog", "resources"] } }, frontmatter: { published: { eq: true } , resource: { eq: true} }}
             ){
                 group(field: frontmatter___technology) {
                     fieldValue
@@ -37,7 +37,7 @@ const Navigation = (props) => {
                 }
             }
             mesh: allMdx(
-              filter: { fields: { collection: { eq: "resources" } }, frontmatter: { published: { eq: true } } }
+              filter: { fields: { collection: { in: ["blog", "resources"] } }, frontmatter: { published: { eq: true } , resource: { eq: true} }}
           ){
               group(field: frontmatter___mesh) {
                   fieldValue


### PR DESCRIPTION
Signed-off-by: Debopriya Bhattacharjee <debopriyabh1908@gmail.com>

**Description**
Added blogs collection to the resource library.

This PR fixes #

**Notes for Reviewers**

- Since not all blogs count as resources, I've added another field `resource: true` to specify the blogs that are to be displayed on the page.
- We need to go through all existing blogs and resources to add appropriate fields to filter.


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
