### PR TITLE
Fixed text cutting glitch on Meshmap page

### DIFF
--- a/src/sections/Meshmap/meshmap-modes.js
+++ b/src/sections/Meshmap/meshmap-modes.js
@@ -176,7 +176,7 @@ const MeshmapModesWrapper = styled.div`
     position: relative;
     z-index: 1;
     text-align: center;
-    margin: 0 1.618em;
+    margin: 0 1.14em;
     top: 23%;
     opacity: 0;
   


### PR DESCRIPTION
Signed-off-by: Yash Raj <tigeryashraj@gmail.com>

**Description**

This PR fixes #3222 

**Notes for Reviewers**

The Fixed text overflow.
![meshmap](https://user-images.githubusercontent.com/74406801/195545001-d9375e5a-b8e3-4e45-8249-9a21951495a0.png)


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
