### PR TITLE
Filter fix on specific integrations page 

### DIFF
--- a/src/sections/Meshery/Meshery-integrations/IntegrationsGrid.js
+++ b/src/sections/Meshery/Meshery-integrations/IntegrationsGrid.js
@@ -48,9 +48,10 @@ const IntegrationsGrid = ({ category, theme, count }) => {
     ),
   ];
 
-  let [categoryNameList ,setcategoryNameList] = useState([{ id: -1,
+  let [categoryNameList ,setcategoryNameList] = useState([{ 
+    id: -1,
     name: "All",
-    isSelected: true, },
+    isSelected: false, },
   ...categoryNames.map((categoryName) => {
     return {
       id: categoryName,


### PR DESCRIPTION
Signed-off-by: Kamal Nayan <geniusamansingh@gmail.com>

**Description**

When we go to specific integration page, the category type of the integration along with All are selected by default.


This PR fixes #3408

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
