### PR TITLE
Made space between sidebar components uniform 

### DIFF
--- a/src/sections/Blog/Blog-sidebar/blogSidebar.style.js
+++ b/src/sections/Blog/Blog-sidebar/blogSidebar.style.js
@@ -177,7 +177,7 @@ const BlogSideBarWrapper = styled.div`
         padding-top: 0rem;
         text-align: center;
         .cards {
-            margin: 0.15rem auto 0 ;
+            margin: 0.15rem auto 2.5rem ;
             max-width: 50rem;
             padding: 1.5rem 2.7rem 0rem 1rem;
             background-color: none;


### PR DESCRIPTION
Signed-off-by: Axit Patel <patelakshit2025@gmail.com>

**Description**

This PR fixes #2673  

**Notes for Reviewers**
Made the space between the Discuss call-out and "Categories" same as that between "Categories" and "Tags".



**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
