### PR TITLE
Resolved the issue of the Layer5 logo

### DIFF
--- a/src/sections/General/Navigation/index.js
+++ b/src/sections/General/Navigation/index.js
@@ -7,13 +7,13 @@ import Button from "../../../reusecore/Button";
 
 
 import { Container } from "../../../reusecore/Layout";
-import { StaticImage } from "gatsby-plugin-image";
+
 import smp_dark_text from "../../../assets/images/service-mesh-performance/stacked/smp-dark-text.svg";
 import meshery from "../../../assets/images/meshery/icon-only/meshery-logo-light.svg";
 import Data from "./utility/menu-items.js";
 import ScrollspyMenu from "./utility/ScrollspyMenu.js";
+import layer5_logo from "../../../assets/images/app/layer5.svg";
 
-const layer5_logo = "../../../assets/images/app/layer5.svg";
 
 import NavigationWrap from "./navigation.style";
 
@@ -182,7 +182,7 @@ const Navigation = () => {
       <Container className="nav-container">
         <div className="navbar-wrap">
           <Link to="/" className="logo">
-            <StaticImage src={layer5_logo} alt="Layer5 logo" />
+            <img src={layer5_logo} alt="Layer5 logo" />
           </Link>
           <nav className="nav">
             {expand ?


### PR DESCRIPTION
Signed-off-by: Attreyee Mukherjee <86184935+a-muk@users.noreply.github.com>

**Description**
This PR fixes #2606

The Layer5 logo was lazy loading every time one refreshes the home page. The problem was arising due to the Gatsby component "StaticImage". I made some minor changes in the file written for the homepage. 


**Notes for Reviewers**
I am not sure if  "import StaticImage" and "const layer5_logo " does some other work in this file or in some other file related to this. Please see that. If there is a problem, then some other way can be worked out to fix this issue. 

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
