### PR TITLE
fix lighthouse `heading-order` test for meshmap page

### DIFF
--- a/src/components/CommonForm/commonForm.style.js
+++ b/src/components/CommonForm/commonForm.style.js
@@ -41,6 +41,9 @@ margin: 1rem;
     text-align: center;
     background-color: ${props => props.theme.secondaryColor};
     color: white;
+    h2 {
+      
+    }
   }
 
 .form{

--- a/src/components/CommonForm/commonForm.style.js
+++ b/src/components/CommonForm/commonForm.style.js
@@ -41,9 +41,6 @@ margin: 1rem;
     text-align: center;
     background-color: ${props => props.theme.secondaryColor};
     color: white;
-    h2 {
-      
-    }
   }
 
 .form{

--- a/src/components/CommonForm/index.js
+++ b/src/components/CommonForm/index.js
@@ -56,7 +56,7 @@ const CommonForm = ({ form, title,account_desc, submit_title, submit_body }) => 
       {
         stepNumber === 0 &&
   <div className="form-body">
-    <h3 className="form-title">{title}</h3>
+    <h2 className="form-title">{title}</h2>
     <Formik
       initialValues={{
         firstname: firstname,

--- a/src/sections/Meshmap/features/features.style.js
+++ b/src/sections/Meshmap/features/features.style.js
@@ -18,8 +18,10 @@ const FeatureWrapper = styled.section`
       padding-right: 1rem;
     }
 
-  & > h3 {
+  & > h2 {
     margin-bottom: 2rem;
+    font-size: 1.75rem;
+    font-weight: 500;
     @media (max-width: 767px) {
       font-size: 1.25rem;
     }

--- a/src/sections/Meshmap/features/index.js
+++ b/src/sections/Meshmap/features/index.js
@@ -19,7 +19,7 @@ export default function Feature({
     <FeatureWrapper>
       <div className="root">
         <div ref={ref} className="text" id = {inView ? "inView" : "notInView"}>
-          <h3>{title}</h3>
+          <h2>{title}</h2>
           <hr />
           <p>{description}</p>
         </div>

--- a/src/sections/Meshmap/meshmap_banner.js
+++ b/src/sections/Meshmap/meshmap_banner.js
@@ -66,19 +66,19 @@ const BannerSectionWrapper = styled.div`
         font-size: 2.5rem;
         text-align: center;
     }
-    h3 {
+
+    }
+    .banner-text p {
         color: ${props => props.theme.saffronColor};
         margin-bottom: .5rem;
         font-weight: 400;
+        font-size: 1.75rem;
         font-style: italic;
         min-width: 18rem;
         font-family: "Qanelas Soft";
         span {
             color: ${props => props.theme.saffronColor};
         }
-    }
-    p {
-        color: ${props => props.theme.primaryLightColor};
     }
     h4 {
         text-transform: uppercase;
@@ -185,9 +185,9 @@ const BannerSection = () => {
         {/* <h3>
                     Application reigns King. Context is his Queen.
                 </h3> */}
-        <h3>
+        <p>
                     Friends don't let friends GitOps alone.
-        </h3>
+        </p>
         {/* <h4>Discover and Visualize</h4>
                 <h4><span>Collaborate and Design</span></h4>
                 any and all your cloud native infra and apps */}


### PR DESCRIPTION
**Description**

This PR fixes the failing lighthouse-ci `heading-order` test for the meshmap page

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
