### PR TITLE
[News]see more of our news card is going outside card Fixes #2817

### DIFF
--- a/src/components/Card/Card.style.js
+++ b/src/components/Card/Card.style.js
@@ -52,6 +52,8 @@ export const CardWrapper = styled.div`
     .post-content-block{
         padding: 1rem 2rem;
         height: 8rem;
+        position: relative;
+        min-height: 150px;
     }
 
     @media screen and (max-width: 1200px) and (min-width: 992px){
@@ -112,8 +114,7 @@ export const CardWrapper = styled.div`
 
     .readmore-btn-wrapper{
         display:flex;
-        justify-content: flex-start;
-       
+        justify-content: space-between;
     }
 
     .readmore-btn::after{
@@ -128,7 +129,8 @@ export const CardWrapper = styled.div`
     .readmore-btn, .external-link-btn{
        color: rgba(0,0,0,0.4);
        display: flex;
-       
+       position: absolute;
+       bottom: 20px;
        flex: auto;
        align-items: center;
        transition: all 0.3s ease-in;
@@ -140,6 +142,8 @@ export const CardWrapper = styled.div`
 
     .external-link-btn{
         justify-content: flex-end;
+        right: 0;
+        padding-right: 1rem;
         svg{
             font-size: 2rem;
             padding: 0.25rem;


### PR DESCRIPTION
Signed-off-by: SooditK <sooditkumarabc@gmail.com>

**Description**
Gave the Card a Minimum Height of 150px, made it Relative and gave the readmore-btn-wrapper Absolute (aligned it to bottom-left) So that It doesn't go outside card

This PR fixes #2817 

**Notes for Reviewers**
My Linter might've messed

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
