### PR TITLE
disable `csp-xss` test for lighthouse-ci

### DIFF
--- a/.github/workflows/lighthouseci.yml
+++ b/.github/workflows/lighthouseci.yml
@@ -1,5 +1,6 @@
 name: lighthouseci
 on: 
+  workflow_dispatch:
   pull_request:
     paths-ignore:
       - "*.md"

--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -1,0 +1,10 @@
+module.exports = {
+    "ci": {
+      "assert": {
+        "preset": "lighthouse:no-pwa",
+        "assertions": {
+          "csp-xss": "off",
+        }
+      }
+    }
+  };


### PR DESCRIPTION
**Description**

This PR disables the [csp-xss](https://web.dev/strict-csp/) rule for the time being until it gets solved by #3695 .

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
