### PR TITLE
fix: title not coming in center

### DIFF
--- a/src/sections/Meshery/Meshery-integrations/Integration.style.js
+++ b/src/sections/Meshery/Meshery-integrations/Integration.style.js
@@ -47,12 +47,12 @@ export const HoneycombGrid = styled.div`
         
         transition: all 1s linear;
         opacity: 1;
-        height:100%;
+        overflow: hidden;
         .title {
           line-height: 1.375rem;
           color:${props => props.theme.DarkTheme ? props.theme.white : props.theme.black};
           transition: all .5s cubic-bezier(1, 0.82, 0.165, 1);
-          margin-bottom: -2.7rem;
+          // margin-bottom: -2.7rem;
           font-size: 0.675rem;
           opacity: .2;
           font-weight: 600;
@@ -71,7 +71,7 @@ export const HoneycombGrid = styled.div`
       .integration-container {
         img {
           transition: all 1s cubic-bezier(0.075, 0.82, 0.165, 1);
-          height: 20%;
+          height: 0%;
           opacity: 0%;
         }
         .integration-content {
@@ -79,7 +79,7 @@ export const HoneycombGrid = styled.div`
           opacity: 1;
           height:100%;
           .title {
-            margin-top: -50%;
+            // margin-top: -50%;
             font-size: 1.2rem;
             opacity: 1;
           }


### PR DESCRIPTION
Signed-off-by: Gaganpreet Kaur Kalsi <gagansinghkalsi4126@gmail.com>

**Description**
Currently when we hover at the integration, the title doesn't appear in center for some integrations. 
This MR fixes this issue.


<img width="1440" alt="image" src="https://user-images.githubusercontent.com/54144759/200119694-7491a0d7-2eb0-4e6d-9f9f-95739b17330c.png">


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
