### PR TITLE
fixing link to issue template and vs code image 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -269,6 +269,7 @@ To ensure all your commits are signed, you may choose to add this alias to your 
 
 Or you may configure your IDE, for example, Visual Studio Code to automatically sign-off commits for you:
 
-<a href=".github/assets/images/git-signoff-vscode.png" ><img src=".github/assets/images/git-signoff-vscode.png" width="50%"/><a>
+<a href="./.github/assets/images/git-signoff-vscode.png" ><img src="./.github/assets/images/git-signoff-vscode.png" width="50%"/><a>
+
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ The following list of instructions pertain to commonplace site updates by contri
 
 ## Updating/Creating a Community Member Profile 
 
-Layer5 community members are an integral part of what makes Layer5 and it's projects successful. Prominently highlighting our members and their works is something that we think is important. When adding a new or updating an existing community member profile, be sure to use the [Community Member Profile issue template](https://github.com/layer5io/layer5/issues/new?assignees=&labels=area%2Fcommunity&template=New+Member+Profile.md&title=%5BCommunity%5D+Member+Profile%3A) which has all the instructions that one may need for this.
+Layer5 community members are an integral part of what makes Layer5 and it's projects successful. Prominently highlighting our members and their works is something that we think is important. When adding a new or updating an existing community member profile, be sure to use the [Community Member Profile issue template](./.github/ISSUE_TEMPLATE/community_member_profile.md) which has all the instructions that one may need for this.
 
 Note that the [Community Member Profile template](https://github.com/layer5io/layer5/tree/master/src/collections/members/_member-profile-template) is helpful when adding new or updating an existing community member profiles. You can easily understand how the template is used by reviewing other profiles.
 
@@ -269,6 +269,6 @@ To ensure all your commits are signed, you may choose to add this alias to your 
 
 Or you may configure your IDE, for example, Visual Studio Code to automatically sign-off commits for you:
 
-<a href="./.github/assets/images/git-signoff-vscode.png" ><img src="./.github/assets/images/git-signoff-vscode.png" width="50%"/><a>
+<a href=".github/assets/images/git-signoff-vscode.png" ><img src=".github/assets/images/git-signoff-vscode.png" width="50%"/><a>
 
 


### PR DESCRIPTION
Signed-off-by:helper-uttam <bajiraouttamsinha@gmail.com>

**Description**
Sometime Vs code image is not showing up due to broken link and there is also a wrong link to the issue template.

**Notes for Reviewers**
- [x] Fixing the link to issue template.
- [x] Fixing link to the image of VScode-sign-off that doesn't render sometime.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
