### PR TITLE
fixed calendar event import url #3229

### DIFF
--- a/src/sections/Community/Calendar/index.js
+++ b/src/sections/Community/Calendar/index.js
@@ -116,7 +116,7 @@ const Calendar = () => {
                   addToCalendar: {
                     text: "Add To Your Calendar",
                     click: function () {
-                      window.open("https://bit.ly/2SbrRhe", "_blank");
+                      window.open("https://bit.ly/3fz1Vfs", "_blank");
                     }
                   }
                 }}


### PR DESCRIPTION
**Description**
Changed the short url that was opening up on clicking `Add to your calendar` that was mapping to https://calendar.google.com/calendar/b/1?cid=bGF5ZXI1LmlvX2VoMmFhOWRwZjFnNDBlbHZvYzc2MmpucGhzQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20
to 
https://calendar.google.com/calendar?cid=bGF5ZXI1LmlvX2VoMmFhOWRwZjFnNDBlbHZvYzc2MmpucGhzQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20

Removed `/b/1` which was opening up the user 1 not default or 0th user.

This PR fixes #3229 

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
