### PR TITLE
[Site Performance] Image optimization for the Community Page Image Carousel

### DIFF
--- a/src/sections/Community/slider.js
+++ b/src/sections/Community/slider.js
@@ -1,6 +1,7 @@
 import React from "react";
 import Slider from "react-slick";
 import styled from "styled-components";
+import Image from "../../components/image";
 
 import { useStaticQuery, graphql } from "gatsby";
 
@@ -53,6 +54,9 @@ const PictureSlider = () => {
             node {
               extension
               publicURL
+              childImageSharp {
+                gatsbyImageData
+              }
             }
           }
         }
@@ -74,7 +78,7 @@ const PictureSlider = () => {
     <PictureSliderWrapper>
       <Slider {...settings}>
         {data.allFile.edges.map((image, id) => (
-          <img key={id} src={image.node.publicURL} alt="community" />
+          <Image key={id} {...image.node} alt="community" />
         ))}
       </Slider>
     </PictureSliderWrapper>


### PR DESCRIPTION
Signed-off-by: sidd-oo <sahoosiddharth3@gmail.com>

**Description**
This PR is related to the Optimization of the Community Page Image Carousel using a prewritten `Image` component which resides inside `src/components/image.js`, which basically uses `GatsbyImage` to render the image to generate all the sizes and formats that you need to support a responsive image. So I updated the graphQL query to return a `childimagesharp` node, then passed it to the `Image` component.

This PR updates #2172 

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
