### PR TITLE
Text is now visible in dark mode on page: /layer5.io/community/events/kubecon-cloudnative-north-america-2022

### DIFF
--- a/src/collections/events/Event.style.js
+++ b/src/collections/events/Event.style.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 export const EventWrapper = styled.div`
-  color: #000;
+  color: ${(props) => props.theme.text};
   .sub-heading {
     color: gray;
     position: relative;


### PR DESCRIPTION
Signed-off-by: Utkarsh Mishra <nasautkarsh@gmail.com>

**Description**
Text is now visible in dark mode on page: /layer5.io/community/events/kubecon-cloudnative-north-america-2022

This PR fixes #3450 
![image](https://user-images.githubusercontent.com/67385503/201755042-67d68687-8a19-4911-9f1a-9ea42ea8e072.png)


**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
