### PR TITLE
Fix Missing Collaborate SVG on /cloud-native-management/meshmap Page

### DIFF
--- a/src/sections/Meshmap/FeaturesSection/Collaborate/CollaboratorFeatures_diagram.js
+++ b/src/sections/Meshmap/FeaturesSection/Collaborate/CollaboratorFeatures_diagram.js
@@ -20,7 +20,7 @@ const CollaboratorFeaturesDiagram = ({ activeExampleIndex }) => {
           <img id="avatar-2" className={(activeExampleIndex == 1) ? "show" : "render"} src={Avatar2} alt="" />
           <img id="avatar-3" className={(activeExampleIndex >= 2) ? "show" : "render"} src={Avatar3} alt="" />
         </div>
-        <div className="root" style={{ minHeight: "25rem" }}>
+        <div className="root" style={{ minHeight: "25rem", minWidth: "41rem" }}>
           <Collab1 id="collaborate-image1" ref={ref} className={inView && activeExampleIndex == 0 ? "show" : "render"} alt="collaborate-image1" />
           <Collab2 id="collaborate-image2" className={(activeExampleIndex == 1) ? "show" : "render"} alt="collaborate-image2" />
           <Collab3 id="collaborate-image3" className={(activeExampleIndex == 2) ? "show" : "render"} alt="collaborate-image3" />

--- a/src/sections/Meshmap/FeaturesSection/Collaborate/images/collab1-colorMode.svg
+++ b/src/sections/Meshmap/FeaturesSection/Collaborate/images/collab1-colorMode.svg
@@ -1,4 +1,4 @@
-<svg width="100%" viewBox="0 0 1366 805" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="auto" viewBox="0 0 1366 805" fill="none" xmlns="http://www.w3.org/2000/svg">
   <rect x="435.5" y="111.5" width="335" height="250" fill="#326CE5" fill-opacity="0.1" stroke="#326CE5"
     stroke-width="5" />
   <path

--- a/src/sections/Meshmap/FeaturesSection/Collaborate/images/collab1-colorMode.svg
+++ b/src/sections/Meshmap/FeaturesSection/Collaborate/images/collab1-colorMode.svg
@@ -1,4 +1,4 @@
-<svg width="auto" viewBox="0 0 1366 805" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="100%" viewBox="0 0 1366 805" fill="none" xmlns="http://www.w3.org/2000/svg">
   <rect x="435.5" y="111.5" width="335" height="250" fill="#326CE5" fill-opacity="0.1" stroke="#326CE5"
     stroke-width="5" />
   <path


### PR DESCRIPTION
**Description**

This PR fixes the missing collaborate SVG on [MeshMap](https://layer5.io/cloud-native-management/meshmap) page.

Currently:
![image](https://user-images.githubusercontent.com/90356410/234956777-31958806-003d-4e40-8770-d3952a9d1eca.png)

Expected:
![image](https://user-images.githubusercontent.com/90356410/234982986-10c1c8d4-cae1-48b4-ad1e-07902cf6a82a.png)

**Notes for Reviewers**
This issue seems to have been caused by my recent change of selected SVGs width from "auto" to "100%" which did not interact well with the div container and required additional minWidth dimension to display correctly (note:  I am unsure why this is the case, so if anyone knows please comment). The other SVGs on this page don't seem to have issues.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
