### PR TITLE
fix lighthouse `tap-size` test for the index page

### DIFF
--- a/src/sections/General/Footer/footer.style.js
+++ b/src/sections/General/Footer/footer.style.js
@@ -236,11 +236,23 @@ const FooterWrapper = styled.section`
 		.footer-bottom{
 			.policies {
 				text-align: center;
+				li {
+					padding: 0.125rem
+				}
 			}
 
 			li + li {
 				margin-left: 0 !important;
 				text-align: center;
+			}
+		}
+		.section-categories {
+			li {
+				margin-left: 0 !important;
+				text-align: center;
+				padding: 0.31rem 0; /* add vertical padding */
+				line-height: 1.5; /* increase the line-height */
+				text-align: left
 			}
 		}
 	}


### PR DESCRIPTION
**Description**

This PR intends to fix the lighthouse `tap-size`failed test for the home page as present [here](https://github.com/layer5io/layer5/actions/runs/4194261870/jobs/7272189271#step:6:114).

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
