### PR TITLE
changed default page to active members

### DIFF
--- a/src/pages/community/members.js
+++ b/src/pages/community/members.js
@@ -176,7 +176,7 @@ const MembersPage = () => {
   /**
    * state storing the currently selected categories.
    */
-  const [members, setMembers] = useState([options[10]]);
+  const [members, setMembers] = useState([options[11]]);
   const handleChange = (value) => setMembers(value);
 
   return (


### PR DESCRIPTION
Signed-off-by: Aditya Chatterjee <speak2adi@gmail.com>

**Description**
Changes the default to active members on the members page. 

This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
