### PR TITLE
Fix community slider

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -380,14 +380,6 @@ module.exports = {
     {
       resolve: "gatsby-source-filesystem",
       options: {
-        name: "communityImageSlider",
-        path: `${__dirname}/src/assets/images/Community-pictures`,
-      },
-    },
-
-    {
-      resolve: "gatsby-source-filesystem",
-      options: {
         path: `${__dirname}/src/collections/blog`,
         name: "blog",
       },


### PR DESCRIPTION
Signed-off-by: Nikhil-Ladha <nikhilladha1999@gmail.com>

**Description**
Since the `Community-pictures` folder was being sourced individually to the source-filesystem plugin the relative directory of the images was no more `Community-pictures` and just "", that's the reason graphql was not picking it up. Earlier, the plugin was not smart enough to avoid duplicity, now things are more robust 😎 

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
