### PR TITLE
Fixed SMI Table horizontal scroll in mobile devices

### DIFF
--- a/src/components/SMI-Table/SMITable.style.js
+++ b/src/components/SMI-Table/SMITable.style.js
@@ -1,7 +1,8 @@
 import styled from "styled-components";
 
 export const TableWrapper = styled.div`
-overflow: hidden;
+overflow-x: auto;
+overflow-y: hidden;
 
 .smiMark {
 	height: 70%;

--- a/src/sections/Landscape/LandscapeGrid.style.js
+++ b/src/sections/Landscape/LandscapeGrid.style.js
@@ -504,7 +504,7 @@ export const LandscapePageWrapper = styled.div`
 	.Legend {
 		display: flex;
 		padding: .7rem;
-		text-align: right;
+		text-align: left;
 		margin-left: auto;
 		vertical-align: middle;
 		border: 1px ${props => props.theme.primaryColor};
@@ -518,6 +518,7 @@ export const LandscapePageWrapper = styled.div`
 			font-weight:600;
 			margin: auto;
 			margin-right: 1rem;
+			padding: 0 0.5rem;
 		}
 		img {
 			height: 2rem;


### PR DESCRIPTION
**Description**

This PR fixes #3826 
Added horizontal scroll in SMI Table and fixed orientation of legend rows on small devices

[Video](https://user-images.githubusercontent.com/92908347/231228036-79538e44-9378-4bc9-888d-a4f7f2cea5cc.webm)


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
