### PR TITLE
fix: close mobile menu when clicked outside 

### DIFF
--- a/src/sections/General/Navigation/index.js
+++ b/src/sections/General/Navigation/index.js
@@ -225,10 +225,7 @@ const Navigation = ({ theme, themeSetter }) => {
         <Container className="nav-container">
           <div className="navbar-wrap">
             <Link to="/" className="logo">
-              <img src={theme === "dark" ? layer5dark_logo : layer5_logo} alt="Layer5 logo"
-                onClick={function () {
-                  setExpand(false); closeDropDown();
-                }}/>
+              <img src={theme === "dark" ? layer5dark_logo : layer5_logo} alt="Layer5 logo" />
             </Link>
             <nav className="nav">
               {expand ?

--- a/src/sections/General/Navigation/index.js
+++ b/src/sections/General/Navigation/index.js
@@ -186,6 +186,20 @@ const Navigation = ({ theme, themeSetter }) => {
   };
 
   const dropDownRef = useRef();
+  const navWrapRef = useRef();
+
+  useEffect(() => {
+    const outsideClickHandler = (e) => {
+      if (expand && navWrapRef.current && !navWrapRef.current.contains(e.target)){
+        setExpand(false);
+        closeDropDown();
+      }
+    };
+    expand && document.addEventListener("click", outsideClickHandler);
+    return () => {
+      document.removeEventListener("click", outsideClickHandler);
+    };
+  }, [expand]);
   useEffect(() => {
     window.addEventListener("scroll", () =>
       window.pageYOffset > 50 ? setScroll(true) : setScroll(false)
@@ -207,11 +221,14 @@ const Navigation = ({ theme, themeSetter }) => {
   return (
 
     <ThemeProvider theme={theme === "dark" ? darktheme : lighttheme}>
-      <NavigationWrap className={`nav-block ${scroll ? "scrolled" : ""}`}>
+      <NavigationWrap className={`nav-block ${scroll ? "scrolled" : ""}`} ref={navWrapRef}>
         <Container className="nav-container">
           <div className="navbar-wrap">
             <Link to="/" className="logo">
-              <img src={theme === "dark" ? layer5dark_logo : layer5_logo} alt="Layer5 logo" />
+              <img src={theme === "dark" ? layer5dark_logo : layer5_logo} alt="Layer5 logo"
+                onClick={function () {
+                  setExpand(false); closeDropDown();
+                }}/>
             </Link>
             <nav className="nav">
               {expand ?


### PR DESCRIPTION
**Description**

This PR fixes #3761 

**Notes for Reviewers**

- Close mobile menu when clicked outside
- Close mobile menu when clicked on `Layer5` logo

### Before
https://user-images.githubusercontent.com/116095538/219590314-d9dc2247-bab6-45b1-b61d-e2c46c5217c0.mp4

### After
https://user-images.githubusercontent.com/116095538/219590399-18e71294-1dd3-433d-9d9f-7c4e8c427ce5.mp4



**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
