### PR TITLE
Change default category to 'Active' members in drop-down

### DIFF
--- a/src/sections/Community/Members-grid/Dropdown.js
+++ b/src/sections/Community/Members-grid/Dropdown.js
@@ -27,7 +27,7 @@ const Dropdown = (props) => {
         >
           <Select
             name='Filter Members'
-            defaultValue={[props.options[10]]}
+            defaultValue={[props.options[11]]}
             isSearchable={false}
             styles={selectStyles}
             options={props.options}


### PR DESCRIPTION
Signed-off-by: Kunal Verma <vkunal321@gmail.com>

**Description**
This PR, changes the default category of members in the dropdown [here](https://layer5.io/community/members) from `All members` to display `Active` members! 
![Screenshot 2022-01-24 at 9 54 49 PM](https://user-images.githubusercontent.com/72245772/150822688-4a4a7adb-6113-421e-9feb-2663e5ff81dd.png)


**Notes for Reviewers**
**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
