### PR TITLE
fix lighthouse `color-contrast` test for about page

### DIFF
--- a/src/sections/Company/About/about.style.js
+++ b/src/sections/Company/About/about.style.js
@@ -108,10 +108,12 @@ const AboutSectionWrapper = styled.section`
   }
   .section-title{
     #contact{
-      color:white;
-      :hover{
-        color:black;
-      }
+      background: ${props => props.theme.highlightColor}; 
+
+      &:hover {
+            background: ${props => props.theme.highlightLightColor}; 
+            box-shadow: ${props => props.theme.DarkTheme ? "rgb(255 255 255 / 40%)" : "rgb(0 0 0 / 40%)"} 0px 2px 10px;
+        }
     }
   }
   #mapBack {

--- a/src/sections/Company/Layer5-statement/statement.style.js
+++ b/src/sections/Company/Layer5-statement/statement.style.js
@@ -58,7 +58,7 @@ const BannerSectionWrapper = styled.section`
     }
     .section-title {
         padding: 3rem 8rem;
-        background: linear-gradient(123deg, #00B39F 60%, #100C0C 100%);
+        background: linear-gradient(123deg, #00B39F 60%, #0F1212 100%);
     }
     .svg-background {
         position: absolute;

--- a/src/sections/Company/Layer5-statement/statement.style.js
+++ b/src/sections/Company/Layer5-statement/statement.style.js
@@ -28,7 +28,7 @@ const BannerSectionWrapper = styled.section`
         margin-bottom: 1rem;
     }
     h3.statement {
-        color: ${(props) => props.theme.secondaryLightColor};
+        color: ${(props) => props.theme.white};
         margin-left: 3.5rem;
         text-indent: -3.5rem;
         margin-bottom: 2rem;

--- a/src/sections/Company/Layer5-statement/statement.style.js
+++ b/src/sections/Company/Layer5-statement/statement.style.js
@@ -58,7 +58,7 @@ const BannerSectionWrapper = styled.section`
     }
     .section-title {
         padding: 3rem 8rem;
-        background: #00b39f;
+        background: linear-gradient(123deg, #00B39F 60%, #100C0C 100%);
     }
     .svg-background {
         position: absolute;

--- a/src/sections/Company/Stewards-of-industry/stewards.style.js
+++ b/src/sections/Company/Stewards-of-industry/stewards.style.js
@@ -34,8 +34,12 @@ const BannerSectionWrapper = styled.section`
     padding: 0 20rem 1.5rem 20rem;
   }
   .section-button {
-    font-weight: 600;
-    color: ${props => props.theme.DarkTheme ? "black" : "white"};
+    background: ${props => props.theme.highlightColor}; 
+
+    &:hover {
+          background: ${props => props.theme.highlightLightColor}; 
+          box-shadow: ${props => props.theme.DarkTheme ? "rgb(255 255 255 / 40%)" : "rgb(0 0 0 / 40%)"} 0px 2px 10px;
+      }
     margin-bottom: -15rem;
   }
   @media only screen and (max-width: 1224px) {


### PR DESCRIPTION
**Description**

This PR fixes the failing `color-contrast` test for the about page as seen [here](https://github.com/layer5io/layer5/actions/runs/4282310945/jobs/7456426349#step:6:248).

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
