### PR TITLE
Updated the Broken Links in Newcomer's Map - Fixing Issue #3528

### DIFF
--- a/src/sections/Community/Newcomers-guide/newcomers-map.js
+++ b/src/sections/Community/Newcomers-guide/newcomers-map.js
@@ -191,7 +191,7 @@ const NewcomersMap = ({ handleMouseHover = false }) => {
         <path d="M260.94,201.87h0a6.74,6.74,0,0,1,4.85,1.93,7,7,0,0,1,1.94,5,10.75,10.75,0,0,1-8.62,10.11,9.35,9.35,0,0,1-1.48.13,6.76,6.76,0,0,1-4.86-1.93,7,7,0,0,1-1.94-5A10.76,10.76,0,0,1,259.47,202a8.19,8.19,0,0,1,1.47-.13m0-1a9.35,9.35,0,0,0-1.64.15,11.74,11.74,0,0,0-9.47,11.1,7.62,7.62,0,0,0,7.8,7.94,9.37,9.37,0,0,0,1.65-.15,11.76,11.76,0,0,0,9.45-11.09,7.61,7.61,0,0,0-7.79-7.95Z" />
         <a
           id="newcomers-guide"
-          href="https://docs.google.com/document/d/1tpg2sLxirozNt3Ofr3GdM002f9rExp74EqrsGZBU710/edit?usp=sharing"
+          href="https://layer5.io/community/handbook"
           target="_blank"
           rel="noreferrer"
         >
@@ -431,7 +431,7 @@ const NewcomersMap = ({ handleMouseHover = false }) => {
           </text>
         </Link>
         <a
-          href="https://docs.google.com/document/d/17OPtDE_rdnPQxmk2Kauhm3GwXF1R5dZ3Cj8qZLKdo5E/edit?usp=sharing"
+          href="https://layer5.io/community/handbook"
           target="_blank"
           rel="noreferrer"
         >


### PR DESCRIPTION
# The updated links are pointing to Community Handbook
https://layer5.io/community/handbook

**Description**
I Updated the Broken links in newcomer's map from 
`https://docs.google.com/document/d/17OPtDE_rdnPQxmk2Kauhm3GwXF1R5dZ3Cj8qZLKdo5E/edit?usp=sharing`
`https://docs.google.com/document/d/1tpg2sLxirozNt3Ofr3GdM002f9rExp74EqrsGZBU710/edit?usp=sharing`
TO
`https://layer5.io/community/handbook`

## As requested in this weeks website meeting.

**Notes for Reviewers**
This PR fixes # `Issue #3528`
https://github.com/layer5io/layer5/issues/3528

Signed-off-by: Yahaya Muhammad Bello <mbyahya2579@gmail.com>

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
