### PR TITLE
text remains visible during font load

### DIFF
--- a/fonts.css
+++ b/fonts.css
@@ -2,18 +2,21 @@
     font-family: "Qanelas Soft";
     src: url('./static/fonts/qanelas-soft/QanelasSoftBlack.otf') format('opentype');
     font-weight: normal;
+    font-display: swap;
 }
 
 @font-face {
     font-family: "Qanelas Soft";
     src: url('./static/fonts/qanelas-soft/QanelasSoftBold.otf') format('opentype');
     font-weight: bold;
+    font-display: swap;
 }
 
 @font-face {
     font-family: "Qanelas Soft";
     src: url('./static/fonts/qanelas-soft/QanelasSoftBlackItalic.otf') format('opentype');
     font-style: italic;
+    font-display: swap;
 }
 
 @font-face {
@@ -21,12 +24,14 @@
     src: url('./static/fonts/qanelas-soft/QanelasSoftBoldItalic.otf') format('opentype');
     font-weight: bold;
     font-style: italic;
+    font-display: swap;
 }
 
 @font-face {
     font-family: "Qanelas Soft";
     src: url('./static/fonts/qanelas-soft/QanelasSoftExtraBold.otf') format('opentype');
     font-weight: 800;
+    font-display: swap;
 }
 
 @font-face {
@@ -34,12 +39,14 @@
     src: url('./static/fonts/qanelas-soft/QanelasSoftExtraBoldItalic.otf') format('opentype');
     font-weight: 800;
     font-style: italic;
+    font-display: swap;
 }
 
 @font-face {
     font-family: "Qanelas Soft";
     src: url('./static/fonts/qanelas-soft/QanelasSoftHeavy.otf') format('opentype');
     font-weight: 900;
+    font-display: swap;
 }
 
 @font-face {
@@ -47,12 +54,14 @@
     src: url('./static/fonts/qanelas-soft/QanelasSoftHeavyItalic.otf') format('opentype');
     font-weight: 900;
     font-style: italic;
+    font-display: swap;
 }
 
 @font-face {
     font-family: "Qanelas Soft";
     src: url('./static/fonts/qanelas-soft/QanelasSoftLight.otf') format('opentype');
     font-weight: 300;
+    font-display: swap;
 }
 
 @font-face {
@@ -60,12 +69,14 @@
     src: url('./static/fonts/qanelas-soft/QanelasSoftLightItalic.otf') format('opentype');
     font-weight: 300;
     font-style: italic;
+    font-display: swap;
 }
 
 @font-face {
     font-family: "Qanelas Soft";
     src: url('./static/fonts/qanelas-soft/QanelasSoftMedium.otf') format('opentype');
     font-weight: 500;
+    font-display: swap;
 }
 
 @font-face {
@@ -73,12 +84,14 @@
     src: url('./static/fonts/qanelas-soft/QanelasSoftMediumItalic.otf') format('opentype');
     font-weight: 500;
     font-style: italic;
+    font-display: swap;
 }
 
 @font-face {
     font-family: "Qanelas Soft";
     src: url('./static/fonts/qanelas-soft/QanelasSoftRegular.otf') format('opentype');
     font-weight: 400;
+    font-display: swap;
 }
 
 @font-face {
@@ -86,12 +99,14 @@
     src: url('./static/fonts/qanelas-soft/QanelasSoftRegularItalic.otf') format('opentype');
     font-weight: 400;
     font-style: italic;
+    font-display: swap;
 }
 
 @font-face {
     font-family: "Qanelas Soft";
     src: url('./static/fonts/qanelas-soft/QanelasSoftSemiBold.otf') format('opentype');
     font-weight: 600;
+    font-display: swap;
 }
 
 @font-face {
@@ -99,12 +114,14 @@
     src: url('./static/fonts/qanelas-soft/QanelasSoftSemiBoldItalic.otf') format('opentype');
     font-weight: 600;
     font-style: italic;
+    font-display: swap;
 }
 
 @font-face {
     font-family: "Qanelas Soft";
     src: url('./static/fonts/qanelas-soft/QanelasSoftThin.otf') format('opentype');
     font-weight: 100;
+    font-display: swap;
 }
 
 @font-face {
@@ -112,12 +129,14 @@
     src: url('./static/fonts/qanelas-soft/QanelasSoftThinItalic.otf') format('opentype');
     font-weight: 100;
     font-style: italic;
+    font-display: swap;
 }
 
 @font-face {
     font-family: "Qanelas Soft";
     src: url('./static/fonts/qanelas-soft/QanelasSoftUltraLight.otf') format('opentype');
     font-weight: 200;
+    font-display: swap;
 }
 
 @font-face {
@@ -125,4 +144,5 @@
     src: url('./static/fonts/qanelas-soft/QanelasSoftUltraLightItalic.otf') format('opentype');
     font-weight: 200;
     font-style: italic;
+    font-display: swap;
 }

--- a/src/assets/discuss/css/app.css
+++ b/src/assets/discuss/css/app.css
@@ -6,6 +6,7 @@
   src: url('Qanelas-Soft?#iefix') format('embedded-opentype'), /* IE6-IE8 */
        url('Qanelas-Soft.woff2') format('woff2'), /* Super Modern Browsers */
        url('Qanelas-Soft.svg#svgFontName') format('svg'); /* Legacy iOS */
+    font-display: swap;
 }
 
 body {

--- a/src/assets/discuss/css/footer.css
+++ b/src/assets/discuss/css/footer.css
@@ -4,18 +4,21 @@
   src: url("https://layer5.io/fonts/qanelas-soft/QanelasSoftBlack.otf")
     format("opentype");
   font-weight: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: "Qanelas Soft";
   src: url("https://layer5.io/fonts/qanelas-soft/QanelasSoftBold.otf")
     format("opentype");
   font-weight: bold;
+  font-display: swap;
 }
 @font-face {
   font-family: "Qanelas Soft";
   src: url("https://layer5.io/fonts/qanelas-soft/QanelasSoftBlackItalic.otf")
     format("opentype");
   font-style: italic;
+  font-display: swap;
 }
 @font-face {
   font-family: "Qanelas Soft";
@@ -23,12 +26,14 @@
     format("opentype");
   font-weight: bold;
   font-style: italic;
+  font-display: swap;
 }
 @font-face {
   font-family: "Qanelas Soft";
   src: url("https://layer5.io/fonts/qanelas-soft/QanelasSoftExtraBold.otf")
     format("opentype");
   font-weight: 800;
+  font-display: swap;
 }
 @font-face {
   font-family: "Qanelas Soft";
@@ -36,12 +41,14 @@
     format("opentype");
   font-weight: 800;
   font-style: italic;
+  font-display: swap;
 }
 @font-face {
   font-family: "Qanelas Soft";
   src: url("https://layer5.io/fonts/qanelas-soft/QanelasSoftHeavy.otf")
     format("opentype");
   font-weight: 900;
+  font-display: swap;
 }
 @font-face {
   font-family: "Qanelas Soft";
@@ -49,12 +56,14 @@
     format("opentype");
   font-weight: 900;
   font-style: italic;
+  font-display: swap;
 }
 @font-face {
   font-family: "Qanelas Soft";
   src: url("https://layer5.io/fonts/qanelas-soft/QanelasSoftLight.otf")
     format("opentype");
   font-weight: 300;
+  font-display: swap;
 }
 @font-face {
   font-family: "Qanelas Soft";
@@ -62,12 +71,14 @@
     format("opentype");
   font-weight: 300;
   font-style: italic;
+  font-display: swap;
 }
 @font-face {
   font-family: "Qanelas Soft";
   src: url("https://layer5.io/fonts/qanelas-soft/QanelasSoftMedium.otf")
     format("opentype");
   font-weight: 500;
+  font-display: swap;
 }
 @font-face {
   font-family: "Qanelas Soft";
@@ -75,12 +86,14 @@
     format("opentype");
   font-weight: 500;
   font-style: italic;
+  font-display: swap;
 }
 @font-face {
   font-family: "Qanelas Soft";
   src: url("https://layer5.io/fonts/qanelas-soft/QanelasSoftRegular.otf")
     format("opentype");
   font-weight: 400;
+  font-display: swap;
 }
 @font-face {
   font-family: "Qanelas Soft";
@@ -88,12 +101,14 @@
     format("opentype");
   font-weight: 400;
   font-style: italic;
+  font-display: swap;
 }
 @font-face {
   font-family: "Qanelas Soft";
   src: url("https://layer5.io/fonts/qanelas-soft/QanelasSoftSemiBold.otf")
     format("opentype");
   font-weight: 600;
+  font-display: swap;
 }
 @font-face {
   font-family: "Qanelas Soft";
@@ -101,12 +116,14 @@
     format("opentype");
   font-weight: 600;
   font-style: italic;
+  font-display: swap;
 }
 @font-face {
   font-family: "Qanelas Soft";
   src: url("https://layer5.io/fonts/qanelas-soft/QanelasSoftThin.otf")
     format("opentype");
   font-weight: 100;
+  font-display: swap;
 }
 @font-face {
   font-family: "Qanelas Soft";
@@ -114,12 +131,14 @@
     format("opentype");
   font-weight: 100;
   font-style: italic;
+  font-display: swap;
 }
 @font-face {
   font-family: "Qanelas Soft";
   src: url("https://layer5.io/fonts/qanelas-soft/QanelasSoftUltraLight.otf")
     format("opentype");
   font-weight: 200;
+  font-display: swap;
 }
 @font-face {
   font-family: "Qanelas Soft";
@@ -127,6 +146,7 @@
     format("opentype");
   font-weight: 200;
   font-style: italic;
+  font-display: swap;
 }
 body {
   font-family: "Open Sans", sans-serif;


### PR DESCRIPTION
Signed-off-by: manik malhotra <manikmalhotra2113@gmail.com>

**Description**
By including font-display: swap in your @font-face style, you can avoid FOIT in most modern browsers

This PR fixes #2996 

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
