### PR TITLE
fixed margin issue in mobile screen on coverage and press-release buttons

### DIFF
--- a/src/sections/Company/News-grid/NewsGrid.style.js
+++ b/src/sections/Company/News-grid/NewsGrid.style.js
@@ -13,20 +13,23 @@ export const NewsPageWrapper = styled.div`
         width: 100%;
         justify-content: start;
         margin-bottom: 3rem;
+        flex-wrap: wrap;
+        justify-content: start;
         @media only screen and (max-width:990px){
-                
             justify-content: center;
-        
-    }
+        }
+      
     }
     .press-release-button{
-        margin-left: 3rem;
+        // when in desktop screen size, the press-release btn is sperated by 1rem space
+        margin-left: 1rem;
         background : rgb(240, 240, 240);
         border-radius: 5px;
         color: black;
         &:hover{
         box-shadow: 0 2px 10px ${props => props.theme.DarkTheme ? "rgba(0, 179, 159, 1.0)" : "rgba(0, 0, 0, 0.5)"};
         }
+      
     }   
     .coverage-button {
         background : rgb(240, 240, 240);
@@ -36,16 +39,30 @@ export const NewsPageWrapper = styled.div`
             box-shadow: 0 2px 10px ${props => props.theme.DarkTheme ? "rgba(0, 179, 159, 1.0)" : "rgba(0, 0, 0, 0.4)"};
             }
     }
+
+
+    // Media Query on coverage and press-release buttons for small screen devices 
+        
+        @media only screen and (max-width:450px) and (min-width: 0px){ 
+        .coverage-button,  .press-release-button {
+            margin: 1rem 0;
+            }  
+        } 
+        
+        @media only screen and (max-width:990px){
+           .coverage-button, .press-release-button{
+                margin: 1rem calc(3% / 2);
+           } 
+        }
     
     .filter-buttons {
         display: flex;
         @media only screen and (max-width:990px){
             display:block;
-        
-    }
+        }
     }
     .search-box-container {
-        width: 35%;
+        width: 0 calc(3% / 2);
     }
     
     .post-content-block {
@@ -66,10 +83,10 @@ export const NewsPageWrapper = styled.div`
         .searchBox{
             flex:0 0 50%;
             @media only screen and (max-width:990px){
-                
                     flex:0 0 100%;
                     max-width:100%;
                     margin-bottom: 1.8rem;
+                    justify-content: center;
                 
             }
         }


### PR DESCRIPTION
**Description**

Earlier coverage and Press-release buttons were touching the borders of the page when "/company/news" page was viewed on mobile screens. 

This PR fixes ##3813

In this PR following changes have been made: - 

1. Class button container can now flex-wrap, which allows both the buttons to be in column orientation when there is not enough space for  both of them to be in a single row
2. Added separate CSS rules, for normal and small mobile screens specifying the margins. 
3. No static sizing is used, therefore buttons are responsive in every screen size. 

Following are the screenshots of various screen sizes : 

**1. Desktop Size**
<img width="1074" alt="Screenshot 2023-03-01 at 1 42 31 PM" src="https://user-images.githubusercontent.com/50709505/222086634-af04297f-bddf-47d2-b0ef-fbac49c207e6.png">

**2. Normal Mobile Screen** 

<img width="466" alt="Screenshot 2023-03-01 at 1 42 48 PM" src="https://user-images.githubusercontent.com/50709505/222086719-6942527b-858c-4eb2-87e6-6eefe7dd3803.png">

**3. Small Mobile Screen**
<img width="466" alt="Screenshot 2023-03-01 at 1 42 58 PM" src="https://user-images.githubusercontent.com/50709505/222086826-7349ad5a-a4a8-464c-888f-38f9bfcffa79.png">

**4. Foldable Mobiles** 
<img width="466" alt="Screenshot 2023-03-01 at 1 43 05 PM" src="https://user-images.githubusercontent.com/50709505/222086942-27214469-5e8b-437b-833c-26b53e9e8026.png">


**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
6. Build and test your changes before submitting a PR. 
7. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
