### PR TITLE
Kuma-logo optimized for dark mode

### DIFF
--- a/src/collections/landscape/non-functional.js
+++ b/src/collections/landscape/non-functional.js
@@ -14,6 +14,7 @@ import Octarine from "../../assets/images/service-mesh-icons/octarine.svg";
 import TraefikMesh from "../../assets/images/service-mesh-icons/traefik.svg";
 import AppMesh from "../../assets/images/service-mesh-icons/aws-app-mesh.svg";
 import Kuma from "../../assets/images/service-mesh-icons/kuma.svg";
+import KumaDark from "../../assets/images/service-mesh-icons/kuma-white.svg";
 import Citrix from "../../assets/images/service-mesh-icons/citrix.svg";
 import Osm from "../../assets/images/service-mesh-icons/osm.svg";
 import Nginx from "../../assets/images/service-mesh-icons/nginx-service-mesh.svg";
@@ -264,7 +265,8 @@ export const non_functional = [{
   commercial: "Kuma",
   category: "Service Mesh",
   timeline_order: 20,
-  icon: Kuma
+  icon: Kuma,
+  darkIcon: KumaDark
 },
 {
   name: "Citrix Service Mesh",


### PR DESCRIPTION
Signed-off-by: Soumyakanta Pattanaik <samcse95@gmail.com>

**Description**
The kuma logo colour optimised for dark mode.
![Screenshot from 2022-10-03 12-04-33](https://user-images.githubusercontent.com/74086891/193514825-05eb41e2-98d9-41cc-ae1a-4bf04422cbc4.png)
![Screenshot from 2022-10-03 12-04-37](https://user-images.githubusercontent.com/74086891/193514903-57fc7455-120e-47df-bee7-682a1f408b56.png)

This PR fixes #3227

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
