### PR TITLE
Made checkbox component independent of theme

### DIFF
--- a/src/sections/Projects/SMP/smp.style.js
+++ b/src/sections/Projects/SMP/smp.style.js
@@ -143,9 +143,6 @@ const SMPWrapper = styled.section`
     rect {
         fill:  ${props => props.theme.DarkTheme ? "#313131" : "#FFF7D8"};  
       }
-      path {
-        stroke: ${props => props.theme.DarkTheme ? props.theme.keppelColor : "#EBC017"};
-      }
     @media only screen and (max-width: 1024px) {
         .smp-hero{
             .hero-text{


### PR DESCRIPTION
Signed-off-by: Aditya <adityasinghboss1234@gmail.com>

I have made the necessary changes so that checkbox tick doesn't turn green in dark mode.
Dark mode: 

<img width="791" alt="image" src="https://user-images.githubusercontent.com/92062352/211294264-eb556f4d-c4dd-43ac-a841-8bcb5cfc78cf.png">

Light mode:

<img width="726" alt="image" src="https://user-images.githubusercontent.com/92062352/211294381-15448325-cbdd-480b-b1de-50662c5eae7b.png">


This PR fixes #3591 


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
