### PR TITLE
Improve Responsiveness for Table at Service Mesh Patterns Page

### DIFF
--- a/src/components/service-mesh-patterns-Table/Table.js
+++ b/src/components/service-mesh-patterns-Table/Table.js
@@ -48,7 +48,7 @@ const Table = () => {
                       : <>
                       </>}
                     {(column.Header == "Category") ?
-                      <div>{column.canFilter ? column.render("Filter") : null}</div>
+                      <div id={"service-mesh-patterns-table"}>{column.canFilter ? column.render("Filter") : null}</div>
                       : <> </>
                     }
                   </div>

--- a/src/components/service-mesh-patterns-Table/Table.js
+++ b/src/components/service-mesh-patterns-Table/Table.js
@@ -48,7 +48,7 @@ const Table = () => {
                       : <>
                       </>}
                     {(column.Header == "Category") ?
-                      <div id={"service-mesh-patterns-table"}>{column.canFilter ? column.render("Filter") : null}</div>
+                      <div id={"service-mesh-patterns-table-filter"}>{column.canFilter ? column.render("Filter") : null}</div>
                       : <> </>
                     }
                   </div>

--- a/src/sections/Learn/Book-single/BookSingle.style.js
+++ b/src/sections/Learn/Book-single/BookSingle.style.js
@@ -28,9 +28,12 @@ const BookSinglePageWrapper = styled.div`
 		
 	}
 
-	@media only screen and (max-width: 480px) {
+	@media only screen and (max-width: 500px) {
 		#service-mesh-patterns-table-filter > select{
 			width: 100%;
+		}
+		table > tbody> tr > td:nth-child(2) {
+			text-align:center;
 		}
 	}
     .single-post-wrapper{

--- a/src/sections/Learn/Book-single/BookSingle.style.js
+++ b/src/sections/Learn/Book-single/BookSingle.style.js
@@ -29,7 +29,7 @@ const BookSinglePageWrapper = styled.div`
 	}
 
 	@media only screen and (max-width: 480px) {
-		#service-mesh-patterns-table > select{
+		#service-mesh-patterns-table-filter > select{
 			width: 100%;
 		}
 	}

--- a/src/sections/Learn/Book-single/BookSingle.style.js
+++ b/src/sections/Learn/Book-single/BookSingle.style.js
@@ -27,6 +27,12 @@ const BookSinglePageWrapper = styled.div`
 		}
 		
 	}
+
+	@media only screen and (max-width: 480px) {
+		#service-mesh-patterns-table > select{
+			width: 100%;
+		}
+	}
     .single-post-wrapper{
         margin: 2rem 0;
     }

--- a/src/sections/Learn/Book-single/BookSingle.style.js
+++ b/src/sections/Learn/Book-single/BookSingle.style.js
@@ -32,9 +32,9 @@ const BookSinglePageWrapper = styled.div`
 		#service-mesh-patterns-table-filter > select{
 			width: 100%;
 		}
-		table > tbody> tr > td:nth-child(2) {
-			text-align:center;
-		}
+	}
+	table > tbody> tr > td {
+		text-align:center;
 	}
     .single-post-wrapper{
         margin: 2rem 0;


### PR DESCRIPTION
**Description**

This PR fixes #4202 

### Cause of Issue
The table does not adjust to CSS width changes due to the content of the table being wider.

### Explanation 
Using the mobile breakpoint [480px], I Set the width for the select block in the header of the table.
This fixes the issue for mobile devices.

![image](https://github.com/layer5io/layer5/assets/75237697/0da4f3fe-02ce-4407-85ad-2f951ceb0845)


**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
