### PR TITLE
fix typo of word setu in service-mesh-landscape

### DIFF
--- a/src/collections/landscape/meshes.js
+++ b/src/collections/landscape/meshes.js
@@ -197,7 +197,7 @@ export const meshes = [
   },
   {
     name: "Linkerd 2.x(Conduit)",
-    desc: "Conduit - A Kubernetes-native (only) service mesh announced as a project in December 2017. In contrast to Istio and in learning from Linkerd, Conduit’s design principles revolve around a minimalist architecture and zero config philosophy, optimizing for streamlined setu. Open Source. From Buoyant. Written in Rust and Go.",
+    desc: "Conduit - A Kubernetes-native (only) service mesh announced as a project in December 2017. In contrast to Istio and in learning from Linkerd, Conduit’s design principles revolve around a minimalist architecture and zero config philosophy, optimizing for streamlined setup. Open Source. From Buoyant. Written in Rust and Go.",
     link: "https://linkerd.io",
     autoinject: "Yes",
     h2: "Yes",


### PR DESCRIPTION
Signed-off-by: Anurag Pathak <anuragpathak911@gmail.com>

**Description**
Fixes typo of word `setu` in service-mesh-landscape. It is modified to setup.

This PR fixes #2831 

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
