### PR TITLE
[UI] Even top-bottom padding added to the navigation cards.

### DIFF
--- a/src/sections/General/Navigation/navigation.style.js
+++ b/src/sections/General/Navigation/navigation.style.js
@@ -147,6 +147,7 @@ const NavigationWrap = styled.header`
     .nav-display {
       border-left: 2px solid ${props => props.theme.DarkTheme ? "rgb(60, 60, 60)" : "#f1f1f1"}; 
       padding-top: 1em;
+      padding-bottom: 1em;
       border-radius: 0 50px 50px 0;
       display: grid;
       grid-template-columns: 50% 50%;
@@ -260,7 +261,7 @@ const NavigationWrap = styled.header`
       line-height: 1.5rem;
       font-size: 15px;
       transition: 450ms all;
-      padding: 0px 20px 5px 20px;
+      padding: 0px 20px 0px 20px;
       cursor: pointer;
       &:before {
         content: "";


### PR DESCRIPTION
Signed-off-by: Agnivesh Chaubey <agniveshvapi@gmail.com>

**Description**
Cards inside the dropdown menu of Navigation bar does not have equal spacing on hover in desktop resolution.

This PR fixes # https://github.com/layer5io/layer5/issues/3632

**Notes for Reviewers**
The top-bottom spacing in the cards of the navigation bar was not even. Equal top-bottom padding is added in this PR.
Before:
![Screenshot (79)](https://user-images.githubusercontent.com/113545196/213612894-fab33774-950c-4df3-9f64-800268f5ef4b.png)

After:
![Screenshot (82)](https://user-images.githubusercontent.com/113545196/213612906-e8ab5f80-f470-4f8a-84d5-7e720e792178.png)




**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
