### PR TITLE
Fixing the overlapping headings at landscape page

### DIFF
--- a/src/sections/Landscape/LandscapeGrid.style.js
+++ b/src/sections/Landscape/LandscapeGrid.style.js
@@ -4,6 +4,7 @@ export const LandscapePageWrapper = styled.div`
 	h2.landscape-section-heading {
 		margin-bottom: 2rem;
 		margin-top: 3rem;
+		padding-top: 5rem;
 		width: 100%;
 		font-weight: 600;
 		text-align: center;


### PR DESCRIPTION
Signed-off-by: Kamal Nayan <geniusamansingh@gmail.com>

**Description**
Fixes the overlap of headings on the landscape page.

![image](https://user-images.githubusercontent.com/95926324/194359381-64bf7bfb-26aa-4660-acac-43e1aca462be.png)

This PR fixes #3271 

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
