### PR TITLE
Build: Added 'cache-preserve' flags to optimise build time

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -9,6 +9,11 @@ module.exports = {
     image: "/images/layer5-company.png",
     twitterUsername: "@layer5",
   },
+  flags: {
+    FAST_DEV: true,
+    PRESERVE_WEBPACK_CACHE: true,
+    PRESERVE_FILE_DOWNLOAD_CACHE: true,
+  },
   plugins: [
     "gatsby-plugin-sitemap",
     "gatsby-plugin-react-helmet",


### PR DESCRIPTION
Signed-off-by: Nikhil-Ladha <nikhilladha1999@gmail.com>

**Description**
Added flags in the `gatsby.config` file to preserve the cache generated from the previous build to optimize
the time taken during a deploy, or development preview.


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
