### PR TITLE
[Handbook] Fixed `repository overview` overflow tables 

### DIFF
--- a/src/sections/Community/Handbook/Handbook.style.js
+++ b/src/sections/Community/Handbook/Handbook.style.js
@@ -222,10 +222,23 @@ export const HandbookWrapper = styled.div`
         margin-top: -2rem;
         margin-left: 0;
         padding: 1rem 2.5rem;
+      
+        .table-container {
+          table {
+            width: 100%;
+            margin-left: 0;
+          }
+          overflow-x: scroll;
+        }
+    
+        .table-container::-webkit-scrollbar { 
+          display: none;
+        }
       }
+      
       .codes{
-      width:100%
-      margin-top:-2rem;
+        width:100%
+        margin-top:-2rem;
       }
     }
 

--- a/src/sections/Community/Handbook/repository.js
+++ b/src/sections/Community/Handbook/repository.js
@@ -116,48 +116,50 @@ const Repository = () => {
             {frontendProjects.map((frontendProjects) => {
               const { category } = frontendProjects;
               return (
-                <table className="frontendTable" key={category}>
-                  <thead>
-                    <tr>
-                      <th className="linkscol">Site</th>
-                      <th>Project</th>
-                      <th>Framework</th>
-                      <th className="linkscol">Repo</th>
-                    </tr>
-                  </thead>
-                  {frontendProjects.subdata.map((subdata) => {
-                    const {
-                      project,
-                      language,
-                      repository,
-                      site,
-                      image,
-                      description,
-                    } = subdata;
-                    return (
-                      <tbody key={project}>
-                        <tr>
-                          <td>
-                            <a href={site} target="_blank" rel="noreferrer">
-                              <img className="site-icon" src={image} />
-                            </a>
-                          </td>
-                          <td>{project}</td>
-                          <td>{language}</td>
-                          <td>
-                            <a
-                              href={repository}
-                              target="_blank"
-                              rel="noreferrer"
-                            >
-                              <img className="github-icon" src={github} />
-                            </a>
-                          </td>
-                        </tr>
-                      </tbody>
-                    );
-                  })}
-                </table>
+                <div className="table-container">
+                  <table className="frontendTable" key={category}>
+                    <thead>
+                      <tr>
+                        <th className="linkscol">Site</th>
+                        <th>Project</th>
+                        <th>Framework</th>
+                        <th className="linkscol">Repo</th>
+                      </tr>
+                    </thead>
+                    {frontendProjects.subdata.map((subdata) => {
+                      const {
+                        project,
+                        language,
+                        repository,
+                        site,
+                        image,
+                        description,
+                      } = subdata;
+                      return (
+                        <tbody key={project}>
+                          <tr>
+                            <td>
+                              <a href={site} target="_blank" rel="noreferrer">
+                                <img className="site-icon" src={image} />
+                              </a>
+                            </td>
+                            <td>{project}</td>
+                            <td>{language}</td>
+                            <td>
+                              <a
+                                href={repository}
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                <img className="github-icon" src={github} />
+                              </a>
+                            </td>
+                          </tr>
+                        </tbody>
+                      );
+                    })}
+                  </table>
+                </div>
               );
             })}
 
@@ -168,38 +170,40 @@ const Repository = () => {
             {backendProjects.map((backendProjects) => {
               const { category } = backendProjects;
               return (
-                <table key={category}>
-                  <thead>
-                    <tr>
-                      <th>{category}</th>
-                      <th>Language</th>
-                      <th>Description</th>
-                      <th className="linkscol">Repo</th>
-                    </tr>
-                  </thead>
-                  {backendProjects.subdata.map((subdata) => {
-                    const { project, image, language, description, repository } = subdata;
-                    return (
-                      <tbody key={project}>
-                        <tr>
-                          <td>
-                            <img className="site-icon inline" src={image} />&nbsp;{project}</td>
-                          <td>{language}</td>
-                          <td>{description}</td>
-                          <td>
-                            <a
-                              href={repository}
-                              target="_blank"
-                              rel="noreferrer"
-                            >
-                              <img className="github-icon" src={github} />
-                            </a>
-                          </td>
-                        </tr>
-                      </tbody>
-                    );
-                  })}
-                </table>
+                <div className="table-container">
+                  <table key={category}>
+                    <thead>
+                      <tr>
+                        <th>{category}</th>
+                        <th>Language</th>
+                        <th>Description</th>
+                        <th className="linkscol">Repo</th>
+                      </tr>
+                    </thead>
+                    {backendProjects.subdata.map((subdata) => {
+                      const { project, image, language, description, repository } = subdata;
+                      return (
+                        <tbody key={project}>
+                          <tr>
+                            <td>
+                              <img className="site-icon inline" src={image} />&nbsp;{project}</td>
+                            <td>{language}</td>
+                            <td>{description}</td>
+                            <td>
+                              <a
+                                href={repository}
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                <img className="github-icon" src={github} />
+                              </a>
+                            </td>
+                          </tr>
+                        </tbody>
+                      );
+                    })}
+                  </table>
+                </div>
               );
             })}
             <TocPagination />


### PR DESCRIPTION
Signed-off-by: Nikhil Sharma <nikhilsharmamusic2000@gmail.com>

**Description**

- changed `repository overview` overflow tables with scrollable tables for smaller screen

## Before Changes

![Screenshot from 2022-01-29 16-47-32](https://user-images.githubusercontent.com/58226527/151659625-a08200d0-327e-476a-bb3b-cf1c0e1f260d.png)

## After Changes

![Screenshot from 2022-01-29 16-59-45](https://user-images.githubusercontent.com/58226527/151659654-c488c33c-f2e9-4d6b-873c-5d279403b7a8.png)

**Notes for Reviewers**

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
