### PR TITLE
Use trailingSlash option in gatsby-config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -14,6 +14,7 @@ module.exports = {
     FAST_DEV: true,
     PARALLEL_SOURCING: true
   },
+  trailingSlash: "never",
   plugins: [
     {
       resolve: "gatsby-plugin-webpack-bundle-analyser-v2",
@@ -516,6 +517,7 @@ module.exports = {
         policy: [{ userAgent: "*", allow: "/" }],
       }
     },
+    "gatsby-plugin-use-dark-mode",
     "gatsby-plugin-meta-redirect", // make sure this is always the last one
   ],
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -517,7 +517,6 @@ module.exports = {
         policy: [{ userAgent: "*", allow: "/" }],
       }
     },
-    "gatsby-plugin-use-dark-mode",
     "gatsby-plugin-meta-redirect", // make sure this is always the last one
   ],
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -12,21 +12,21 @@ const { paginate } = require("gatsby-awesome-pagination");
 const { createFilePath } = require("gatsby-source-filesystem");
 const config = require("./gatsby-config");
 
-// Replacing '/' would result in empty string which is invalid
-const replacePath = path => (path === "/" ? path : path.replace(/\/$/, ""));
-// Implement the Gatsby API “onCreatePage”. This is
-// called after every page is created.
-exports.onCreatePage = ({ page, actions }) => {
-  const { createPage, deletePage } = actions;
-  const oldPage = Object.assign({}, page);
-  // Remove trailing slash unless page is /
-  page.path = replacePath(page.path);
-  if (page.path !== oldPage.path) {
-    // Replace new page with old page
-    deletePage(oldPage);
-    createPage(page);
-  }
-};
+// // Replacing '/' would result in empty string which is invalid
+// const replacePath = path => (path === "/" ? path : path.replace(/\/$/, ""));
+// // Implement the Gatsby API “onCreatePage”. This is
+// // called after every page is created.
+// exports.onCreatePage = ({ page, actions }) => {
+//   const { createPage, deletePage } = actions;
+//   const oldPage = Object.assign({}, page);
+//   // Remove trailing slash unless page is /
+//   page.path = replacePath(page.path);
+//   if (page.path !== oldPage.path) {
+//     // Replace new page with old page
+//     deletePage(oldPage);
+//     createPage(page);
+//   }
+// };
 
 exports.createPages = async ({ actions, graphql, reporter }) => {
 


### PR DESCRIPTION
Signed-off-by: Nikhil-Ladha <nikhilladha1999@gmail.com>

**Description**
The `trailingSlash` option allows us to remove/mandate the use of trailing slash in the paths. However, there are still speculations about it working without `gatsby serve`. So, try it out to see if it works for us or not, since we don't actually do a `gatsby serve` to host the site.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
