### PR TITLE
Add patterns badge 

### DIFF
--- a/src/pages/community/members.js
+++ b/src/pages/community/members.js
@@ -99,7 +99,7 @@ const options = [
   },
   {
     label: "Service Mesh Patterns",
-    value: "mesh-patterns",
+    value: "patterns",
     color: theme.linkColor,
     isFixed: true,
     icon: patternsIcon,

--- a/src/pages/community/members.js
+++ b/src/pages/community/members.js
@@ -26,6 +26,7 @@ import mesheryOpIcon from "../../assets/images/meshery-operator/meshery-operator
 import smpIcon from "../../assets/images/service-mesh-performance/icon/smp-dark.svg";
 import inactiveIcon from "../../assets/images/status/inactive.png";
 import activeIcon from "../../assets/images/status/active.png";
+import patternsIcon from "../../assets/images/service-mesh-patterns/service-mesh-pattern.svg";
 
 /**
  * Array containing a list of categories to be shown in the dropdown.
@@ -94,6 +95,14 @@ const options = [
     color: theme.linkColor,
     isFixed: true,
     icon: hawkIcon,
+    className: "allOptions",
+  },
+  {
+    label: "Service Mesh Patterns",
+    value: "mesh-patterns",
+    color: theme.linkColor,
+    isFixed: true,
+    icon: patternsIcon,
     className: "allOptions",
   },
   {


### PR DESCRIPTION
**Description**

This PR fixes #2479 
Adds the Service Mesh Patterns badge to the Members page filter

![img](https://user-images.githubusercontent.com/72245772/150530091-2742f03f-435a-4a60-8047-df5890361197.png)


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

