### PR TITLE
fix tooltip for smi table

### DIFF
--- a/src/components/SMI-Table/SMITable.style.js
+++ b/src/components/SMI-Table/SMITable.style.js
@@ -1,8 +1,7 @@
 import styled from "styled-components";
 
 export const TableWrapper = styled.div`
-overflow-y: hidden;
-overflow-x: auto;
+overflow: hidden;
 
 .smiMark {
 	height: 70%;

--- a/src/components/SMI-Table/SMITable.style.js
+++ b/src/components/SMI-Table/SMITable.style.js
@@ -23,6 +23,10 @@ overflow-x: auto;
 	line-height: 1.5rem;
 }
 
+.tooltip-div{
+	display: inline-block;
+}
+
 table {
     border-spacing: 0;
     width: 100%;

--- a/src/components/SMI-Table/index.js
+++ b/src/components/SMI-Table/index.js
@@ -56,10 +56,10 @@ const Table = ({ columns, data, spec }) => {
                     {
                       (non_functional.find(ele => ele.name.includes(row.original.mesh_name))) ?
                         <>
-                          <img data-for="mesh-icon" data-tip={row.original.mesh_name} className="smiMark" src={non_functional.find(ele => ele.name.includes(row.original.mesh_name)).icon} alt="Mesh Icon" />
+                          <img data-for="react-tooltip" data-tip={row.original.mesh_name} className="smiMark" src={non_functional.find(ele => ele.name.includes(row.original.mesh_name)).icon} alt="Mesh Icon" />
                           <ReactTooltip
-                            id="mesh-icon"
-                            place="left"
+                            id="react-tooltip"
+                            place="bottom"
                             effect="solid"
                             multiline
                             backgroundColor="rgb(60,73,79)"
@@ -67,10 +67,10 @@ const Table = ({ columns, data, spec }) => {
                           />
                         </>
                         : <>
-                          <StaticImage  data-for="mesh-icon" data-tip={"Service Mesh"} className="smiMark" src={ServiceMeshIcon} alt="Service Mesh" />
+                          <StaticImage  data-for="react-tooltip" data-tip={"Service Mesh"} className="smiMark" src={ServiceMeshIcon} alt="Service Mesh" />
                           <ReactTooltip
-                            id="mesh-icon"
-                            place="left"
+                            id="react-tooltip"
+                            place="bottom"
                             effect="solid"
                             multiline
                             backgroundColor="rgb(60,73,79)"
@@ -84,45 +84,19 @@ const Table = ({ columns, data, spec }) => {
                     if (spec["capability"] === "FULL"){
                       return <td>
                         <div className="tooltip">
-                          <StaticImage data-for="capablity" data-tip={`${spec["result"]}`} className="smiMark" src={passingMark} alt="Pass Mark" />
-                          <ReactTooltip
-                            id="capablity"
-                            place="bottom"
-                            effect="solid"
-                            multiline
-                            backgroundColor="rgb(60,73,79)"
-                            className="smi-tooltip"
-                          />
-                        </div>
-                      </td>;
-                    } else if (spec["capability"] === "NONE") {
-                      return <td >
-                        <div >
-                          <StaticImage data-for="capablity" data-tip={`${spec["reason"]}<br>${spec["result"]}`} className="smiMark" src={failingMark} alt="Fail Mark" />
-                          <ReactTooltip
-                            id="capablity"
-                            place="bottom"
-                            effect="solid"
-                            multiline
-                            wrapper="span"
-
-                            backgroundColor="rgb(60,73,79)"
-                            className="smi-tooltip"
-                          />
+                          <span data-for="react-tooltip" data-tip={`${spec["result"]}`}><StaticImage className="smiMark" src={passingMark} alt="Pass Mark" /></span>
                         </div>
                       </td>;
                     } else if (spec["capability"] === "HALF"){
                       return <td>
                         <div className="tooltip">
-                          <StaticImage data-for="capablity" data-tip={`${spec["reason"]}<br>${spec["result"]}`} className="smiMark" src={halfMark} alt="Half Mark" />
-                          <ReactTooltip
-                            id="capablity"
-                            place="bottom"
-                            effect="solid"
-                            multiline
-                            backgroundColor="rgb(60,73,79)"
-                            className="smi-tooltip"
-                          />
+                          <span data-for="react-tooltip" data-tip={`${spec["reason"]}<br>${spec["result"]}`}><StaticImage className="smiMark" src={halfMark} alt="Half Mark" /></span>
+                        </div>
+                      </td>;
+                    } else if (spec["capability"] === "NONE") {
+                      return <td >
+                        <div>
+                          <span data-for="react-tooltip" data-tip={`${spec["reason"]}<br>${spec["result"]}`}><StaticImage className="smiMark" src={failingMark} alt="Fail Mark" /></span>
                         </div>
                       </td>;
                     } else {

--- a/src/components/SMI-Table/index.js
+++ b/src/components/SMI-Table/index.js
@@ -83,20 +83,20 @@ const Table = ({ columns, data, spec }) => {
                   {row.original.more_details.map(spec => {
                     if (spec["capability"] === "FULL"){
                       return <td>
-                        <div className="tooltip">
-                          <span data-for="react-tooltip" data-tip={`${spec["result"]}`}><StaticImage className="smiMark" src={passingMark} alt="Pass Mark" /></span>
+                        <div className="tooltip-div" data-for="react-tooltip" data-tip={`${spec["result"]}`}>
+                          <StaticImage className="smiMark" src={passingMark} alt="Pass Mark" />
                         </div>
                       </td>;
                     } else if (spec["capability"] === "HALF"){
                       return <td>
-                        <div className="tooltip">
-                          <span data-for="react-tooltip" data-tip={`${spec["reason"]}<br>${spec["result"]}`}><StaticImage className="smiMark" src={halfMark} alt="Half Mark" /></span>
+                        <div className="tooltip-div" data-for="react-tooltip" data-tip={`${spec["reason"]}<br>${spec["result"]}`}>
+                          <StaticImage className="smiMark" src={halfMark} alt="Half Mark" />
                         </div>
                       </td>;
                     } else if (spec["capability"] === "NONE") {
                       return <td >
-                        <div>
-                          <span data-for="react-tooltip" data-tip={`${spec["reason"]}<br>${spec["result"]}`}><StaticImage className="smiMark" src={failingMark} alt="Fail Mark" /></span>
+                        <div className="tooltip-div" data-for="react-tooltip" data-tip={`${spec["reason"]}<br>${spec["result"]}`}>
+                          <StaticImage className="smiMark" src={failingMark} alt="Fail Mark" />
                         </div>
                       </td>;
                     } else {


### PR DESCRIPTION
**Description**
Issues :- 
- Tooltip not visible for Partially Compatible checks
- Each cell has more than 1 tooltip displaying for it. Not noticeable because positioning is bottom for all tooltips. So all tooltips overlap each other and couldn't see the multiple stacked tooltips with naked eye. Can be visible if we change the color and position for FULL, HALF and NONE tooltips. Below is an image displaying the same.
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/54144759/194764723-bd45818b-d822-4cc0-800a-e4bda38e90ff.png">

**This happens because all tooltips have the same id `id="capablity"`**

<br>

**This PR fixes #3279** 

**Notes for Reviewers**
- Now each row has a single tooltip. Previously there were 4 different tooltips, 1 with different id and other 3 with same id. 
- In future we can use rc-tooltip instead of react-tooltip. rc-tooltip is much easier to implement and works in a much simpler manner.
- The tooltips work perfectly fine now for all kinds of cells in the table 
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/54144759/194765169-b23e9965-a208-4e6e-9b44-a886b00c42b5.png">

- Tooltips are visible for last row cells as well.
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/54144759/194765224-0ebd4341-529e-4cb4-99e4-8a1310043839.png">
 


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
