### PR TITLE
fix lighthouse `unsized img` test for index page

### DIFF
--- a/src/sections/Home/Partners-home/index.js
+++ b/src/sections/Home/Partners-home/index.js
@@ -44,7 +44,7 @@ const Projects = () => {
         {partners.map((partner, index) => (
           <Link className="partner-card" to={partner.imageRoute} key={index}>
             <div className={partner.innerDivStyle}>
-              <img className="partner-image" src={partner.imageLink} alt={partner.name} width="100%" height="auto" />
+              <img className="partner-image" src={partner.imageLink} alt={partner.name} width={partner.imageWidth} height={partner.imageHeight} />
             </div>
           </Link>
         ))}


### PR DESCRIPTION
**Description**

This PR fixes the failing `unsized img` test for the index page as seen [here](https://github.com/layer5io/layer5/actions/runs/4275953578/jobs/7443700378#step:6:266) which was re-introduced after PR #3728 .

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
