### PR TITLE
Update react-tabs to 4.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "react-select": "^5.3.1",
         "react-slick": "^0.28.1",
         "react-table": "^7.7.0",
-        "react-tabs": "^3.2.3",
+        "react-tabs": "^4.2.1",
         "react-tooltip": "^4.2.21",
         "react-tsparticles": "^1.39.0",
         "react-vertical-timeline-component": "^3.5.2",
@@ -20942,15 +20942,15 @@
       }
     },
     "node_modules/react-tabs": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-3.2.3.tgz",
-      "integrity": "sha512-jx325RhRVnS9DdFbeF511z0T0WEqEoMl1uCE3LoZ6VaZZm7ytatxbum0B8bCTmaiV0KsU+4TtLGTGevCic7SWg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-4.2.1.tgz",
+      "integrity": "sha512-nQcEN3KrAsSry6f9Jz2oyMQsnh+sLEy31YjlskL/mnI3KU/c7BeyD1VzHZmmcJ15UEFu12pYOXYkdTzZ0uyIbw==",
       "dependencies": {
         "clsx": "^1.1.0",
         "prop-types": "^15.5.0"
       },
       "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.0-0"
+        "react": "^16.8.0 || ^17.0.0-0 || ^18.0.0"
       }
     },
     "node_modules/react-tooltip": {
@@ -42133,9 +42133,9 @@
       "requires": {}
     },
     "react-tabs": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-3.2.3.tgz",
-      "integrity": "sha512-jx325RhRVnS9DdFbeF511z0T0WEqEoMl1uCE3LoZ6VaZZm7ytatxbum0B8bCTmaiV0KsU+4TtLGTGevCic7SWg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-4.2.1.tgz",
+      "integrity": "sha512-nQcEN3KrAsSry6f9Jz2oyMQsnh+sLEy31YjlskL/mnI3KU/c7BeyD1VzHZmmcJ15UEFu12pYOXYkdTzZ0uyIbw==",
       "requires": {
         "clsx": "^1.1.0",
         "prop-types": "^15.5.0"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react-select": "^5.3.1",
     "react-slick": "^0.28.1",
     "react-table": "^7.7.0",
-    "react-tabs": "^3.2.3",
+    "react-tabs": "^4.2.1",
     "react-tooltip": "^4.2.21",
     "react-tsparticles": "^1.39.0",
     "react-vertical-timeline-component": "^3.5.2",

--- a/src/sections/Landscape/smi.js
+++ b/src/sections/Landscape/smi.js
@@ -92,7 +92,7 @@ function SMI_Compatibility() {
   }
 
   return (
-    <Tabs defaultFocus style={{ overflow: "auto", whiteSpace: "nowrap"}} className="landscape-table">
+    <Tabs style={{ overflow: "auto", whiteSpace: "nowrap"}} className="landscape-table">
       <TabList>
         {
           Object.keys(smiData).map((ver, ind) => {


### PR DESCRIPTION
Signed-off-by: Nikhil-Ladha <nikhilladha1999@gmail.com>

**Description**
The prop `defaultFocus` caused the page to jump to the SMI table on the landscape page render.
It is not needed in our use case and can be safely removed.


**Notes for Reviewers**
_When Nikhil is here, why fear!_


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
