### PR TITLE
fix lighthouse `heading-order` test for meshery page

### DIFF
--- a/src/sections/Meshery/Features-Col/featuresColSection.style.js
+++ b/src/sections/Meshery/Features-Col/featuresColSection.style.js
@@ -71,7 +71,7 @@ export const FeatureTitleInfoContainer = styled.div`
   .feature-block {
     font-size: 0.9rem;
     color: darkgray;
-    h3 {
+    h2 {
       font-size: 2rem;
       font-weight: 600;
       margin: 0 0 0.625rem 0;

--- a/src/sections/Meshery/Features-Col/index.js
+++ b/src/sections/Meshery/Features-Col/index.js
@@ -31,7 +31,7 @@ function getFeatureBlock(feature, index, performanceCount) {
     <FeatureBlockContainer key={index} className="feature-col">
       <FeatureTitleInfoContainer>
         <div className="feature-block">
-          <h3>{feature.name}</h3>
+          <h2>{feature.name}</h2>
         </div>
         <p>{feature.description}</p>
       </FeatureTitleInfoContainer>

--- a/src/sections/Meshery/Features-section/features-section.style.js
+++ b/src/sections/Meshery/Features-section/features-section.style.js
@@ -86,8 +86,12 @@ const FeaturesSectionWrapper = styled.section`
 				color: white;
 			}
 		.smp-section-data {
-			h1, h3, p {
+			h1, h2, p {
 				text-align: start; color: white;
+			}
+			h2 {
+				font-size: 1.75rem;
+    			font-weight: 500;
 			}
 		}
 
@@ -238,9 +242,10 @@ const FeaturesSectionWrapper = styled.section`
 	}
 
 	.mesh-mngmnt {
-		h4 {
+		h3 {
 			margin: 1rem 0;
 			color: rgba(255, 255, 255, 0.6);
+			font-size: 1.5rem;
 		}
 		p {
 			margin: 0.5rem 0;

--- a/src/sections/Meshery/Features-section/index.js
+++ b/src/sections/Meshery/Features-section/index.js
@@ -60,7 +60,7 @@ const FeaturesSection = () => {
           {/* <h4>No matter what service mesh you use, Meshery just works.</h4> */}
           <Row className="smp-section-row">
             <Col xs={12} xl={4} className="smp-section-data">
-              <h3>The Performance Yardstick: MeshMark</h3>
+              <h2>The Performance Yardstick: MeshMark</h2>
               <p>
                 Assess the value of your service mesh in context of its cost. Benchmark and manage the performance of your          application across different service meshes. Compare and manage service mesh overhead.
               </p>
@@ -82,7 +82,7 @@ const FeaturesSection = () => {
         </div>
         <div className="mesh-mngmnt">
           <div>
-            <h4>One step to managing your microservices</h4>
+            <h3>One step to managing your microservices</h3>
             <h1>Cloud Native Application Management</h1>
             <p>Confidently take full advantage of all that your infrastructure offers.</p>
           </div>


### PR DESCRIPTION
**Description**

This PR fixes the failing `heading-order` test for meshery page as seen [here](https://github.com/layer5io/layer5/actions/runs/4408794340/jobs/7724267800#step:6:364)

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
