### PR TITLE
Skip meshmap video download/render for mobile view

### DIFF
--- a/src/sections/Home/Banner-4/index.js
+++ b/src/sections/Home/Banner-4/index.js
@@ -62,13 +62,15 @@ const Banner1 = () => {
               </span>
             </Container>
           </Col>
-          <Col sm={4} lg={6} className="section-title-wrapper video-col">
-            <Link to="/cloud-native-management/meshmap">
-              <video autoPlay muted loop preload="metadata" className="meshmapVideo">
-                <source src={meshmapVideo} type="video/mp4"></source>
-              </video>
-            </Link>
-          </Col>
+          {typeof window != "undefined" && window.innerWidth > 760 && (
+            <Col sm={4} lg={6} className="section-title-wrapper video-col">
+              <Link to="/cloud-native-management/meshmap">
+                <video autoPlay muted loop preload="metadata" className="meshmapVideo">
+                  <source src={meshmapVideo} type="video/mp4"></source>
+                </video>
+              </Link>
+            </Col>
+          )}
         </Row>
       </BgImage>
     </Banner1SectionWrapper>

--- a/src/sections/Meshery/Meshery-integrations/Individual-Integrations/index.js
+++ b/src/sections/Meshery/Meshery-integrations/Individual-Integrations/index.js
@@ -11,7 +11,6 @@ import RelatedIntegration from "../IntegrationsGrid";
 const IndividualIntegrations = ({ theme, data }) => {
   const { frontmatter, body } = data.mdx;
 
-  console.log(frontmatter.category);
   return (
     <IntegrationPageWrapper>
       <section className="herosection">


### PR DESCRIPTION
Signed-off-by: Nikhil-Ladha <nikhilladha1999@gmail.com>

**Description**
Avoiding the download of meshmap video in the banner for mobile view by limiting the rendering based on the `window.innerWidth` property.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
