### PR TITLE
github-icon color change

### DIFF
--- a/src/components/SocialLinks-Color/sociallinkscolor.style.js
+++ b/src/components/SocialLinks-Color/sociallinkscolor.style.js
@@ -19,7 +19,7 @@ const SocialLinksWrapper = styled.div`
             }
         }
         .github:hover {
-            filter: grayscale(0) invert(1);
+            filter: grayscale(1) invert(0.25);
         }
 
         .mail_icon {


### PR DESCRIPTION
**Description**

This PR fixes #github icon color was not visible on the website, hover color was working fine, fixed this by changing the filter.

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
