### PR TITLE
Integrations boxes now have a sufficient margin(Left & Right)

### DIFF
--- a/src/sections/Meshery/Meshery-integrations/Integration.style.js
+++ b/src/sections/Meshery/Meshery-integrations/Integration.style.js
@@ -128,7 +128,7 @@ export const HoneycombGrid = styled.div`
   .category {
     display: flex;
     flex-wrap: wrap;
-    margin: 2.5625rem 0;
+    margin: 2.5625rem 1.2rem;
     gap: 0.625rem;
     justify-content: center;
   }


### PR DESCRIPTION
Signed-off-by: Utkarsh Mishra <nasautkarsh@gmail.com>

**Description**
Integrations boxes now have a sufficient margin(Left & Right)

This PR fixes #3461 
**Before**

https://user-images.githubusercontent.com/67385503/202538088-e207dfaa-f948-456b-9bf6-93af252f7fb7.mp4

**Now**

https://user-images.githubusercontent.com/67385503/202538118-a4d2fa24-2aee-4260-a028-b1f037ec6496.mp4



**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
