### PR TITLE
setup github action to tweet issue/pr when 'issue/tweet' label is applied

### DIFF
--- a/.github/workflows/tweet-issue.yml
+++ b/.github/workflows/tweet-issue.yml
@@ -1,4 +1,4 @@
-name: 'Tweet issue or pr'
+name: "Tweet issue/pr when labeled"
 
 on:
   issues:
@@ -21,27 +21,26 @@ jobs:
           id: checkUserMember
           with:
             username: ${{ github.actor }}
-            team: 'Layer5'
-            GITHUB_TOKEN: ${{  secrets.GLOBAL_TOKEN }}
+            organization: "layer5"
+            team: "maintainers"
+            GITHUB_TOKEN: ${{ secrets.GLOBAL_TOKEN }}
 
-        - if: ${{ github.event_name != 'pull_request' }}
-          if: ${{ steps.checkUserMember.outputs.isTeamMember == 'true' }}
+        - if: ${{ github.event_name != 'pull_request' && steps.checkUserMember.outputs.isTeamMember == 'true' }}
           name: send a tweet for issue
           uses: ethomson/send-tweet-action@v1
           with:
             status: "Hey everyone, we need some help with this issue - ${{ github.event.issue.title }} here at : ${{ github.event.issue.html_url }} #opensource"
-            consumer-key: ${{ secrets.TWITTER_CONSUMER_API_KEY }}
-            consumer-secret: ${{ secrets.TWITTER_CONSUMER_API_SECRET }}
-            access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
-            access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+            consumer-key: ${{ secrets.TWITTER_CONSUMER_API_KEY_LAYER5 }}
+            consumer-secret: ${{ secrets.TWITTER_CONSUMER_API_SECRET_LAYER5 }}
+            access-token: ${{ secrets.TWITTER_ACCESS_TOKEN_LAYER5 }}
+            access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET_LAYER5 }}
             
-        - if: ${{ github.event_name == 'pull_request' }}
-          if: ${{ steps.checkUserMember.outputs.isTeamMember == 'true' }}
+        - if: ${{ github.event_name == 'pull_request' && steps.checkUserMember.outputs.isTeamMember == 'true' }}
           name: send a tweet for pull request
           uses: ethomson/send-tweet-action@v1
           with:
             status: "Hey everyone, we need some help with this pull request - ${{ github.event.pull_request.title }} here at : ${{ github.event.pull_request.html_url }} #opensource"
-            consumer-key: ${{ secrets.TWITTER_CONSUMER_API_KEY }}
-            consumer-secret: ${{ secrets.TWITTER_CONSUMER_API_SECRET }}
-            access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
-            access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+            consumer-key: ${{ secrets.TWITTER_CONSUMER_API_KEY_LAYER5 }}
+            consumer-secret: ${{ secrets.TWITTER_CONSUMER_API_SECRET_LAYER5 }}
+            access-token: ${{ secrets.TWITTER_ACCESS_TOKEN_LAYER5 }}
+            access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET_LAYER5 }}

--- a/.github/workflows/tweet-issue.yml
+++ b/.github/workflows/tweet-issue.yml
@@ -26,7 +26,7 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.GLOBAL_TOKEN }}
 
         - if: ${{ github.event_name != 'pull_request' && steps.checkUserMember.outputs.isTeamMember == 'true' }}
-          name: send a tweet for issue
+          name: Check if it is issue
           uses: ethomson/send-tweet-action@v1
           with:
             status: 'Help wanted on this issue: "${{ github.event.issue.title }}" - ${{ github.event.issue.html_url }} \#opensource'
@@ -36,7 +36,7 @@ jobs:
             access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET_LAYER5 }}
             
         - if: ${{ github.event_name == 'pull_request' && steps.checkUserMember.outputs.isTeamMember == 'true' }}
-          name: send a tweet for pull request
+          name: Check if it is PR
           uses: ethomson/send-tweet-action@v1
           with:
             status: 'Help wanted on this PR: "${{ github.event.pull_request.title }}" - ${{ github.event.pull_request.html_url }} \#opensource'

--- a/.github/workflows/tweet-issue.yml
+++ b/.github/workflows/tweet-issue.yml
@@ -13,7 +13,7 @@ permissions:
   
 jobs:
   tweet:
-    if: ${{ github.event.label.name == 'bug' }}
+    if: ${{ github.event.label.name == 'issue/tweet' }}
     runs-on: ubuntu-latest
     steps:
         - if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/tweet-issue.yml
+++ b/.github/workflows/tweet-issue.yml
@@ -29,7 +29,7 @@ jobs:
           name: send a tweet for issue
           uses: ethomson/send-tweet-action@v1
           with:
-            status: "Hey everyone, we need some help with this issue - ${{ github.event.issue.title }} here at : ${{ github.event.issue.html_url }} #opensource"
+            status: 'Help wanted on this issue: "${{ github.event.issue.title }}" - ${{ github.event.issue.html_url }} \#opensource'
             consumer-key: ${{ secrets.TWITTER_CONSUMER_API_KEY_LAYER5 }}
             consumer-secret: ${{ secrets.TWITTER_CONSUMER_API_SECRET_LAYER5 }}
             access-token: ${{ secrets.TWITTER_ACCESS_TOKEN_LAYER5 }}
@@ -39,7 +39,7 @@ jobs:
           name: send a tweet for pull request
           uses: ethomson/send-tweet-action@v1
           with:
-            status: "Hey everyone, we need some help with this pull request - ${{ github.event.pull_request.title }} here at : ${{ github.event.pull_request.html_url }} #opensource"
+            status: 'Help wanted on this PR: "${{ github.event.pull_request.title }}" - ${{ github.event.pull_request.html_url }} \#opensource'
             consumer-key: ${{ secrets.TWITTER_CONSUMER_API_KEY_LAYER5 }}
             consumer-secret: ${{ secrets.TWITTER_CONSUMER_API_SECRET_LAYER5 }}
             access-token: ${{ secrets.TWITTER_ACCESS_TOKEN_LAYER5 }}

--- a/.github/workflows/tweet-issue.yml
+++ b/.github/workflows/tweet-issue.yml
@@ -22,7 +22,7 @@ jobs:
           with:
             username: ${{ github.actor }}
             team: 'Layer5'
-            GITHUB_TOKEN: ${{ github.token }}
+            GITHUB_TOKEN: ${{  secrets.GLOBAL_TOKEN }}
 
         - if: ${{ github.event_name != 'pull_request' }}
           if: ${{ steps.checkUserMember.outputs.isTeamMember == 'true' }}

--- a/.github/workflows/tweet-issue.yml
+++ b/.github/workflows/tweet-issue.yml
@@ -16,21 +16,31 @@ jobs:
     if: ${{ github.event.label.name == 'issue/tweet' }}
     runs-on: ubuntu-latest
     steps:
+        - name: Check if the workflow initiater is an organization member
+          uses: tspascoal/get-user-teams-membership@v2
+          id: checkUserMember
+          with:
+            username: ${{ github.actor }}
+            team: 'Layer5'
+            GITHUB_TOKEN: ${{ github.token }}
+
         - if: ${{ github.event_name != 'pull_request' }}
+          if: ${{ steps.checkUserMember.outputs.isTeamMember == 'true' }}
           name: send a tweet for issue
           uses: ethomson/send-tweet-action@v1
           with:
-            status: "Hey everyone, checkout this issue - ${{ github.event.issue.title }} here at : ${{ github.event.issue.html_url }}"
+            status: "Hey everyone, we need some help with this issue - ${{ github.event.issue.title }} here at : ${{ github.event.issue.html_url }} #opensource"
             consumer-key: ${{ secrets.TWITTER_CONSUMER_API_KEY }}
             consumer-secret: ${{ secrets.TWITTER_CONSUMER_API_SECRET }}
             access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
             access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
             
         - if: ${{ github.event_name == 'pull_request' }}
+          if: ${{ steps.checkUserMember.outputs.isTeamMember == 'true' }}
           name: send a tweet for pull request
           uses: ethomson/send-tweet-action@v1
           with:
-            status: "Hey everyone, checkout this pull request - ${{ github.event.pull_request.title }} here at : ${{ github.event.pull_request.html_url }}"
+            status: "Hey everyone, we need some help with this pull request - ${{ github.event.pull_request.title }} here at : ${{ github.event.pull_request.html_url }} #opensource"
             consumer-key: ${{ secrets.TWITTER_CONSUMER_API_KEY }}
             consumer-secret: ${{ secrets.TWITTER_CONSUMER_API_SECRET }}
             access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}

--- a/.github/workflows/tweet-issue.yml
+++ b/.github/workflows/tweet-issue.yml
@@ -1,0 +1,37 @@
+name: 'Tweet issue or pr'
+
+on:
+  issues:
+    types: labeled
+  pull_request:
+    types: labeled 
+
+    
+permissions:
+  contents: read
+  issues: write
+  
+jobs:
+  tweet:
+    if: ${{ github.event.label.name == 'bug' }}
+    runs-on: ubuntu-latest
+    steps:
+        - if: ${{ github.event_name != 'pull_request' }}
+          name: send a tweet for issue
+          uses: ethomson/send-tweet-action@v1
+          with:
+            status: "Hey everyone, checkout this issue - ${{ github.event.issue.title }} here at : ${{ github.event.issue.html_url }}"
+            consumer-key: ${{ secrets.TWITTER_CONSUMER_API_KEY }}
+            consumer-secret: ${{ secrets.TWITTER_CONSUMER_API_SECRET }}
+            access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+            access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+            
+        - if: ${{ github.event_name == 'pull_request' }}
+          name: send a tweet for pull request
+          uses: ethomson/send-tweet-action@v1
+          with:
+            status: "Hey everyone, checkout this pull request - ${{ github.event.pull_request.title }} here at : ${{ github.event.pull_request.html_url }}"
+            consumer-key: ${{ secrets.TWITTER_CONSUMER_API_KEY }}
+            consumer-secret: ${{ secrets.TWITTER_CONSUMER_API_SECRET }}
+            access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+            access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}


### PR DESCRIPTION
**Description**

This PR fixes #3489 
Adds a github action workflow to tweet whenever 'issue/tweet' label is applied to a issue or a pull request. 

**Notes for Reviewers**
The following secrets need to be created to use this workflow:
* TWITTER_CONSUMER_API_KEY_LAYER5
* TWITTER_CONSUMER_API_SECRET_LAYER5
* TWITTER_ACCESS_TOKEN_LAYER5
* TWITTER_ACCESS_TOKEN_SECRET_LAYER5

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
