### PR TITLE
Add an infinite carousel in the partner section

### DIFF
--- a/src/sections/Home/Partners-home/index.js
+++ b/src/sections/Home/Partners-home/index.js
@@ -13,8 +13,8 @@ const settings = {
   dots: true,
   infinite: true,
   speed: 500,
-  slidesToShow: 3,
-  slidesToScroll: 1,
+  centerMode: true,
+  variableWidth: true,
   autoplay: true,
   autoplaySpeed: 2000,
   className: "partner-slider",
@@ -39,16 +39,16 @@ const Projects = () => {
             <h4>ENGAGING AND COLLABORATING WITH</h4>
           </SectionTitle>
         </Row>
-        <Slider {...settings}>
-          {partners.map((partner, index) => (
-            <Link className="partner-card" to={partner.imageRoute} key={index}>
-              <div className={partner.innerDivStyle}>
-                <img src={partner.imageLink} alt={partner.name} width="100%" height="auto" />
-              </div>
-            </Link>
-          ))}
-        </Slider>
       </Container>
+      <Slider {...settings}>
+        {partners.map((partner, index) => (
+          <Link className="partner-card" to={partner.imageRoute} key={index}>
+            <div className={partner.innerDivStyle}>
+              <img src={partner.imageLink} alt={partner.name} width="100%" height="auto" />
+            </div>
+          </Link>
+        ))}
+      </Slider>
     </PartnerItemWrapper>
   );
 };

--- a/src/sections/Home/Partners-home/index.js
+++ b/src/sections/Home/Partners-home/index.js
@@ -1,9 +1,30 @@
 import React from "react";
-import { Container, Row, Col } from "../../../reusecore/Layout";
+import { Container, Row } from "../../../reusecore/Layout";
 import SectionTitle from "../../../reusecore/SectionTitle";
 import PartnerItemWrapper from "./partnerSection.style";
 import { Link } from "gatsby";
 import { partners } from "./partners-home-data";
+import Slider from "react-slick";
+import "slick-carousel/slick/slick.css";
+import "slick-carousel/slick/slick-theme.css";
+
+const settings = {
+  arrows: false,
+  dots: true,
+  infinite: true,
+  speed: 500,
+  slidesToShow: 3,
+  slidesToScroll: 1,
+  autoplay: true,
+  autoplaySpeed: 2000,
+  className: "partner-slider",
+  responsive: [
+    {
+      breakpoint: 1400,
+      settings: "unslick"
+    }
+  ]
+};
 
 const Projects = () => {
   return (
@@ -18,17 +39,15 @@ const Projects = () => {
             <h4>ENGAGING AND COLLABORATING WITH</h4>
           </SectionTitle>
         </Row>
-        <Row Hcenter className="row">
+        <Slider {...settings}>
           {partners.map((partner, index) => (
-            <Col sm={2} md={2} lg={2} key={index}>
-              <Link className="partner-card" to={partner.imageRoute}>
-                <div className={partner.innerDivStyle}>
-                  <img src={partner.imageLink} alt={partner.name} width="100%" height="auto" />
-                </div>
-              </Link>
-            </Col>
+            <Link className="partner-card" to={partner.imageRoute} key={index}>
+              <div className={partner.innerDivStyle}>
+                <img src={partner.imageLink} alt={partner.name} width="100%" height="auto" />
+              </div>
+            </Link>
           ))}
-        </Row>
+        </Slider>
       </Container>
     </PartnerItemWrapper>
   );

--- a/src/sections/Home/Partners-home/partnerSection.style.js
+++ b/src/sections/Home/Partners-home/partnerSection.style.js
@@ -10,20 +10,21 @@ const PartnerItemWrapper = styled.section`
             margin-top: .5rem;
         }
     }
-    .row{
+    .partner-slider{
+        display: flex;
+        justify-content: center;
         flex-wrap: nowrap;
         @media(max-width: 1400px){
             flex-wrap: wrap;
         }
-
-        .col{
-              flex: 0 0 12%;
-              margin-left:0.5rem;
-              margin-right:0.5rem;
-        }
     }
-   
     a.partner-card {
+        @media(max-width: 1400px){
+            flex: 0 0 12%;
+            margin-left:0.5rem;
+            margin-right:0.5rem;
+        }
+
         &:hover {
              img  {
                 opacity: 1;


### PR DESCRIPTION
Signed-off-by: Teruaki Atake <operation.versatile.roottool@gmail.com>

**Description**

This PR fixes #3476
This PR adds an infinite carousel in the partner section.

The infinite carousel is only activated when the window width size is 1400px over.
It is not activated when the window width size is 1400px or less. The partner section shows as before.
The disabling method was taken from ["Responsive Display" in the slick docs](https://kenwheeler.github.io/slick/#:~:text=%7D\)%3B-,Responsive%20Display,-Previous).

Ref. https://github.com/layer5io/layer5/issues/3476#issuecomment-1332155290

**Screenshot**

![responsive partners](https://user-images.githubusercontent.com/11808736/205452364-20690fb6-ee5c-4826-82f2-1754349e77e1.gif)

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 


<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
