### PR TITLE
[Learn] Remove the extra sentence

### DIFF
--- a/src/sections/Home/Proud-maintainers/index.js
+++ b/src/sections/Home/Proud-maintainers/index.js
@@ -27,8 +27,7 @@ const ProudMaintainers = () => {
           </SectionTitle>
           <p className="project-text">
             We are the world’s largest collection of service mesh practitioners
-            and maintainers of leading open source projects We are open source
-            contributors and maintainers.
+            and maintainers of leading open source projects.
           </p>
         </Row>
       </Container>


### PR DESCRIPTION
Signed-off-by: Ronald Arias <ariasron@hotmail.com>

**Description**

This PR removes the extra sentence in The Layer5 home page

Current State:
The second sentence on [The Layer5 home page](https://github.com/layer5io/layer5/blob/master/src/sections/Home/Proud-maintainers/index.js#L29)[](https://user-images.githubusercontent.com/64528871/156799893-aa5900ea-4314-4136-beaa-fc686304cab3.PNG) needs to the removed

Desired State:
The second sentence is a repetition of the first. Delete the extra sentence.
![image](https://user-images.githubusercontent.com/22307059/156805367-790c90d6-ebb5-4d35-8fc9-e97d8f23d966.png)

Contributor Resources

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
