### PR TITLE
Issue #3964 : changed hover color for disappearing table cells

### DIFF
--- a/src/components/MeetInfo-Table/MeetInfoTable.style.js
+++ b/src/components/MeetInfo-Table/MeetInfoTable.style.js
@@ -24,7 +24,7 @@ export const TableWrapper = styled.div`
 			a {
 				color: ${props => props.theme.text};
 				&:hover {
-					color: ${props => props.theme.primaryLightColor};
+					color: ${props => props.theme.DarkTheme ? "rgb(180, 180, 180)" : "rgb(80, 80, 80)"};
 				}
 			}
 			:first-child {


### PR DESCRIPTION
**Description**
Changed hover color to rgb(180 , 180 , 180) for dark theme and rgb(80 , 80 , 80) for light theme.

This PR fixes #3964 

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
