### PR TITLE
fix lighthouse `unsized-images` test for the index page

### DIFF
--- a/src/sections/Home/Partners-home/index.js
+++ b/src/sections/Home/Partners-home/index.js
@@ -23,7 +23,7 @@ const Projects = () => {
             <Col sm={2} md={2} lg={2} key={index}>
               <Link className="partner-card" to={partner.imageRoute}>
                 <div className={partner.innerDivStyle}>
-                  <img loading="lazy" src={partner.imageLink} alt={partner.name} width="100%" height="auto" />
+                  <img loading="lazy" src={partner.imageLink} alt={partner.name} width={partner.imageWidth} height={partner.imageHeight} />
                 </div>
               </Link>
             </Col>

--- a/src/sections/Home/Partners-home/partners-home-data.js
+++ b/src/sections/Home/Partners-home/partners-home-data.js
@@ -15,54 +15,74 @@ export const partners = [
     name: "Redhat",
     imageLink: redhat,
     imageRoute: "/partners#redhat",
-    innerDivStyle: "partner__block__inner horizontal"
+    innerDivStyle: "partner__block__inner horizontal",
+    imageHeight: 90,
+    imageWidth: 382
   }, {
     name: "Intel",
     imageLink: intel,
     imageRoute: "/partners#intel",
-    innerDivStyle: "partner__block__inner"
+    innerDivStyle: "partner__block__inner",
+    imageHeight: 533,
+    imageWidth: 809
 
   }, {
     name: "University of Texas at Austin partnership with Layer5",
     imageLink: utaustin,
     imageRoute: "/partners#utaustin",
-    innerDivStyle: "partner__block__inner horizontal"
+    innerDivStyle: "partner__block__inner horizontal",
+    imageHeight: 78,
+    imageWidth: 278
   }, {
     name: "Citrix",
     imageLink: citrix,
     imageRoute: "/partners#Citrix",
-    innerDivStyle: "partner__block__inner"
+    innerDivStyle: "partner__block__inner",
+    imageHeight: 144,
+    imageWidth: 144
   }, {
     name: "Hashicorp partnership with Layer5",
     imageLink: hashicorp,
     imageRoute: "/company/news/layer5-and-hashicorp-launch-service-mesh-partnership",
-    innerDivStyle: "partner__block__inner"
+    innerDivStyle: "partner__block__inner",
+    imageHeight: 113,
+    imageWidth: 113
   }, {
     name: "Hewlett-Packard Enterprise",
     imageLink: hpe,
     imageRoute: "/partners#hpe",
-    innerDivStyle: "partner__block__inner"
+    innerDivStyle: "partner__block__inner",
+    imageHeight: 69,
+    imageWidth: 178
   }, {
     name: "National Institute of Technology Karnataka",
     imageLink: nitk,
     imageRoute: "/partners#nitk",
-    innerDivStyle: "partner__block__inner"
+    innerDivStyle: "partner__block__inner",
+    imageHeight: 433,
+    imageWidth: 409
   }, {
     name: "Rackspace Technology",
     imageLink: rackspace,
     imageRoute: "/partners#rackspace",
-    innerDivStyle: "partner__block__inner"
+    innerDivStyle: "partner__block__inner",
+    imageHeight: 124,
+    imageWidth: 400
 
   }, {
     name: "UEM",
     imageLink: uem,
     imageRoute: "/partners#uem",
-    innerDivStyle: "partner__block__inner"
+    innerDivStyle: "partner__block__inner",
+    imageHeight: 164,
+    imageWidth: 302
   }, {
     name: "VMware",
     imageLink: vmware,
     imageRoute: "/partners#VMware",
     innerDivStyle: "partner__block__inner",
+    imageHeight: 31,
+    imageWidth: 190
   }
 
 ];

--- a/src/sections/Home/Projects-home/projectSection.style.js
+++ b/src/sections/Home/Projects-home/projectSection.style.js
@@ -74,10 +74,11 @@ const ProjectItemWrapper = styled.section`
         }
 
         img{
-            height: 40px ; 
+            height: 40px; 
         }
         .gatsby-image-wrapper{
             margin: 10px auto; 
+            min-height: 40px;
         }
     }
     .description {

--- a/src/sections/Home/Projects-home/projectSection.style.js
+++ b/src/sections/Home/Projects-home/projectSection.style.js
@@ -75,7 +75,6 @@ const ProjectItemWrapper = styled.section`
 
         img{
             height: 40px ; 
-            width: auto ;
         }
         .gatsby-image-wrapper{
             margin: 10px auto; 

--- a/src/sections/Home/Projects-home/projectSection.style.js
+++ b/src/sections/Home/Projects-home/projectSection.style.js
@@ -78,8 +78,7 @@ const ProjectItemWrapper = styled.section`
             width: auto ;
         }
         .gatsby-image-wrapper{
-            margin: 10px auto;
-            min-height: 40px;
+            margin: 10px auto; 
         }
     }
     .description {


### PR DESCRIPTION
**Description**

This PR fixes the failing lighthouse `unsized-images` test for the index/home page as seen [here](https://github.com/layer5io/layer5/actions/runs/4206205144/jobs/7299370862#step:6:123).

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
