### PR TITLE
Custom embedding video

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -516,6 +516,34 @@ module.exports = {
         policy: [{ userAgent: "*", allow: "/" }],
       }
     },
+    {
+      resolve: "gatsby-transformer-remark",
+      options: {
+        plugins: [
+          {
+            resolve: "gatsby-remark-embed-video",
+            options: {
+              width: 800,
+              ratio: 1.77, // Optional: Defaults to 16/9 = 1.77
+              height: 400, // Optional: Overrides optional.ratio
+              related: false, //Optional: Will remove related videos from the end of an embedded YouTube video.
+              noIframeBorder: true, //Optional: Disable insertion of <style> border: 0
+              loadingStrategy: "lazy", //Optional: Enable support for lazy-load offscreen iframes. Default is disabled.
+              urlOverrides: [
+                {
+                  id: "youtube",
+                  embedURL: videoId =>
+                    `https://www.youtube-nocookie.com/embed/${videoId}`,
+                },
+              ], //Optional: Override URL of a service provider, e.g to enable youtube-nocookie support
+              containerClass: "embedVideo-container", //Optional: Custom CSS class for iframe container, for multiple classes separate them by space
+              iframeId: false, //Optional: if true, iframe's id will be set to what is provided after 'video:' (YouTube IFrame player API requires iframe id)
+            },
+            // "gatsby-remark-responsive-iframe", //Optional: Must be loaded after gatsby-remark-embed-video
+          },
+        ],
+      },
+    },
     "gatsby-plugin-meta-redirect", // make sure this is always the last one
   ],
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "gatsby-plugin-sitemap": "^5.19.0",
     "gatsby-plugin-styled-components": "^5.19.0",
     "gatsby-redirect-from": "^0.5.0",
+    "gatsby-remark-embed-video": "^3.2.1",
     "gatsby-source-filesystem": "^4.19.0",
     "gatsby-transformer-sharp": "^4.19.0",
     "gbimage-bridge": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "gatsby-redirect-from": "^0.5.0",
     "gatsby-remark-embed-video": "^3.2.1",
     "gatsby-source-filesystem": "^4.19.0",
+    "gatsby-transformer-remark": "^5.24.0",
     "gatsby-transformer-sharp": "^4.19.0",
     "gbimage-bridge": "^0.2.2",
     "js-search": "^2.0.0",

--- a/src/reusecore/video/video.js
+++ b/src/reusecore/video/video.js
@@ -1,0 +1,57 @@
+const config = {
+  siteMetadata: {
+    title: `My Gatsby Site`,
+    siteUrl: `https://www.yourdomain.tld`
+  },
+  graphqlTypegen: true,
+  plugins: [
+    "gatsby-plugin-react-helmet",
+    "gatsby-plugin-sitemap",
+    {
+      resolve: "gatsby-plugin-mdx",
+      options: {
+        gatsbyRemarkPlugins: [
+          {
+            resolve: "gatsby-remark-embed-video",
+            options: {
+              width: 800,
+              ratio: 1.77, // Optional: Defaults to 16/9 = 1.77
+              height: 400, // Optional: Overrides optional.ratio
+              related: false, //Optional: Will remove related videos from the end of an embedded YouTube video.
+              noIframeBorder: true, //Optional: Disable insertion of <style> border: 0
+              loadingStrategy: "lazy", //Optional: Enable support for lazy-load offscreen iframes. Default is disabled.
+              urlOverrides: [
+                {
+                  id: "youtube",
+                  embedURL: videoId =>
+                    `https://www.youtube-nocookie.com/embed/${videoId}`
+                }
+              ], //Optional: Override URL of a service provider, e.g to enable youtube-nocookie support
+              containerClass: "embedVideo-container", //Optional: Custom CSS class for iframe container, for multiple classes separate them by space
+              iframeId: false, //Optional: if true, iframe's id will be set to what is provided after 'video:' (YouTube IFrame player API requires iframe id)
+              sandbox: "allow-same-origin allow-scripts allow-presentation" // Optional: iframe sandbox options - Default: undefined
+            }
+          },
+          "gatsby-remark-responsive-iframe" //Optional: Must be loaded after gatsby-remark-embed-video
+        ]
+      }
+    },
+    {
+      resolve: "gatsby-plugin-manifest",
+      options: {
+        icon: "src/images/icon.png"
+      }
+    },
+
+    {
+      resolve: "gatsby-source-filesystem",
+      options: {
+        name: "pages",
+        path: "./src/pages/"
+      },
+      __key: "pages"
+    }
+  ]
+}
+
+export default config

--- a/src/reusecore/video/video.js
+++ b/src/reusecore/video/video.js
@@ -1,7 +1,7 @@
 const config = {
   siteMetadata: {
-    title: `My Gatsby Site`,
-    siteUrl: `https://www.yourdomain.tld`
+    title: "My Gatsby Site",
+    siteUrl: "https://www.yourdomain.tld"
   },
   graphqlTypegen: true,
   plugins: [
@@ -52,6 +52,6 @@ const config = {
       __key: "pages"
     }
   ]
-}
+};
 
-export default config
+export default config;


### PR DESCRIPTION
**Description**

Currently for adding/embedding video to the site we are just using <iframe> due to which its customization availability limits us.

The idea behind is to use [gatsby-remark-embed-video](https://www.gatsbyjs.com/plugins/gatsby-remark-embed-video/?=video) plugin for sourcing a video. It will allow us to write custom components for videos such as controllers and thumbnail customization etc.

This PR fixes #2968 

**Notes for Reviewers**
I am pushing step by step to see the integration with the main site.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
