### PR TITLE
[Bug] Added responsiveness to the meshmap page

### DIFF
--- a/src/sections/Meshmap/meshery-action.js
+++ b/src/sections/Meshmap/meshery-action.js
@@ -5,8 +5,12 @@ const MesheryWrapper = styled.div`
 
 .blocks {
   display: flex;
+  
   padding-bottom: 5rem;
+
 }
+
+
 
 .block {
   min-height: 100px;
@@ -94,8 +98,19 @@ p.caption {
   .mobile-modes{
     display: block;
   }
+  .blocks{
+    flex-direction: column;
+    gap: 3rem;
+    width: 100%;
+    align-items: center;
+
+     .block--left, .block--right {
+      width: 70%;
+      height: 20rem;
+     }
+     }
 }
- 
+
 `;
 
 const MesheryAction = () => {


### PR DESCRIPTION


Signed-off-by: Yash Kamboj <yashkamboj29@gmail.com>

**Description**Added responsiveness to the "See Meshery in Action" section on meshmap page
![Screenshot (120)](https://user-images.githubusercontent.com/75125203/175007816-a3262628-6484-45db-bde0-66cde44e3003.png)
![Screenshot (119)](https://user-images.githubusercontent.com/75125203/175007830-d64739a0-5622-426e-affa-64ae4f44affc.png)

This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
