### PR TITLE
Hero images leave much whitespace #3221

### DIFF
--- a/src/reusecore/PageHeader/pageHeader.style.js
+++ b/src/reusecore/PageHeader/pageHeader.style.js
@@ -9,7 +9,7 @@ const PageHeaderWrapper = styled.div`
             text-align: center;
             position: relative;
             height: auto;
-            margin: 3rem auto;
+            margin-bottom: 2rem;
             padding: 0 1rem 0;
             z-index: 99;
             h1 {
@@ -24,13 +24,13 @@ const PageHeaderWrapper = styled.div`
         }
         
         .feature-image{
-            margin: 2rem auto;
+            /* margin: 2rem auto; */
             object-fit: contain;
             justify-content: center; 
             
             img{
                 max-height: 25rem;
-                max-width: 31rem;
+                /* max-width: 31rem; */
                 display: block;
                 margin-left: auto; 
                 margin-right: auto; 

--- a/src/sections/Community/Event-single/EventSingle.style.js
+++ b/src/sections/Community/Event-single/EventSingle.style.js
@@ -2,7 +2,8 @@ import styled from "styled-components";
 
 const EventSinglePageWrapper = styled.div`
     .feature-image{
-    margin-bottom: -3.8rem
+    margin-bottom: -3.8rem;
+    margin-top: -4rem;
 }
     .single-event-wrapper{
         padding: 3rem 0 5rem;

--- a/src/sections/Community/Event-single/EventSingle.style.js
+++ b/src/sections/Community/Event-single/EventSingle.style.js
@@ -1,6 +1,9 @@
 import styled from "styled-components";
 
 const EventSinglePageWrapper = styled.div`
+    .feature-image{
+    margin-bottom: -3.8rem
+}
     .single-event-wrapper{
         padding: 3rem 0 5rem;
     }

--- a/src/sections/Community/Event-single/EventSingle.style.js
+++ b/src/sections/Community/Event-single/EventSingle.style.js
@@ -1,13 +1,6 @@
 import styled from "styled-components";
 
 const EventSinglePageWrapper = styled.div`
-    .feature-image{
-    margin-bottom: -3.8rem;
-    margin-top: -4rem;
-}
-    .single-event-wrapper{
-        padding: 3rem 0 5rem;
-    }
     .single-event-block{
         p+p{
             margin-top: 1.75rem;  


### PR DESCRIPTION
Signed-off-by: Abhishek Tiwari <97469132+AbhishekTiwari23@users.noreply.github.com>

**Description**
Solved issue #3221 by adding some lines of code that will remove unwanted white space.
This PR fixes #3221 

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
