### PR TITLE
Change the links of contributors and License

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-<a href="https://github.com/layer5io/layer5" alt="GitHub contributors">
+<a href="https://github.com/layer5io/layer5/graphs/contributors" alt="GitHub contributors">
 <img src="https://img.shields.io/github/contributors/layer5io/layer5.svg" /></a>
 <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Alayer5io+org%3Ameshery+org%3Alayer5labs+org%3Aservice-mesh-performance+org%3Aservice-mesh-patterns+label%3A%22help+wanted%22" alt="Help wanted GitHub issues">
 <img src="https://img.shields.io/github/issues/layer5io/layer5/help%20wanted.svg?color=%23DDDD00" /></a>
@@ -15,7 +15,7 @@
 <img src="https://img.shields.io/badge/Slack-@layer5.svg?logo=slack" /></a>
 <a href="https://twitter.com/layer5" alt="Twitter Follow">
 <img src="https://img.shields.io/twitter/follow/layer5.svg?label=Follow+Layer5&style=social" /></a>
-<a href="https://github.com/layer5io/layer5" alt="License">
+<a href="https://github.com/layer5io/layer5/blob/master/LICENSE" alt="License">
 <img src="https://img.shields.io/github/license/layer5io/layer5.svg" /></a>
 </p>
 


### PR DESCRIPTION
This PR fixes #4031 
I have change the links of contributor and license that redirect the users to their respective locations for easier access.

Signed-off-by: Jamir Ahmed <jamir.ahmed.ghtwtrlkdn@gmail.com>



