### PR TITLE
Config: Updated sharp-plugin config and robots.txt for deploy previews

### DIFF
--- a/.github/workflows/build-and-preview-site.yml
+++ b/.github/workflows/build-and-preview-site.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install and Build 🔧 
         run: |
           npm install
-          npm run noIndex
+          npm run build
 
       - name: Zip Site
         run: bash ./script.sh

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ yarn.lock
 .vscode
 
 default.profraw
+
+#Husky configuration
+.husky/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx --no-install lint-staged

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -467,7 +467,14 @@ module.exports = {
       },
     },
     "gatsby-plugin-image",
-    "gatsby-plugin-sharp",
+    {
+      resolve: "gatsby-plugin-sharp",
+      options: {
+        defaults: {
+          placeholder: 'blurred',
+        }
+      }
+    },
     {
       resolve: "gatsby-transformer-sharp",
       options: {
@@ -492,12 +499,35 @@ module.exports = {
         query: "allMdx",
       },
     },
+    // {
+    //   resolve: "gatsby-plugin-robots-txt",
+    //   options: {
+    //     host: "https://layer5.io",
+    //     sitemap: "https://layer5.io/sitemap.xml",
+    //     policy: [{userAgent: "*", allow: "/"}],
+    //   }
+    // },
     {
-      resolve: "gatsby-plugin-robots-txt",
+      resolve: 'gatsby-plugin-robots-txt',
       options: {
-        host: "https://layer5.io",
-        sitemap: "https://layer5.io/sitemap.xml",
-        policy: [{userAgent: "*", allow: "/"}],
+        resolveEnv: () => process.env.NODE_ENV,
+        env: {
+          production: {
+            policy: [{userAgent: '*', allow: '/'}],
+            host: "https://layer5.io",
+            sitemap: "https://layer5.io/sitemap.xml",
+          },
+          'branch-deploy': {
+            policy: [{userAgent: '*', disallow: ['/']}],
+            sitemap: null,
+            host: null
+          },
+          'deploy-preview': {
+            policy: [{userAgent: '*', disallow: ['/']}],
+            sitemap: null,
+            host: null
+          }
+        }
       }
     },
     "gatsby-plugin-meta-redirect", // make sure this is always the last one

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -471,7 +471,7 @@ module.exports = {
       resolve: "gatsby-plugin-sharp",
       options: {
         defaults: {
-          placeholder: 'blurred',
+          placeholder: "blurred",
         }
       }
     },
@@ -499,31 +499,23 @@ module.exports = {
         query: "allMdx",
       },
     },
-    // {
-    //   resolve: "gatsby-plugin-robots-txt",
-    //   options: {
-    //     host: "https://layer5.io",
-    //     sitemap: "https://layer5.io/sitemap.xml",
-    //     policy: [{userAgent: "*", allow: "/"}],
-    //   }
-    // },
     {
-      resolve: 'gatsby-plugin-robots-txt',
+      resolve: "gatsby-plugin-robots-txt",
       options: {
         resolveEnv: () => process.env.NODE_ENV,
         env: {
           production: {
-            policy: [{userAgent: '*', allow: '/'}],
+            policy: [{userAgent: "*", allow: "/"}],
             host: "https://layer5.io",
             sitemap: "https://layer5.io/sitemap.xml",
           },
-          'branch-deploy': {
-            policy: [{userAgent: '*', disallow: ['/']}],
+          "branch-deploy": {
+            policy: [{userAgent: "*", disallow: ["/"]}],
             sitemap: null,
             host: null
           },
-          'deploy-preview': {
-            policy: [{userAgent: '*', disallow: ['/']}],
+          "deploy-preview": {
+            policy: [{userAgent: "*", disallow: ["/"]}],
             sitemap: null,
             host: null
           }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "pretest": "eslint --ignore-path .gitignore .",
     "preload-fonts": "gatsby-preload-fonts",
     "deploy": "gatsby build && gh-pages -d public -b master",
-    "noIndex": "gatsby build && echo 'User-agent: *\nDisallow: /' > public/robots.txt"
+    "noIndex": "gatsby build && echo 'User-agent: *\nDisallow: /' > public/robots.txt",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@fullcalendar/daygrid": "^5.10.1",

--- a/src/components/Learn-Components/Pagination/index.js
+++ b/src/components/Learn-Components/Pagination/index.js
@@ -52,13 +52,13 @@ const Pagination = ({ TOCData, chapterData, location, showQuizModal }) => {
         </div>
       </PaginationWrapper>
     ) : null
-      // : (
-      //       <QuizWrapper onClick={showQuizModal}>
-      //           <Button secondary title="Take Quiz"
-      //             external={false} 
-      //           />
-      //         </QuizWrapper>
-      //   )
+  // : (
+  //       <QuizWrapper onClick={showQuizModal}>
+  //           <Button secondary title="Take Quiz"
+  //             external={false} 
+  //           />
+  //         </QuizWrapper>
+  //   )
   );
 };
 

--- a/src/components/Learn-Components/QuizModal/quiz-component.js
+++ b/src/components/Learn-Components/QuizModal/quiz-component.js
@@ -76,6 +76,7 @@ const QuestionBox = (props) => {
                 answerItem={answer}
                 answerCallback={props.answerCallback}
                 index={index}
+                key={index}
               />
             );
           }, this)}
@@ -122,7 +123,7 @@ const QuizComponent = () => {
     ];
 
     // Will be fetching the title from backend
-    setQuizTitle("Test Quiz")
+    setQuizTitle("Test Quiz");
 
     // Will be fetching these questions from backend
     setQuestionData(fetchedQuestion);

--- a/src/sections/Community/Handbook/repository.js
+++ b/src/sections/Community/Handbook/repository.js
@@ -113,10 +113,10 @@ const Repository = () => {
               <h2>Frontend Projects</h2>
             </a>
 
-            {frontendProjects.map((frontendProjects) => {
-              const { category } = frontendProjects;
+            {frontendProjects.map((frontendProject, index) => {
+              const { category } = frontendProject;
               return (
-                <div className="table-container">
+                <div className="table-container" key={index}>
                   <table className="frontendTable" key={category}>
                     <thead>
                       <tr>
@@ -126,7 +126,7 @@ const Repository = () => {
                         <th className="linkscol">Repo</th>
                       </tr>
                     </thead>
-                    {frontendProjects.subdata.map((subdata) => {
+                    {frontendProject.subdata.map((subdata) => {
                       const {
                         project,
                         language,
@@ -167,10 +167,10 @@ const Repository = () => {
               <h2>Backend Projects</h2>
             </a>
 
-            {backendProjects.map((backendProjects) => {
-              const { category } = backendProjects;
+            {backendProjects.map((backendProject, index) => {
+              const { category } = backendProject;
               return (
-                <div className="table-container">
+                <div className="table-container" key={index}>
                   <table key={category}>
                     <thead>
                       <tr>
@@ -180,7 +180,7 @@ const Repository = () => {
                         <th className="linkscol">Repo</th>
                       </tr>
                     </thead>
-                    {backendProjects.subdata.map((subdata) => {
+                    {backendProject.subdata.map((subdata) => {
                       const { project, image, language, description, repository } = subdata;
                       return (
                         <tbody key={project}>

--- a/src/sections/Learn-Layer5/Course-Overview/index.js
+++ b/src/sections/Learn-Layer5/Course-Overview/index.js
@@ -47,7 +47,7 @@ const CourseOverview = ({ course, chapters, serviceMeshesList }) => {
           />
         </div>
       );
-  });
+    });
 
   useEffect(() => {
     let bookmarkPath = localStorage.getItem("bookmarkpath-"+course.fields.slug.split("/")[3]);
@@ -86,14 +86,14 @@ const CourseOverview = ({ course, chapters, serviceMeshesList }) => {
             title={hasBookmark ? "Start Again" : "Get Started"}
             url={`istio/${course.frontmatter.toc[0]}`}
           />
-        {hasBookmark && (
-          <Button
-            className="start-again-button"
-            primary
-            title="Resume"
-            url={bookmarkUrl}
-          />
-        )}
+          {hasBookmark && (
+            <Button
+              className="start-again-button"
+              primary
+              title="Resume"
+              url={bookmarkUrl}
+            />
+          )}
         </div>
         <div className="course-hero-head-image">
           <Image


### PR DESCRIPTION
**Description**

This PR updates the default value of `placeholder` in gatsby-sharp to show `blurred` images while the image loads, instead of a dominant color.
Also, it updates the `gatsby-robots-txt` plugin to create a `robots.txt` file based on the type of deployment.


**Note for reviewers**
Husky@7 is a breaking change and they have updated the config file setup. Hence, I have updated the same in the repo so that others do not face issues while committing.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
