### PR TITLE
Partners-home: added support for react slider dots (partner section) : dark mode w/s…

### DIFF
--- a/src/sections/Home/Partners-home/partnerSection.style.js
+++ b/src/sections/Home/Partners-home/partnerSection.style.js
@@ -22,6 +22,12 @@ const PartnerItemWrapper = styled.section`
             flex-wrap: wrap;
         }
     }
+		.slick-dots li button:before{
+			color: ${props => props.theme.DarkTheme ? "#939393" : ""}
+		}
+		.slick-dots li.slick-active button:before {
+				color: ${props => props.theme.DarkTheme ? "white" : ""};
+		}
     a.partner-card {
         @media(max-width: 1400px){
             flex: 0 0 12%;

--- a/src/sections/Home/Partners-home/partnerSection.style.js
+++ b/src/sections/Home/Partners-home/partnerSection.style.js
@@ -28,6 +28,9 @@ const PartnerItemWrapper = styled.section`
 		.slick-dots li.slick-active button:before {
 				color: ${props => props.theme.DarkTheme ? "white" : ""};
 		}
+		.slick-dots li button:hover{
+				box-shadow: none;
+		}
     a.partner-card {
         @media(max-width: 1400px){
             flex: 0 0 12%;


### PR DESCRIPTION
…ignoff

**Description**

This PR fixes #3830

**Notes for Reviewers**
### Before
* in dark mode, the Partner section dots were not visible because the color was set to dark gray/black same as in light mode
### After 
* changed the color to white for the active dot and the remaining dots to the #939393 color
------------------
* Below I am attaching a video showing the output of this PR



**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
 - [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->

[Layer5 - Partner Section PR](https://user-images.githubusercontent.com/88551650/222546168-b6d061f2-9a12-4eba-901a-68bae5a1ad0c.webm)

