### PR TITLE
fix lighthouse `color-contrast` audit for home page

### DIFF
--- a/src/sections/Company/Cloud-Native/cloud-native.style.js
+++ b/src/sections/Company/Cloud-Native/cloud-native.style.js
@@ -57,11 +57,11 @@ const CloudNativeWrapper = styled.div`
 
     }
     .btn-cont button{
-        color:${props => props.theme.DarkTheme ? "black" : "white"};
+        color:black;
     }
     .btn-cont button:hover{
-        color:${props => props.theme.DarkTheme ? "white" : "black"};
-        box-shadow:0 2px 10px rgba(0,0,0,0.4);
+        color:white;
+        box-shadow: rgb(255 255 255 / 40%) 0px 2px 10px;
     }
     
     @media only screen and (max-width:1220px)

--- a/src/sections/General/Footer/footer.style.js
+++ b/src/sections/General/Footer/footer.style.js
@@ -102,7 +102,13 @@ const FooterWrapper = styled.section`
 
 		button {
 			height: 3.5rem;
-			color: black;
+			color: white;
+			background: linear-gradient(123deg, #00b39f 60%, #00b39f 100%);
+			font-weight: 510;
+			:hover{
+                color: white;
+                box-shadow: white 0px 2px 10px;
+			}
 		}
 	}
 

--- a/src/sections/General/Footer/footer.style.js
+++ b/src/sections/General/Footer/footer.style.js
@@ -180,7 +180,7 @@ const FooterWrapper = styled.section`
 
 			button {
 				min-width: 8rem;
-				color: black;
+				color: white;
 			}
 		}
 	}
@@ -228,7 +228,7 @@ const FooterWrapper = styled.section`
 
 			button {
 				min-width: 6rem;
-				color: black;
+				color: white;
 			}
 		}
 	}

--- a/src/sections/General/Footer/footer.style.js
+++ b/src/sections/General/Footer/footer.style.js
@@ -104,7 +104,6 @@ const FooterWrapper = styled.section`
 			height: 3.5rem;
 			color: white;
 			background: linear-gradient(123deg, #00b39f 60%, #00b39f 100%);
-			font-weight: 510;
 			:hover{
                 color: white;
                 box-shadow: white 0px 2px 10px;

--- a/src/sections/Home/CloudNativeManagement/statement.style.js
+++ b/src/sections/Home/CloudNativeManagement/statement.style.js
@@ -62,6 +62,12 @@ const BannerSectionWrapper = styled.section`
 
         }
     }
+    .join-community-button {
+        :hover{
+            color: white;
+            box-shadow:  rgb(0 0 0 / 60%) 0px 2px 10px;
+        }
+    }
     .demo {
         color:${props => props.theme.offWhiteColor};
         margin-bottom: 1rem;
@@ -82,7 +88,7 @@ const BannerSectionWrapper = styled.section`
     }
     .section-title {
         padding: 3rem 8rem;
-        background: #00b39f;
+        background: linear-gradient(123deg, #00B39F 60%, #1f2424 100%);
     }
     .svg-background {
         position: absolute;

--- a/src/sections/Home/Partners-home/partnerSection.style.js
+++ b/src/sections/Home/Partners-home/partnerSection.style.js
@@ -5,7 +5,7 @@ const PartnerItemWrapper = styled.section`
     overflow: hidden;
     .section-title{
         h4{
-            color: ${props => props.theme.DarkTheme ? "#737373" : "#b3b3b3"};
+            color: ${props => props.theme.DarkTheme ? "#737373" : "#4c4a4a"};
             text-align: center;
             margin-top: .5rem;
         }

--- a/src/sections/Home/Projects-home/projectSection.style.js
+++ b/src/sections/Home/Projects-home/projectSection.style.js
@@ -52,7 +52,7 @@ const ProjectItemWrapper = styled.section`
     .project__block__inner { 
         display: flex;
         flex-direction: column;
-        background: ${props => props.theme.DarkTheme ? "#212121" : "#FFFFFF"};
+        background: ${props => props.theme.DarkTheme ? "#212121" : "linear-gradient(123deg, white 60%, white 100%)"};
         box-shadow: 0px 0px ${props => props.theme.projectShadowsize} ${props => props.theme.DarkTheme ? "#00D3A9" : "#E6E6E6"};
         &:hover{
             box-shadow: 0px 0px 5px ${props => props.theme.DarkTheme ? "#FFFFFF" : "#3c494f"};
@@ -82,6 +82,9 @@ const ProjectItemWrapper = styled.section`
             margin: 10px auto;
             min-height: 40px;
         }
+    }
+    .banner-btn {
+        background: linear-gradient(123deg, #00b39f 60%, #00b39f 100%);
     }
     .description {
         padding: 1rem;

--- a/src/sections/Home/Service-mesh-focussed/service-mesh-focussed.style.js
+++ b/src/sections/Home/Service-mesh-focussed/service-mesh-focussed.style.js
@@ -62,6 +62,9 @@ const MeshFocusWrapper = styled.div`
     .book_btn{
        padding-right: 3rem;
        text-align: center;
+       :hover{
+        color: white;
+        box-shadow: ${props => props.theme.DarkTheme ? " rgb(255 255 255 / 40%)" : " rgb(0 0 0 / 40%)"} 0px 2px 10px;
     }
     .icon-right{
         position: relative;

--- a/src/sections/Home/So-Special-Section/so-special-style.js
+++ b/src/sections/Home/So-Special-Section/so-special-style.js
@@ -87,7 +87,7 @@ const SoSpecialWrapper = styled.div`
         padding:2rem;
         text-align:center; 
         p{
-            color:#b3b3b3;
+            color:#5e5e5e;
             padding:2rem 0;
             font-size: 1.5rem;
         }
@@ -148,10 +148,11 @@ const SoSpecialWrapper = styled.div`
         }
         .so-special-foot-btn
         {
-            color:${props => props.theme.DarkTheme ? "black" : "white"};
+            color: black;
             margin:2rem;
             :hover{
-                color:${props => props.theme.DarkTheme ? "white" : "black"};
+                color: white;
+                box-shadow: ${props => props.theme.DarkTheme ? " rgb(255 255 255 / 40%)" : " rgb(0 0 0 / 40%)"} 0px 2px 10px;
             }
         }
     }

--- a/src/sections/subscribe/subscribe.style.js
+++ b/src/sections/subscribe/subscribe.style.js
@@ -13,6 +13,7 @@ const SubscribeWrapper = styled.div`
     }
     h2 span{
         color:${props => props.theme.secondaryColor};
+        background: ${props => props.theme.DarkTheme ? "#1D1D1D" : "linear-gradient(123deg, white 60%, white 100%)"};
     }
     
     input{
@@ -33,10 +34,11 @@ const SubscribeWrapper = styled.div`
     }
     #mc-embedded-subscribe{
         margin: 1.5rem 0.3125rem 0;
+        background: linear-gradient(123deg, #00b39f 60%, #00b39f 100%);
+        font-weight: 510;
     }
     #mc-embedded-subscribe:hover{
-        color:black;
-        box-shadow:0 2px 10px rgba(0,0,0,0.4);
+        box-shadow: ${props => props.theme.DarkTheme ? "rgb(255 255 255 / 40%)" : "rgb(0 0 0 / 40%)"} 0px 2px 10px;
     }
     @media only screen and (max-width: 1050px) {
         .email-cont{

--- a/src/sections/subscribe/subscribe.style.js
+++ b/src/sections/subscribe/subscribe.style.js
@@ -35,7 +35,6 @@ const SubscribeWrapper = styled.div`
     #mc-embedded-subscribe{
         margin: 1.5rem 0.3125rem 0;
         background: linear-gradient(123deg, #00b39f 60%, #00b39f 100%);
-        font-weight: 510;
     }
     #mc-embedded-subscribe:hover{
         box-shadow: ${props => props.theme.DarkTheme ? "rgb(255 255 255 / 40%)" : "rgb(0 0 0 / 40%)"} 0px 2px 10px;


### PR DESCRIPTION
**Description**

This PR fixes the failing lighthouse-ci `color-contrast` test for the index page as reported [here](https://github.com/layer5io/layer5/actions/runs/4296451595/jobs/7488190132#step:6:87).

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
