### PR TITLE
Update Hacktoberfest date to 2022

### DIFF
--- a/src/collections/programs/hacktoberfest-2020/index.mdx
+++ b/src/collections/programs/hacktoberfest-2020/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Hacktoberfest 2021"
+title: "Hacktoberfest 2022"
 thumbnail: ./hacktoberfest2021.png
 permalink: "hacktoberfest/2020"
 program: "Hacktoberfest"
@@ -13,7 +13,7 @@ import hacktoberfest2020 from "./hacktoberfest2021.png";
 <ProgramsWrapper>
 
 <img class="hacktoberfest-img" src={hacktoberfest2020}/>
-<h2>Participate in Hacktoberfest 2021 with Layer5</h2>
+<h2>Participate in Hacktoberfest 2022 with Layer5</h2>
 <div>
     Hacktoberfest is open to everyone in the global community. Whether you’re
       a developer, student learning to code, event host, or a company of any


### PR DESCRIPTION
Signed-off-by: Deborah Udoh <deborahudoh02@gmail.com>

**Description**
This PR fixes issue #3175. 
The date on the Hacktoberfest page has been updated to 2022.

![Hacktoberfest2022](https://user-images.githubusercontent.com/105166953/191975071-e5668d8f-fdab-46a2-9a44-1755cef9116d.png)

**Notes for Reviewers**
Here is the path to the page => https://layer5.io/programs/hacktoberfest

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
