### PR TITLE
Redirecting the Sign-off link in Handbook to appropriate section

### DIFF
--- a/src/sections/Community/Handbook/contributing.js
+++ b/src/sections/Community/Handbook/contributing.js
@@ -27,26 +27,23 @@ const contributingGuide = () => {
         <Container>
           <h2>General contribution flow</h2>
           <p>
-						Pull requests (PRs) are the best ways to propose changes to a
-						project repository. At Layer5 org, we use the Github Flow:
+            Pull requests (PRs) are the best ways to propose changes to a
+            project repository. At Layer5 org, we use the Github Flow:
           </p>
           <div className="content">
-            <a id="Clone your fork">
-              {" "}
-              <h3>Clone your fork to your local machine</h3>{" "}
-            </a>
+            <a id="Clone your fork">  <h3>Clone your fork to your local machine</h3> </a>
             <ul>
               <li>Fork the repository you are working on.</li>
               <li>
                 <span>
-									Go to your GitHub account, open the forked repository, click
-									on the code button and then click the “copy to clipboard” icon
-									if you intend to use a command-line tool.{" "}
+                  Go to your GitHub account, open the forked repository, click
+                  on the code button and then click the “copy to clipboard” icon
+                  if you intend to use a command-line tool.{ " " }
                 </span>
               </li>
               <li>
                 <span>
-									Open the terminal and run the following git command:
+                  Open the terminal and run the following git command:
                   <div className="codes">
                     <Code codeString="git clone “URL you copied from the clipboard.”" />
                   </div>
@@ -58,51 +55,48 @@ const contributingGuide = () => {
             <ul>
               <li>
                 <span>
-									Keeping your fork up to date while this isn't a necessary
-									step. If you plan on doing anything more than a tiny quick
-									fix, you'll want to make sure you keep your fork up to date by
-									tracking the original "upstream" repo that you forked earlier.
+                  Keeping your fork up to date while this isn't a necessary
+                  step. If you plan on doing anything more than a tiny quick
+                  fix, you'll want to make sure you keep your fork up to date by
+                  tracking the original "upstream" repo that you forked earlier.
                 </span>
               </li>
               <li>
                 <span>
-									To do this, you'll need to add a remote. An example of the
-									command is given below:
+                  To do this, you'll need to add a remote. An example of the
+                  command is given below:
                   <div className="codes">
                     <Code codeString="git remote add upstream https://github.com/layer5io/meshery.git " />
                   </div>
-									Here “meshery" is used as the example repo. Be sure to
-									reference the actual repo you are contributing to.
+                  Here “meshery" is used as the example repo. Be sure to
+                  reference the actual repo you are contributing to.
                 </span>
               </li>
             </ul>
 
-            <a id="Checkout a new branch">
-              {" "}
-              <h3>Create and checkout a new branch</h3>{" "}
-            </a>
+            <a id="Checkout a new branch">  <h3>Create and checkout a new branch</h3> </a>
             <ul>
               <li>
                 <span>
-									Whenever you begin to work on a new feature or bugfix, it's
-									important that you create a new branch. Not only is it a
-									proper git workflow, but it also keeps your changes organized
-									and separated from the master branch so that you can easily
-									submit and manage multiple pull requests for every task
-									completed.
+                  Whenever you begin to work on a new feature or bugfix, it's
+                  important that you create a new branch. Not only is it a
+                  proper git workflow, but it also keeps your changes organized
+                  and separated from the master branch so that you can easily
+                  submit and manage multiple pull requests for every task
+                  completed.
                 </span>
               </li>
               <li>
                 <span>
-									Perform the flow:
+                  Perform the flow:
                   <div className="codes">
                     <Code codeString=" git checkout -b your-new-branch-name" />
                   </div>
-									For example,
+                  For example,
                   <div className="codes">
                     <Code codeString="git checkout -b feature" />
-                  </div>{" "}
-									(feature being a branch name)
+                  </div>{ " " }
+                  (feature being a branch name)
                 </span>
               </li>
             </ul>
@@ -111,7 +105,7 @@ const contributingGuide = () => {
             <ul>
               <li>
                 <span>
-									To add the changes you have made to your branch, use:
+                  To add the changes you have made to your branch, use:
                   <div className="codes">
                     <Code codeString="git add <file> " />
                   </div>
@@ -119,9 +113,9 @@ const contributingGuide = () => {
               </li>
               <li>
                 <span>
-                  {" "}
-									If you add multiple file changes to the branch, you simply
-									use:
+                  { " " }
+                  If you add multiple file changes to the branch, you simply
+                  use:
                   <div className="codes">
                     <Code codeString=" git add ." />
                   </div>
@@ -129,14 +123,11 @@ const contributingGuide = () => {
               </li>
             </ul>
 
-            <a id="Commit your changes">
-              {" "}
-              <h3>Commit the changes made</h3>{" "}
-            </a>
+            <a id="Commit your changes">  <h3>Commit the changes made</h3> </a>
             <ul>
               <li>
                 <span>
-									Now commit those changes using the git commit command:
+                  Now commit those changes using the git commit command:
                   <div className="codes">
                     <Code codeString="git commit -s -m “This is my commit message”" />
                   </div>
@@ -144,16 +135,11 @@ const contributingGuide = () => {
               </li>
             </ul>
 
-            <a id="Push changes to Github">
-              {" "}
-              <h3>
-								Push changes to Github and submit a pull request (PR)
-              </h3>{" "}
-            </a>
+            <a id="Push changes to Github">  <h3>Push changes to Github and submit a pull request (PR)</h3> </a>
             <ul>
               <li>
                 <span>
-									To push your changes, run the git command:
+                  To push your changes, run the git command:
                   <div className="codes">
                     <Code codeString="git push origin your_branch_name" />
                   </div>
@@ -161,41 +147,39 @@ const contributingGuide = () => {
               </li>
             </ul>
           </div>
-          <a id="Sign-off commits">
-            {" "}
-            <h2>
-							Make sure to{" "}
-              <a href="https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits">
-								Sign-off
-              </a>{" "}
-							on your Commits (Developer Certificate of Origin)
-            </h2>
+          <a id="Sign-off commits"> <h2>
+            Make sure to{ " " }
+            <a href="https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits">
+              Sign-off
+            </a>{ " " }
+            on your Commits (Developer Certificate of Origin)
+          </h2>
           </a>
           <p>
-						To contribute to this project, you must agree to the Developer
-						Certificate of Origin (DCO) for each commit you make. The DCO is a
-						simple statement that you, as a contributor, have the legal right to
-						contribute.{" "}
+            To contribute to this project, you must agree to the Developer
+            Certificate of Origin (DCO) for each commit you make. The DCO is a
+            simple statement that you, as a contributor, have the legal right to
+            contribute.{ " " }
           </p>
           <p>
-						To signify that you agree to the DCO for contributions, you simply
-						add a line to each of your git commit messages:
+            To signify that you agree to the DCO for contributions, you simply
+            add a line to each of your git commit messages:
           </p>
           <div className="codes">
             <Code codeString="Signed-off-by: Jane Smith <jane.smith@example.com>" />
           </div>
           <p>
-						In most cases, you can add this signoff to your commit automatically
-						with the -s or --signoff flag to git commit. You must use your real
-						name and a reachable email address (sorry, no pseudonyms or
-						anonymous contributions). An example of signing off on a commit:
+            In most cases, you can add this signoff to your commit automatically
+            with the -s or --signoff flag to git commit. You must use your real
+            name and a reachable email address (sorry, no pseudonyms or
+            anonymous contributions). An example of signing off on a commit:
           </p>
           <div className="codes">
             <Code codeString="$ commit -s -m “my commit message w/signoff”" />
           </div>
           <p>
-						To ensure all your commits are signed, you may choose to add this
-						alias to your global .gitconfig:
+            To ensure all your commits are signed, you may choose to add this
+            alias to your global .gitconfig:
           </p>
           <div className="codes">
             <Code
@@ -207,14 +191,14 @@ const contributingGuide = () => {
             />
           </div>
           <p>
-						Or you may configure your IDE, for example, Visual Studio Code to
-						automatically sign-off commits for you:
+            Or you may configure your IDE, for example, Visual Studio Code to
+            automatically sign-off commits for you:
           </p>
-          <img src={Signoff} width="74%" id="sign-off" />
+          <img src={ Signoff } width="74%" id="sign-off" />
           <TocPagination />
         </Container>
 
-        <IntraPage contents={contents} />
+        <IntraPage contents={ contents } />
       </div>
     </HandbookWrapper>
   );

--- a/src/sections/Community/Handbook/contributing.js
+++ b/src/sections/Community/Handbook/contributing.js
@@ -147,7 +147,7 @@ const contributingGuide = () => {
             <a id="Push changes to Github">
               {" "}
               <h3>
-								Push changes to Github and submit a Pull Request (PR)
+								Push changes to Github and submit a pull request (PR)
               </h3>{" "}
             </a>
             <ul>
@@ -165,7 +165,7 @@ const contributingGuide = () => {
             {" "}
             <h2>
 							Make sure to{" "}
-              <a href="https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits">
+              <a href="ttps://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits">
 								Sign-off
               </a>{" "}
 							on your Commits (Developer Certificate of Origin)

--- a/src/sections/Community/Handbook/contributing.js
+++ b/src/sections/Community/Handbook/contributing.js
@@ -165,7 +165,7 @@ const contributingGuide = () => {
             {" "}
             <h2>
 							Make sure to{" "}
-              <a href="ttps://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits">
+              <a href="https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits">
 								Sign-off
               </a>{" "}
 							on your Commits (Developer Certificate of Origin)

--- a/src/sections/Community/Handbook/contributing.js
+++ b/src/sections/Community/Handbook/contributing.js
@@ -147,7 +147,7 @@ const contributingGuide = () => {
             <a id="Push changes to Github">
               {" "}
               <h3>
-								Push changes to Github and submit a pull request (PR)
+								Push changes to Github and submit a Pull Request (PR)
               </h3>{" "}
             </a>
             <ul>

--- a/src/sections/Community/Handbook/contributing.js
+++ b/src/sections/Community/Handbook/contributing.js
@@ -12,40 +12,43 @@ const contents = [
   { id: 0, link: "#Clone your fork", text: "Clone your fork" },
   { id: 1, link: "#Checkout a new branch", text: "Checkout a new branch" },
   { id: 2, link: "#Commit your changes", text: "Commit your changes" },
-  { id: 3, link: "#Push changes to Github", text: "Push changes to Github"},
+  { id: 3, link: "#Push changes to Github", text: "Push changes to Github" },
   { id: 4, link: "#Sign-off commits", text: "Sign-off commits" },
 ];
 
 const contributingGuide = () => {
   return (
     <HandbookWrapper>
-      <div className="page-header-section">
+      <div className='page-header-section'>
         <h1>Contribution</h1>
       </div>
       <TOC />
-      <div className="page-section">
+      <div className='page-section'>
         <Container>
           <h2>General contribution flow</h2>
           <p>
-            Pull requests (PRs) are the best ways to propose changes to a
-            project repository. At Layer5 org, we use the Github Flow:
+						Pull requests (PRs) are the best ways to propose changes to a
+						project repository. At Layer5 org, we use the Github Flow:
           </p>
-          <div className="content">
-            <a id="Clone your fork">  <h3>Clone your fork to your local machine</h3> </a>
+          <div className='content'>
+            <a id='Clone your fork'>
+              {" "}
+              <h3>Clone your fork to your local machine</h3>{" "}
+            </a>
             <ul>
               <li>Fork the repository you are working on.</li>
               <li>
                 <span>
-                  Go to your GitHub account, open the forked repository, click
-                  on the code button and then click the “copy to clipboard” icon
-                  if you intend to use a command-line tool.{" "}
+									Go to your GitHub account, open the forked repository, click
+									on the code button and then click the “copy to clipboard” icon
+									if you intend to use a command-line tool.{" "}
                 </span>
               </li>
               <li>
                 <span>
-                  Open the terminal and run the following git command:
-                  <div className="codes">
-                    <Code codeString="git clone “URL you copied from the clipboard.”" />
+									Open the terminal and run the following git command:
+                  <div className='codes'>
+                    <Code codeString='git clone “URL you copied from the clipboard.”' />
                   </div>
                 </span>
               </li>
@@ -55,48 +58,51 @@ const contributingGuide = () => {
             <ul>
               <li>
                 <span>
-                  Keeping your fork up to date while this isn't a necessary
-                  step. If you plan on doing anything more than a tiny quick
-                  fix, you'll want to make sure you keep your fork up to date by
-                  tracking the original "upstream" repo that you forked earlier.
+									Keeping your fork up to date while this isn't a necessary
+									step. If you plan on doing anything more than a tiny quick
+									fix, you'll want to make sure you keep your fork up to date by
+									tracking the original "upstream" repo that you forked earlier.
                 </span>
               </li>
               <li>
                 <span>
-                  To do this, you'll need to add a remote. An example of the
-                  command is given below:
-                  <div className="codes">
-                    <Code codeString="git remote add upstream https://github.com/layer5io/meshery.git " />
+									To do this, you'll need to add a remote. An example of the
+									command is given below:
+                  <div className='codes'>
+                    <Code codeString='git remote add upstream https://github.com/layer5io/meshery.git ' />
                   </div>
-                  Here “meshery" is used as the example repo. Be sure to
-                  reference the actual repo you are contributing to.
+									Here “meshery" is used as the example repo. Be sure to
+									reference the actual repo you are contributing to.
                 </span>
               </li>
             </ul>
 
-            <a id="Checkout a new branch">  <h3>Create and checkout a new branch</h3> </a>
+            <a id='Checkout a new branch'>
+              {" "}
+              <h3>Create and checkout a new branch</h3>{" "}
+            </a>
             <ul>
               <li>
                 <span>
-                  Whenever you begin to work on a new feature or bugfix, it's
-                  important that you create a new branch. Not only is it a
-                  proper git workflow, but it also keeps your changes organized
-                  and separated from the master branch so that you can easily
-                  submit and manage multiple pull requests for every task
-                  completed.
+									Whenever you begin to work on a new feature or bugfix, it's
+									important that you create a new branch. Not only is it a
+									proper git workflow, but it also keeps your changes organized
+									and separated from the master branch so that you can easily
+									submit and manage multiple pull requests for every task
+									completed.
                 </span>
               </li>
               <li>
                 <span>
-                  Perform the flow:
-                  <div className="codes">
-                    <Code codeString=" git checkout -b your-new-branch-name" />
+									Perform the flow:
+                  <div className='codes'>
+                    <Code codeString=' git checkout -b your-new-branch-name' />
                   </div>
-                  For example,
-                  <div className="codes">
-                    <Code codeString="git checkout -b feature" />
+									For example,
+                  <div className='codes'>
+                    <Code codeString='git checkout -b feature' />
                   </div>{" "}
-                  (feature being a branch name)
+									(feature being a branch name)
                 </span>
               </li>
             </ul>
@@ -105,96 +111,106 @@ const contributingGuide = () => {
             <ul>
               <li>
                 <span>
-                  To add the changes you have made to your branch, use:
-                  <div className="codes">
-                    <Code codeString="git add <file> " />
+									To add the changes you have made to your branch, use:
+                  <div className='codes'>
+                    <Code codeString='git add <file> ' />
                   </div>
                 </span>
               </li>
               <li>
                 <span>
                   {" "}
-                  If you add multiple file changes to the branch, you simply
-                  use:
-                  <div className="codes">
-                    <Code codeString=" git add ." />
+									If you add multiple file changes to the branch, you simply
+									use:
+                  <div className='codes'>
+                    <Code codeString=' git add .' />
                   </div>
                 </span>
               </li>
             </ul>
 
-            <a id="Commit your changes">  <h3>Commit the changes made</h3> </a>
+            <a id='Commit your changes'>
+              {" "}
+              <h3>Commit the changes made</h3>{" "}
+            </a>
             <ul>
               <li>
                 <span>
-                  Now commit those changes using the git commit command:
-                  <div className="codes">
-                    <Code codeString="git commit -s -m “This is my commit message”" />
+									Now commit those changes using the git commit command:
+                  <div className='codes'>
+                    <Code codeString='git commit -s -m “This is my commit message”' />
                   </div>
                 </span>
               </li>
             </ul>
 
-            <a id="Push changes to Github">  <h3>Push changes to Github and submit a pull request (PR)</h3> </a>
+            <a id='Push changes to Github'>
+              {" "}
+              <h3>
+								Push changes to Github and submit a pull request (PR)
+              </h3>{" "}
+            </a>
             <ul>
               <li>
                 <span>
-                  To push your changes, run the git command:
-                  <div className="codes">
-                    <Code codeString="git push origin your_branch_name" />
+									To push your changes, run the git command:
+                  <div className='codes'>
+                    <Code codeString='git push origin your_branch_name' />
                   </div>
                 </span>
               </li>
             </ul>
           </div>
-          <a id="Sign-off commits"> <h2>
-            Make sure to{" "}
-            <a href="https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin">
-              Sign-off
-            </a>{" "}
-            on your Commits (Developer Certificate of Origin)
-          </h2>
+          <a id='Sign-off commits'>
+            {" "}
+            <h2>
+							Make sure to{" "}
+              <a href='https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits'>
+								Sign-off
+              </a>{" "}
+							on your Commits (Developer Certificate of Origin)
+            </h2>
           </a>
           <p>
-            To contribute to this project, you must agree to the Developer
-            Certificate of Origin (DCO) for each commit you make. The DCO is a
-            simple statement that you, as a contributor, have the legal right to
-            contribute.{" "}
+						To contribute to this project, you must agree to the Developer
+						Certificate of Origin (DCO) for each commit you make. The DCO is a
+						simple statement that you, as a contributor, have the legal right to
+						contribute.{" "}
           </p>
           <p>
-            To signify that you agree to the DCO for contributions, you simply
-            add a line to each of your git commit messages:
+						To signify that you agree to the DCO for contributions, you simply
+						add a line to each of your git commit messages:
           </p>
-          <div className="codes">
-            <Code codeString="Signed-off-by: Jane Smith <jane.smith@example.com>" />
+          <div className='codes'>
+            <Code codeString='Signed-off-by: Jane Smith <jane.smith@example.com>' />
           </div>
           <p>
-            In most cases, you can add this signoff to your commit automatically
-            with the -s or --signoff flag to git commit. You must use your real
-            name and a reachable email address (sorry, no pseudonyms or
-            anonymous contributions). An example of signing off on a commit:
+						In most cases, you can add this signoff to your commit automatically
+						with the -s or --signoff flag to git commit. You must use your real
+						name and a reachable email address (sorry, no pseudonyms or
+						anonymous contributions). An example of signing off on a commit:
           </p>
-          <div className="codes">
-            <Code codeString="$ commit -s -m “my commit message w/signoff”" />
+          <div className='codes'>
+            <Code codeString='$ commit -s -m “my commit message w/signoff”' />
           </div>
           <p>
-            To ensure all your commits are signed, you may choose to add this
-            alias to your global .gitconfig:
+						To ensure all your commits are signed, you may choose to add this
+						alias to your global .gitconfig:
           </p>
-          <div className="codes">
+          <div className='codes'>
             <Code
-              codeString="[alias]
+              codeString='[alias]
   amend = commit -s --amend
   cm = commit -s -m
   commit = commit -s
-"
+'
             />
           </div>
           <p>
-            Or you may configure your IDE, for example, Visual Studio Code to
-            automatically sign-off commits for you:
+						Or you may configure your IDE, for example, Visual Studio Code to
+						automatically sign-off commits for you:
           </p>
-          <img src={Signoff} width="74%" id="sign-off" />
+          <img src={Signoff} width='74%' id='sign-off' />
           <TocPagination />
         </Container>
 

--- a/src/sections/Community/Handbook/contributing.js
+++ b/src/sections/Community/Handbook/contributing.js
@@ -19,19 +19,19 @@ const contents = [
 const contributingGuide = () => {
   return (
     <HandbookWrapper>
-      <div className='page-header-section'>
+      <div className="page-header-section">
         <h1>Contribution</h1>
       </div>
       <TOC />
-      <div className='page-section'>
+      <div className="page-section">
         <Container>
           <h2>General contribution flow</h2>
           <p>
 						Pull requests (PRs) are the best ways to propose changes to a
 						project repository. At Layer5 org, we use the Github Flow:
           </p>
-          <div className='content'>
-            <a id='Clone your fork'>
+          <div className="content">
+            <a id="Clone your fork">
               {" "}
               <h3>Clone your fork to your local machine</h3>{" "}
             </a>
@@ -47,8 +47,8 @@ const contributingGuide = () => {
               <li>
                 <span>
 									Open the terminal and run the following git command:
-                  <div className='codes'>
-                    <Code codeString='git clone “URL you copied from the clipboard.”' />
+                  <div className="codes">
+                    <Code codeString="git clone “URL you copied from the clipboard.”" />
                   </div>
                 </span>
               </li>
@@ -68,8 +68,8 @@ const contributingGuide = () => {
                 <span>
 									To do this, you'll need to add a remote. An example of the
 									command is given below:
-                  <div className='codes'>
-                    <Code codeString='git remote add upstream https://github.com/layer5io/meshery.git ' />
+                  <div className="codes">
+                    <Code codeString="git remote add upstream https://github.com/layer5io/meshery.git " />
                   </div>
 									Here “meshery" is used as the example repo. Be sure to
 									reference the actual repo you are contributing to.
@@ -77,7 +77,7 @@ const contributingGuide = () => {
               </li>
             </ul>
 
-            <a id='Checkout a new branch'>
+            <a id="Checkout a new branch">
               {" "}
               <h3>Create and checkout a new branch</h3>{" "}
             </a>
@@ -95,12 +95,12 @@ const contributingGuide = () => {
               <li>
                 <span>
 									Perform the flow:
-                  <div className='codes'>
-                    <Code codeString=' git checkout -b your-new-branch-name' />
+                  <div className="codes">
+                    <Code codeString=" git checkout -b your-new-branch-name" />
                   </div>
 									For example,
-                  <div className='codes'>
-                    <Code codeString='git checkout -b feature' />
+                  <div className="codes">
+                    <Code codeString="git checkout -b feature" />
                   </div>{" "}
 									(feature being a branch name)
                 </span>
@@ -112,8 +112,8 @@ const contributingGuide = () => {
               <li>
                 <span>
 									To add the changes you have made to your branch, use:
-                  <div className='codes'>
-                    <Code codeString='git add <file> ' />
+                  <div className="codes">
+                    <Code codeString="git add <file> " />
                   </div>
                 </span>
               </li>
@@ -122,14 +122,14 @@ const contributingGuide = () => {
                   {" "}
 									If you add multiple file changes to the branch, you simply
 									use:
-                  <div className='codes'>
-                    <Code codeString=' git add .' />
+                  <div className="codes">
+                    <Code codeString=" git add ." />
                   </div>
                 </span>
               </li>
             </ul>
 
-            <a id='Commit your changes'>
+            <a id="Commit your changes">
               {" "}
               <h3>Commit the changes made</h3>{" "}
             </a>
@@ -137,14 +137,14 @@ const contributingGuide = () => {
               <li>
                 <span>
 									Now commit those changes using the git commit command:
-                  <div className='codes'>
-                    <Code codeString='git commit -s -m “This is my commit message”' />
+                  <div className="codes">
+                    <Code codeString="git commit -s -m “This is my commit message”" />
                   </div>
                 </span>
               </li>
             </ul>
 
-            <a id='Push changes to Github'>
+            <a id="Push changes to Github">
               {" "}
               <h3>
 								Push changes to Github and submit a pull request (PR)
@@ -154,18 +154,18 @@ const contributingGuide = () => {
               <li>
                 <span>
 									To push your changes, run the git command:
-                  <div className='codes'>
-                    <Code codeString='git push origin your_branch_name' />
+                  <div className="codes">
+                    <Code codeString="git push origin your_branch_name" />
                   </div>
                 </span>
               </li>
             </ul>
           </div>
-          <a id='Sign-off commits'>
+          <a id="Sign-off commits">
             {" "}
             <h2>
 							Make sure to{" "}
-              <a href='https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits'>
+              <a href="https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits">
 								Sign-off
               </a>{" "}
 							on your Commits (Developer Certificate of Origin)
@@ -181,8 +181,8 @@ const contributingGuide = () => {
 						To signify that you agree to the DCO for contributions, you simply
 						add a line to each of your git commit messages:
           </p>
-          <div className='codes'>
-            <Code codeString='Signed-off-by: Jane Smith <jane.smith@example.com>' />
+          <div className="codes">
+            <Code codeString="Signed-off-by: Jane Smith <jane.smith@example.com>" />
           </div>
           <p>
 						In most cases, you can add this signoff to your commit automatically
@@ -190,27 +190,27 @@ const contributingGuide = () => {
 						name and a reachable email address (sorry, no pseudonyms or
 						anonymous contributions). An example of signing off on a commit:
           </p>
-          <div className='codes'>
-            <Code codeString='$ commit -s -m “my commit message w/signoff”' />
+          <div className="codes">
+            <Code codeString="$ commit -s -m “my commit message w/signoff”" />
           </div>
           <p>
 						To ensure all your commits are signed, you may choose to add this
 						alias to your global .gitconfig:
           </p>
-          <div className='codes'>
+          <div className="codes">
             <Code
-              codeString='[alias]
+              codeString="[alias]
   amend = commit -s --amend
   cm = commit -s -m
   commit = commit -s
-'
+"
             />
           </div>
           <p>
 						Or you may configure your IDE, for example, Visual Studio Code to
 						automatically sign-off commits for you:
           </p>
-          <img src={Signoff} width='74%' id='sign-off' />
+          <img src={Signoff} width="74%" id="sign-off" />
           <TocPagination />
         </Container>
 


### PR DESCRIPTION

Signed-off-by: Santosh Kaluskar <dtshbl@gmail.com>

**Description**
Redirects the Sign-off link in the Contribution section of the Handbook to the appropriate section in the CONTIBUTION.md file.

This PR fixes #2914

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
