### PR TITLE
fix lighthouse `offscreen-img` test for home page

### DIFF
--- a/src/sections/Company/Cloud-Native/index.js
+++ b/src/sections/Company/Cloud-Native/index.js
@@ -16,7 +16,7 @@ const CloudNativeLeaders = () => {
           <p>
             From the beginning Layer5 actively engaged in leadership roles in CNCF initiatives and projects.
           </p>
-          <img src={cncf} alt="Cloud Native-logo" />
+          <img src={cncf} alt="Cloud Native-logo" loading="lazy" />
           <p>Commissioned by the CNCF.</p>
         </div>
 

--- a/src/sections/Home/CloudNativeManagement/index.js
+++ b/src/sections/Home/CloudNativeManagement/index.js
@@ -20,7 +20,7 @@ const BannerDefault = () => {
             <div className="left">
               <div className="left-child">
                 <div className="svg-background">
-                  <img src={svgBackground} alt="background" />
+                  <img src={svgBackground} alt="background" loading="lazy"/>
                 </div>
                 <SectionTitle
                   className="section-title"
@@ -56,7 +56,7 @@ const BannerDefault = () => {
               url="https://youtu.be/Do7htKrRzDA"
               playing
               controls
-              light={imgHero}
+              light={< img src={imgHero} loading="lazy" />}
               width="auto"
               height="100%"
               style={{ margin: "auto" }}

--- a/src/sections/Home/CloudNativeManagement/index.js
+++ b/src/sections/Home/CloudNativeManagement/index.js
@@ -56,7 +56,7 @@ const BannerDefault = () => {
               url="https://youtu.be/Do7htKrRzDA"
               playing
               controls
-              light={< img className="imgHero" src={imgHero} loading="lazy" alt="meshmap designer" width="auto" height="100%" />}
+              light={< img className="imgHero" src={imgHero} loading="lazy" alt="meshmap designer" width="100%" height="100%" />}
               width="auto"
               height="100%"
               style={{ margin: "auto" }}

--- a/src/sections/Home/CloudNativeManagement/index.js
+++ b/src/sections/Home/CloudNativeManagement/index.js
@@ -56,7 +56,7 @@ const BannerDefault = () => {
               url="https://youtu.be/Do7htKrRzDA"
               playing
               controls
-              light={< img src={imgHero} loading="lazy" />}
+              light={< img src={imgHero} loading="lazy" alt="meshmap designer" />}
               width="auto"
               height="100%"
               style={{ margin: "auto" }}

--- a/src/sections/Home/CloudNativeManagement/index.js
+++ b/src/sections/Home/CloudNativeManagement/index.js
@@ -56,7 +56,7 @@ const BannerDefault = () => {
               url="https://youtu.be/Do7htKrRzDA"
               playing
               controls
-              light={< img src={imgHero} loading="lazy" alt="meshmap designer" />}
+              light={< img className="imgHero" src={imgHero} loading="lazy" alt="meshmap designer" width="auto" height="100%" />}
               width="auto"
               height="100%"
               style={{ margin: "auto" }}


### PR DESCRIPTION
**Description**

This PR fixes the failing lighthouse-ci `offscreen-img` test for the home page as seen [here](https://github.com/layer5io/layer5/actions/runs/4396115569/jobs/7698357203#step:6:96)

**Notes for Reviewers**
The changes should be first checked in the safari browser before merging this pr

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
