### PR TITLE
remove white solid line at bottom of tab when in focus in table component

### DIFF
--- a/src/sections/Landscape/LandscapeGrid.style.js
+++ b/src/sections/Landscape/LandscapeGrid.style.js
@@ -440,6 +440,9 @@ export const LandscapePageWrapper = styled.div`
 		color: ${props => props.theme.textRevert};
 		font-weight: 600;
 	}
+	.react-tabs__tab:focus:after{
+		content: none;
+	}
 	.card-content {
 		border-right: none;
 	}

--- a/src/sections/Projects/SMI/smi.style.js
+++ b/src/sections/Projects/SMI/smi.style.js
@@ -206,6 +206,9 @@ const SMIWrapper = styled.section`
 			border-top-right-radius: .5rem;
 		}
 	}
+    .react-tabs__tab:focus:after{
+		content: none;
+	}
 	.react-tabs__tab-list {
 		margin: 0px;
 		padding: 0px;


### PR DESCRIPTION
Signed-off-by: Gaganpreet Kaur Kalsi <gagansinghkalsi4126@gmail.com>

**Description** - 
- **Issue** - A white solid line appears at the bottom when a tab is in focus state in table component.
- **Steps taken to resolve** - Encountered this at 2 places. :after pseudo element was causing the stated issue. Removed it at both the places.

**This PR fixes #3277** 

**Notes for Reviewers**
Below are the urls and screenshots where the issue stated is appearing. This PR will fix the issue at both the places.
- https://layer5.io/service-mesh-landscape
- https://layer5.io/projects/service-mesh-interface-conformance
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/54144759/194695852-a0024311-2d6a-409e-b6c6-5f16b3d25642.png">
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/54144759/194695889-541a2e1a-4409-4c22-b4db-cee6f57cf7b8.png">


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
