### PR TITLE
correct Meshery.io repo link in the repository overview page

### DIFF
--- a/src/sections/Community/Handbook/repo-data.js
+++ b/src/sections/Community/Handbook/repo-data.js
@@ -39,7 +39,7 @@ export const repo_data = [
         language: "Jekyll",
         maintainers_name: ["Aditya Chatterjee"],
         link: ["https://layer5.io/community/members/aditya-chatterjee"],
-        repository: "https://github.com/meshery/meshery",
+        repository: "https://github.com/meshery/meshery.io",
       },
       {
         project: "Meshery Documentation",


### PR DESCRIPTION
**Description**
This PR fixes the wrong repository link of Meshery.io in the [Frontend projects](https://layer5.io/community/handbook/repository-overview#Frontend%20Projects) section of the [Repository Overview](https://layer5.io/community/handbook/repository-overview) page of Layer5

This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
