### PR TITLE
Added Press kits to News

### DIFF
--- a/src/collections/news/2021/2021-10-13-cncf-adopts-meshery/index.mdx
+++ b/src/collections/news/2021/2021-10-13-cncf-adopts-meshery/index.mdx
@@ -84,8 +84,4 @@ Not just a service mesh manager, Meshery comprises a set of microservices each o
 <h3>About Layer5</h3>
 <p>Layer5 offers cloud native application management by harnessing the unique position service meshes have in changing how developers write applications, how operators run modern infrastructure and how product owners manage their service offerings. Layer5’s MeshMap delivers the world’s only universal service mesh designer. Layer5’s leadership stewards the Network and Service Mesh groups in the CNCF.</p>
 
-<h4>Media Contact</h4>
-<p>Kate Suttons
-<br />press@layer5.io</p>
-
 </NewsWrapper>

--- a/src/collections/news/2022/2022-05-10-layer5-joins-docker-extension-program-bringing-kubernetes-and-service-mesh-management-to-docker-with-meshery/layer5-joins-docker-extension-program-bringing-kubernetes-and-service-mesh-management-to-docker-with-meshery.mdx
+++ b/src/collections/news/2022/2022-05-10-layer5-joins-docker-extension-program-bringing-kubernetes-and-service-mesh-management-to-docker-with-meshery/layer5-joins-docker-extension-program-bringing-kubernetes-and-service-mesh-management-to-docker-with-meshery.mdx
@@ -90,8 +90,5 @@ HashiCorp is a leader in multi-cloud infrastructure automation software. For mor
 <p style="font-size:1rem">
 Hewlett Packard Enterprise (NYSE: HPE) is the global edge-to-cloud company that helps organizations accelerate outcomes by unlocking value from all of their data, everywhere. For more information, visit hpe.com.</p>
 
-#### Media Contacts
-<p>Kate Suttons<br />
-<span style="font-size:1rem">press@layer5.io</span></p>
 
 </NewsWrapper>

--- a/src/collections/news/2022/2022-05-18-meshmark-the-cloud-native-value-measurement/meshmark-the-cloud-native-value-measurement.md
+++ b/src/collections/news/2022/2022-05-18-meshmark-the-cloud-native-value-measurement/meshmark-the-cloud-native-value-measurement.md
@@ -5,7 +5,7 @@ date: 2022-05-17 08:00:00 -0530
 author: The Newsroom
 thumbnail: ../../../../assets/images/meshmark/stacked/meshmark-dark-full.png
 category: "Press Release"
-presskit: "/press-kits/MeshMark-press-kit.zip"
+presskit: "/press/kits/MeshMark-press-kit.zip"
 description: "Layer5, a provider of cloud native management software, announced today the general availability of the Meshery Docker Extension. Complementing Docker Desktop's role as the go-to Kubernetes environment for cloud native developers, the Meshery Docker Extension provides easy access to the next layer of cloud native infrastructure: service meshes. As an inaugural Docker Extensions Partner and a maker of industry-defining, cloud native software, Layer5’s integration of Meshery provides a visual pathway for existing Docker Compose applications to move into Kubernetes and onto any service mesh."
 tags:
  - Announcements

--- a/src/collections/news/2022/2022-05-18-meshmark-the-cloud-native-value-measurement/meshmark-the-cloud-native-value-measurement.md
+++ b/src/collections/news/2022/2022-05-18-meshmark-the-cloud-native-value-measurement/meshmark-the-cloud-native-value-measurement.md
@@ -5,6 +5,7 @@ date: 2022-05-17 08:00:00 -0530
 author: The Newsroom
 thumbnail: ../../../../assets/images/meshmark/stacked/meshmark-dark-full.png
 category: "Press Release"
+presskit: "/press-kits/MeshMark-press-kit.zip"
 description: "Layer5, a provider of cloud native management software, announced today the general availability of the Meshery Docker Extension. Complementing Docker Desktop's role as the go-to Kubernetes environment for cloud native developers, the Meshery Docker Extension provides easy access to the next layer of cloud native infrastructure: service meshes. As an inaugural Docker Extensions Partner and a maker of industry-defining, cloud native software, Layer5’s integration of Meshery provides a visual pathway for existing Docker Compose applications to move into Kubernetes and onto any service mesh."
 tags:
  - Announcements
@@ -37,7 +38,7 @@ VALENCIA, Spain (May 17th, 2022) - ServiceMeshCon EU /KubeCon EU - <a href="http
 A wall of performance metrics causes confusion, not clarity.
 </p>
 
-<img src={MeshmapMeshmark} alt="MeshMark in Layer5 MeshMap" width="50%"/>
+<img src={MeshmapMeshmark} alt="MeshMark in Layer5 MeshMap" width="40%"/>
 
 <p>
 By specifying a uniform way to analyze and report on the degree to which measured performance provides business value, MeshMark converts these metrics into insights about the efficiency and value of the functions your cloud native infrastructure is providing to your applications and services.
@@ -118,11 +119,6 @@ Layer5 offers cloud native application management by harnessing the unique posit
 ##### About Service Mesh Performance 
 <p style="font-size:1rem">
 Hosted within the CNCF, <Link to="/projects/service-mesh-performance">Service Mesh Performance</Link> is a vendor-neutral cloud native performance measurement standard. Based on SMP, MeshMark provides a universal performance index to gauge your cloud native infrastructure’s efficiency and value. Visit <a href="https://smp-spec.io/">smp-spec.io</a></p>
-
-#### Media Contacts
-<p>Kate Suttons<br />
-<span style="font-size:1rem">press@layer5.io</span></p>
-
 
 
 </NewsWrapper>

--- a/src/sections/Company/News-single/Sidebar.js
+++ b/src/sections/Company/News-single/Sidebar.js
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import Button from "../../../reusecore/Button";
 import { FiDownloadCloud } from "@react-icons/all-files/fi/FiDownloadCloud";
-import { FcSms } from "@react-icons/all-files/fc/FcSms";
+import { FiMail } from "@react-icons/all-files/fi/FiMail";
 import { Link } from "gatsby";
 
 const NewsSidebarWrapper = styled.div`
@@ -55,13 +55,13 @@ const NewsSidebar = (props) => {
           </Button>
         </a> : "" }
       <Link to="/brand">
-        <Button primary title="Check out our Brand Kit" external={true} />
+        <Button secondary title="Check out our Brand Kit" external={true} />
       </Link>
       <a href="mailto:press@layer5.io" target="_blank" rel="noreferrer">
         <div className="project__block__inner">
           <h5>Media Contacts</h5>
           <p>Kate Suttons</p>
-          <FcSms size={40} className="icon" />
+          <FiMail size={40} className="icon" />
           <p>press@layer5.io</p>
         </div>
       </a>

--- a/src/sections/Company/News-single/Sidebar.js
+++ b/src/sections/Company/News-single/Sidebar.js
@@ -55,7 +55,7 @@ const NewsSidebar = (props) => {
           </Button>
         </a> : "" }
       <Link to="/brand">
-        <Button secondary title="Check out our Brand Kit" external={true} />
+        <Button secondary title="Layer5 brand kit" external={true} />
       </Link>
       <a href="mailto:press@layer5.io" target="_blank" rel="noreferrer">
         <div className="project__block__inner">

--- a/src/sections/Company/News-single/Sidebar.js
+++ b/src/sections/Company/News-single/Sidebar.js
@@ -48,12 +48,12 @@ Button{
 const NewsSidebar = (props) => {
   return (
     <NewsSidebarWrapper>
-      {props.kit ? 
+      {props.kit ?
         <a href={props.kit}>
-          <Button primary title="Get the press kit" external={true}>
+          <Button primary title="Press Kit" external={true}>
             <FiDownloadCloud size={21} className="icon-left" />
           </Button>
-        </a> : "" }
+        </a> : ""}
       <Link to="/brand">
         <Button secondary title="Layer5 brand kit" external={true} />
       </Link>

--- a/src/sections/Company/News-single/Sidebar.js
+++ b/src/sections/Company/News-single/Sidebar.js
@@ -50,7 +50,7 @@ const NewsSidebar = (props) => {
     <NewsSidebarWrapper>
       {props.kit ? 
         <a href={props.kit}>
-          <Button primary title="Get the Press Kit" external={true}>
+          <Button primary title="Get the press kit" external={true}>
             <FiDownloadCloud size={21} className="icon-left" />
           </Button>
         </a> : "" }

--- a/src/sections/Company/News-single/Sidebar.js
+++ b/src/sections/Company/News-single/Sidebar.js
@@ -1,0 +1,73 @@
+import React from "react";
+import styled from "styled-components";
+import Button from "../../../reusecore/Button";
+import { FiDownloadCloud } from "@react-icons/all-files/fi/FiDownloadCloud";
+import { FcSms } from "@react-icons/all-files/fc/FcSms";
+import { Link } from "gatsby";
+
+const NewsSidebarWrapper = styled.div`
+  
+Button{
+    margin: 0 0 1rem ;
+    @media screen and (max-width: 768px) {
+        display: block;
+        margin: 1rem auto;
+        }
+}
+.icon{
+    display: block;
+    margin: auto;
+}
+
+.project__block__inner { 
+    background: ${props => props.theme.white};
+    transition: 450ms all;
+    border: 1px solid ${props => props.theme.shadowLightColor};
+    &:hover{
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.4);
+    }
+    padding: 12% 6% 12% 6%;
+    border-radius: 4%;
+    text-align: center;
+    h5{
+        font-weight: 700;
+        color: ${props => props.theme.secondaryColor}
+    }
+    p{
+        font-weight: 300;
+        color: ${props => props.theme.black};
+    }
+    @media screen and (max-width: 768px) {
+        margin: 6% 15%;
+        padding: 6% 10%;
+        }
+}
+
+`;
+
+const NewsSidebar = (props) => {
+  return (
+    <NewsSidebarWrapper>
+      {props.kit ? 
+        <a href={props.kit}>
+          <Button primary title="Get the Press Kit" external={true}>
+            <FiDownloadCloud size={21} className="icon-left" />
+          </Button>
+        </a> : "" }
+      <Link to="/brand">
+        <Button primary title="Check out our Brand Kit" external={true} />
+      </Link>
+      <a href="mailto:press@layer5.io" target="_blank" rel="noreferrer">
+        <div className="project__block__inner">
+          <h5>Media Contacts</h5>
+          <p>Kate Suttons</p>
+          <FcSms size={40} className="icon" />
+          <p>press@layer5.io</p>
+        </div>
+      </a>
+    </NewsSidebarWrapper>
+  );
+};
+
+export default NewsSidebar;
+

--- a/src/sections/Company/News-single/index.js
+++ b/src/sections/Company/News-single/index.js
@@ -2,8 +2,9 @@ import React from "react";
 import { MDXRenderer } from "gatsby-plugin-mdx";
 import { SRLWrapper } from "simple-react-lightbox";
 import { graphql, useStaticQuery} from "gatsby";
-import { Container } from "../../../reusecore/Layout";
+import { Container, Row, Col } from "../../../reusecore/Layout";
 import PageHeader from "../../../reusecore/PageHeader";
+import NewsSidebar from "./Sidebar";
 
 import NewsPageWrapper from "./NewsSingle.style.js";
 import RelatedPosts from "../../../components/Related-Posts";
@@ -24,6 +25,7 @@ const NewsSingle = ({data}) => {
         author
         category
         tags
+        presskit
         thumbnail {
           childImageSharp {
             gatsbyImageData(layout: FULL_WIDTH)
@@ -52,9 +54,16 @@ const NewsSingle = ({data}) => {
       <div className="single-post-wrapper">
         <Container>
           <div className="single-post-block">
-            <SRLWrapper>
-              <MDXRenderer>{body}</MDXRenderer>
-            </SRLWrapper>
+            <Row>
+              <Col lg={10} md={9} xs={12}>
+                <SRLWrapper>
+                  <MDXRenderer>{body}</MDXRenderer>
+                </SRLWrapper>
+              </Col>
+              <Col lg={2} md={3} xs={12}>
+                <NewsSidebar kit={frontmatter.presskit} />
+              </Col>
+            </Row>
           </div>
           <RelatedPosts 
             postType="news"

--- a/src/templates/news-single.js
+++ b/src/templates/news-single.js
@@ -21,6 +21,7 @@ export const query = graphql`query NewsBySlug($slug: String!) {
       subtitle
       date(formatString: "MMMM Do, YYYY")
       author
+      presskit
       thumbnail {
         childImageSharp {
           gatsbyImageData(width: 500, layout: CONSTRAINED)


### PR DESCRIPTION
Signed-off-by: Debopriya Bhattacharjee <debopriyabhattacharjee@Debopriyas-MacBook-Air.local>

**Description**
Added press kit for MeshMark Press Release. 

<img width="1440" alt="Screenshot 2022-05-27 at 3 20 49 AM" src="https://user-images.githubusercontent.com/85789734/170585968-6158952c-f3dd-456a-b855-bee21a6b5d4d.png">


Press Kits for any other news articles/press releases can be added by:

1.  Creating the zip folder under `static/press-kits/`
2. Adding `presskit: "/press-kits/name.zip"` to the frontmatter of the individual news mdx files.

This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
3. Build and test your changes before submitting a PR. 
4. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
