### PR TITLE
Updated Slick Slider Arrows for Dark mode

### DIFF
--- a/src/sections/Home/So-Special-Section/so-special-style.js
+++ b/src/sections/Home/So-Special-Section/so-special-style.js
@@ -41,7 +41,6 @@ const SoSpecialWrapper = styled.div`
         font-size: 6rem;
         display: inline-block;
         height: 3rem;
-        filter: invert(${(props) => props.theme.meshInterfaceLogoFilter});
     }
     .slick-arrow:hover:before{	
         color: ${props => props.theme.secondaryColor};


### PR DESCRIPTION
**Description**
Slick slider arrows is not clearly visible in dark mode, I fixed it.

This PR fixes # https://github.com/layer5io/layer5/issues/3568

**Notes for Reviewers**
PROBLEM
![Screenshot 2022-12-29 235228](https://user-images.githubusercontent.com/53899426/210064927-b0246f57-2277-469a-9443-b1c232cce6c0.jpg)
SOLUTION
![NEWER](https://user-images.githubusercontent.com/53899426/210064982-73716fc8-a987-4e6a-9725-f0d22cfc2d62.jpg)


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

Signed-off-by: Yahaya Muhammad Bello <mbyahya2579@gmail.com>

- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
