### PR TITLE
make text readable in hacktoberfest page ( Layer5 site ) (Issue #3250)

### DIFF
--- a/src/collections/programs/Programs.style.js
+++ b/src/collections/programs/Programs.style.js
@@ -71,7 +71,7 @@ export const ProgramsWrapper = styled.div`
         tbody tr {
             transition: .2s ease;
             :hover {
-                background-color: #f5f5f5;
+                ${props => props.theme.DarkTheme ? "background-color: #3c494f" : "background-color: #f5f5f5" };
             }
 
         }


### PR DESCRIPTION
Signed-off-by: Abhishek Tiwari <tiwari.abhishektiwari23@gmail.com>

**Description**
I have fixed issue #3250 by changing the hover colour of the table. For light mode, the colour is the same as the original one (#f5f5f5), and I made the colour (#3c494f) for dark mode. This makes the text readable in dark and light modes both

This PR fixes #3250 

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
