### PR TITLE
Disable lighthouse-ci from auditing `googlea9b1e6fb98465659.html`

### DIFF
--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -1,8 +1,8 @@
 module.exports = {
     "ci": {
       "collect": {
-        "startServerCommand": "npx http-server -p 35341",
-        "url" : " http://localhost:35341/404.html" ,
+        "staticDistDir": "./public",
+        "url" : " http://localhost/404.html" ,
       },
       "assert": {
         "preset": "lighthouse:no-pwa",

--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -1,7 +1,8 @@
 module.exports = {
     "ci": {
       "collect": {
-        "url" : " http://localhost/404.html" ,
+        "startServerCommand": "npx http-server -p 35341",
+        "url" : " http://localhost:35341/404.html" ,
       },
       "assert": {
         "preset": "lighthouse:no-pwa",

--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -2,7 +2,7 @@ module.exports = {
     "ci": {
       "collect": {
         "staticDistDir": "./public",
-        "url" : " http://localhost/404.html" ,
+        "url" : ["http://localhost/404.html" ,"http://localhost/index.html","http://localhost/404/index.html","http://localhost/about/index.html"],
       },
       "assert": {
         "preset": "lighthouse:no-pwa",

--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -1,5 +1,8 @@
 module.exports = {
     "ci": {
+      "collect": {
+        "url" : " http://localhost/404.html" ,
+      },
       "assert": {
         "preset": "lighthouse:no-pwa",
         "assertions": {


### PR DESCRIPTION
**Description**

Currently lighthouse-ci audits 5 pages including `googlea9b1e6fb98465659.html` as present [here](https://github.com/layer5io/layer5/actions/runs/4152545189/jobs/7183763662#step:6:101) giving a lot of errors for this page. This PR disables lighthouse from auditing the above page & only let it audit the other 4 pages.

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
