### PR TITLE
Page jumps to about halfway down the page on load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "react-select": "^3.2.0",
         "react-slick": "^0.28.1",
         "react-table": "^7.7.0",
-        "react-tabs": "^4.0.1",
+        "react-tabs": "^3.2.3",
         "react-tooltip": "^4.2.21",
         "react-tsparticles": "^1.39.0",
         "react-vertical-timeline-component": "^3.5.2",
@@ -20710,15 +20710,15 @@
       }
     },
     "node_modules/react-tabs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-4.0.1.tgz",
-      "integrity": "sha512-Xldj56RHhaRd37iftOwnnjsFEemHY2R07EQ9x5EqOApGauxhdLi7fc/sEKJrtFANHnasNXzSnCWdJ0ulEamMoQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-3.2.3.tgz",
+      "integrity": "sha512-jx325RhRVnS9DdFbeF511z0T0WEqEoMl1uCE3LoZ6VaZZm7ytatxbum0B8bCTmaiV0KsU+4TtLGTGevCic7SWg==",
       "dependencies": {
         "clsx": "^1.1.0",
         "prop-types": "^15.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-0"
+        "react": "^16.3.0 || ^17.0.0-0"
       }
     },
     "node_modules/react-tooltip": {
@@ -41670,9 +41670,9 @@
       "requires": {}
     },
     "react-tabs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-4.0.1.tgz",
-      "integrity": "sha512-Xldj56RHhaRd37iftOwnnjsFEemHY2R07EQ9x5EqOApGauxhdLi7fc/sEKJrtFANHnasNXzSnCWdJ0ulEamMoQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-3.2.3.tgz",
+      "integrity": "sha512-jx325RhRVnS9DdFbeF511z0T0WEqEoMl1uCE3LoZ6VaZZm7ytatxbum0B8bCTmaiV0KsU+4TtLGTGevCic7SWg==",
       "requires": {
         "clsx": "^1.1.0",
         "prop-types": "^15.5.0"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "react-select": "^3.2.0",
     "react-slick": "^0.28.1",
     "react-table": "^7.7.0",
-    "react-tabs": "^4.0.1",
+    "react-tabs": "^3.2.3",
     "react-tooltip": "^4.2.21",
     "react-tsparticles": "^1.39.0",
     "react-vertical-timeline-component": "^3.5.2",


### PR DESCRIPTION
Signed-off-by: Debopriya Bhattacharjee <debopriyabhattacharjee@Debopriyas-MacBook-Air.local>

**Description**
This behaviour is taking place after [this](https://github.com/layer5io/layer5/pull/2628/files) update. Testing to see if this fixes the problem.

This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
