### PR TITLE
fix GitHub logo for dark mode

### DIFF
--- a/src/pages/cloud-native-management/meshery/operating-service-meshes.js
+++ b/src/pages/cloud-native-management/meshery/operating-service-meshes.js
@@ -16,6 +16,7 @@ import Smi from "../../../assets/images/app/projects/smi.svg";
 import WebA from "../../../sections/Meshery/How-meshery-works/images/webassembly_logo.svg";
 import SMP from "../../../sections/Meshery/How-meshery-works/images/smp-dark-text.png";
 import dark_githubLogo from "../../../assets/images/socialIcons/github_black.svg";
+import light_githubLogo from "../../../assets/images/socialIcons/github-light.svg";
 
 import { darktheme } from "../../../theme/app/themeStyles";
 import lighttheme from "../../../theme/app/themeStyles";
@@ -46,7 +47,7 @@ const OperatingServiceMeshes = () => {
             [
               {
                 title: "GitOps: Configuration as Visual Design",
-                icon: dark_githubLogo,
+                icon: theme === "dark" ? light_githubLogo : dark_githubLogo,
                 description: <p>GitOps is a way to define workflows for declarative configuration using Git. Meshery greatly simplifies configuring and managing cloud native infrastructure at-scale across multiple clusters with a git-integrated experience.</p>
               },
               {

--- a/src/sections/Home/Projects-home/index.js
+++ b/src/sections/Home/Projects-home/index.js
@@ -44,7 +44,7 @@ const Projects = () => {
             <Col sm={12} md={6} lg={3}>
               <Link className="project-card" to="/cloud-native-management/meshmap">
                 <div className="project__block__inner">
-                  <StaticImage loading="lazy" src={meshmapLogo} alt="MeshMap Logo" width={50} height={80} imgStyle={{ width: "35px", height: "56px"}} />
+                  <StaticImage loading="lazy" src={meshmapLogo} alt="MeshMap Logo" width={50} height={80} imgStyle={{ width: "35px", height: "56px" }} />
                   <h3>MeshMap</h3>
                   <p>Visual Infrastructure Management</p>
                 </div>
@@ -53,7 +53,7 @@ const Projects = () => {
             <Col sm={12} md={6} lg={3}>
               <Link className="project-card" to="/cloud-native-management/meshery">
                 <div className="project__block__inner">
-                  <StaticImage loading="lazy" src={projectImage3} alt="Meshery Logo"  width={80} height={80} imgStyle={{ width: "40px", height: "40px"}} />
+                  <StaticImage loading="lazy" src={projectImage3} alt="Meshery Logo"  width={80} height={80} imgStyle={{ width: "40px", height: "40px" }} />
                   <h3>Meshery</h3>
                   <p>Cloud Native Management</p>
                 </div>
@@ -62,7 +62,7 @@ const Projects = () => {
             <Col sm={12} md={6} lg={3}>
               <Link className="project-card" to="/projects/service-mesh-performance">
                 <div className="project__block__inner">
-                  <StaticImage loading="lazy" src={projectImage2} alt="SMP Logo" width={294} height={120} imgStyle={{ width: "98px", height: "40px"}} />
+                  <StaticImage loading="lazy" src={projectImage2} alt="SMP Logo" width={294} height={120} imgStyle={{ width: "98px", height: "40px" }} />
                   <h3>Service Mesh Performance</h3>
                   <p>The Measurement Standard</p>
                 </div>
@@ -71,7 +71,7 @@ const Projects = () => {
             <Col sm={12} md={6} lg={3}>
               <Link className="project-card" to="/projects/nighthawk">
                 <div className="project__block__inner">
-                  <StaticImage loading="lazy" src={projectImage4} alt="Nighthawk Logo" width={100} height={80} imgStyle={{ width: "50px", height: "40px"}}/>
+                  <StaticImage loading="lazy" src={projectImage4} alt="Nighthawk Logo" width={100} height={80} imgStyle={{ width: "50px", height: "40px" }}/>
                   <h3>Nighthawk</h3>
                   <p>Distributed Performance Management</p>
                 </div>


### PR DESCRIPTION
**Description**

This PR fixes #3785 

**Notes for Reviewers**

Before
![Screen Shot 2023-02-20 at 6 13 40 PM](https://user-images.githubusercontent.com/36399086/220112134-eac051b6-11b7-4f6d-8416-70c33193ad77.png)

After
![Screen Shot 2023-02-20 at 6 11 50 PM](https://user-images.githubusercontent.com/36399086/220111410-896eb66f-828b-4b0f-9cbc-5f06b938374a.png)

I used only the existing assets. However, the light logo seems to be a bit larger. Need advice on this.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
