### PR TITLE
Fixed the 'Active' members icon

### DIFF
--- a/src/pages/community/members.js
+++ b/src/pages/community/members.js
@@ -209,7 +209,7 @@ const activeMember = {
   value: "active",
   color: theme.linkColor,
   isFixed: true,
-  icon: activeIcon,
+  icon: activeIcon && `url(${activeIcon})`,
   className: "allOptions",
 };
 


### PR DESCRIPTION
**Description**
The active filter should have a green dot when the [Members Page](https://layer5.io/community/members) is initially loaded

This PR fixes #3630 

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
ned my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
