### PR TITLE
[Meshery] Integrations: remove reference to color icon for Knative dark mode

### DIFF
--- a/src/collections/integrations/knative/index.mdx
+++ b/src/collections/integrations/knative/index.mdx
@@ -2,7 +2,7 @@
 title: Knative  
 subtitle: Collaborative and visual infrastructure as code for Knative
 integrationIcon: icon/color/knative-icon-color.svg
-darkModeIntegrationIcon: icon/color/knative-icon-color.svg
+darkModeIntegrationIcon: 
 docURL: 
 category: Serverless
 subcategory: Installable Platform


### PR DESCRIPTION
Leaving darkmodeintegrationicon empty, so that a CSS filter can be applied.

Signed-off-by: Lee Calcote <leecalcote@gmail.com>

**Description**

This PR allows a CSS filter to be applied to the color version of the Knative icon.