### PR TITLE
[CI] Move to sitemap-index.xml

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -506,7 +506,7 @@ module.exports = {
       resolve: "gatsby-plugin-robots-txt",
       options: {
         host: "https://layer5.io",
-        sitemap: "https://layer5.io/sitemap.xml",
+        sitemap: "https://layer5.io/sitemap/sitemap-index.xml",
         policy: [{ userAgent: "*", allow: "/" }],
       }
     },


### PR DESCRIPTION
Signed-off-by: leecalcote <leecalcote@gmail.com>

**Description**

This PR fixes #3008.

I tried the number of configuration combinations for the [gatsby-plugin-sitemap](https://www.gatsbyjs.com/plugins/gatsby-plugin-sitemap/) plug-in, but couldn't find any of which that would land the sitemap.xml in the root directory. 

Two solutions to getting the sitemap.xml back to the route directories or 1) creating a redirect or 2) downgrading to v3.x of the plug-in. 

For now, we're moving to /sitemap/sitemap-index.xml as an index of sitemap files. I've updated Google Search Console and the robots.txt file to point to this new location. It might not hurt to have a redirect from `/sitemap.xml` to this new location...

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
