### PR TITLE
updated node version in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Node.js version: 14, 12, 10
-ARG VARIANT=14
+# [Choice] Node.js version: 18, 14, 12, 10
+ARG VARIANT=18
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,8 @@
 	"name": "Node.js",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick a Node version: 10, 12, 14
-		"args": { "VARIANT": "14" }
+		// Update 'VARIANT' to pick a Node version: 10, 12, 14, 18
+		"args": { "VARIANT": "18" }
 	},
 
 	// Set *default* container specific settings.json values on container create.


### PR DESCRIPTION
**Description**

This PR fixes #3903

**Notes for Reviewers**
Previously the node version specified in the devcontainer was v14. But according to Gatsby's documentation node v18 or newer is required. Here is a screenshot from the gatsby documentation.

<br>

![gatsby-docs](https://user-images.githubusercontent.com/88551650/223078353-79d1acf3-a0f2-4112-92a9-3d1122cdc2a3.png)

<br>

[Gatsby docs link](https://www.gatsbyjs.com/docs/tutorial/part-0/)

In this pull request, I updated the node version to 18 so that gatsby can work properly.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
