### PR TITLE
Enable lighthouse-ci audit on more pages

### DIFF
--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -6,8 +6,8 @@ module.exports = {
                  "http://localhost/index.html",
                  "http://localhost/404/index.html",
                  "http://localhost/about/index.html" ,
-                 "http://localhost/cloud-native-management/mesher/index.html",
-                 "http://localhost/cloud-native-management/mesher/index.html"],
+                 "http://localhost/cloud-native-management/meshery/index.html",
+                 "http://localhost/cloud-native-management/meshmap/index.html"],
       },
       "assert": {
         "preset": "lighthouse:no-pwa",

--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -2,7 +2,12 @@ module.exports = {
     "ci": {
       "collect": {
         "staticDistDir": "./public",
-        "url" : ["http://localhost/404.html" ,"http://localhost/index.html","http://localhost/404/index.html","http://localhost/about/index.html"],
+        "url" : ["http://localhost/404.html",
+                 "http://localhost/index.html",
+                 "http://localhost/404/index.html",
+                 "http://localhost/about/index.html" ,
+                 "http://localhost/cloud-native-management/mesher/index.html",
+                 "http://localhost/cloud-native-management/mesher/index.html"],
       },
       "assert": {
         "preset": "lighthouse:no-pwa",

--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -7,12 +7,15 @@ module.exports = {
                  "http://localhost/404/index.html",
                  "http://localhost/about/index.html" ,
                  "http://localhost/cloud-native-management/meshery/index.html",
-                 "http://localhost/cloud-native-management/meshmap/index.html"],
+                 "http://localhost/cloud-native-management/meshmap/index.html",
+                 "http://localhost/learn/index.html",
+                 "http://localhost/community/index.html"],
       },
       "assert": {
         "preset": "lighthouse:no-pwa",
         "assertions": {
           "csp-xss": "off",
+          "aria-hidden-focus": "off"
         }
       }
     }


### PR DESCRIPTION
**Description**

This PR enables lighthouse-ci audit on 4 more pages which are :
* `meshery`
* `meshmap`
* `community`
* `learn`

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
