### PR TITLE
Fix for occasional flash of white in the background upon page load

### DIFF
--- a/src/sections/app.style.js
+++ b/src/sections/app.style.js
@@ -21,6 +21,11 @@ const GlobalStyle = createGlobalStyle`
     outline: none;
   }
 
+  #___gatsby {
+    background: ${(props) => props.theme.body};
+    transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
+  }
+
 html{
     box-sizing: border-box;
     -ms-overflow-style: scrollbar;


### PR DESCRIPTION
**Description**

This PR fixes a white flash that can happen upon page load in components that do not have a background-color specified.

The examples below uses the projects page in dark mode because light mode and the banner on the home page makes it difficult to see the flash when it occurs:

Multiple [hard refreshes](https://fabricdigital.co.nz/blog/how-to-hard-refresh-your-browser-and-clear-cache) (the flash does not happen all the time):
![intermittent-flash](https://github.com/layer5io/layer5/assets/90356410/ae1dbe70-91f1-4f3f-83fd-574f45017228)

Unfortunately while I found a fix/workaround, I cannot explain exactly why it works (hopefully someone can help on this) .

----

Fix:

- there is a wrapping gatsby element generated (#___gatsby) that can be targeted for styling:
![image](https://github.com/layer5io/layer5/assets/90356410/bf482c3a-a2a8-4c7a-b201-d34d35f7608a)

- update the globalStyle, and target this element:
![image](https://github.com/layer5io/layer5/assets/90356410/039cd669-1cb2-4c4a-87b4-5d5da33ac49c)

![flash-fix2](https://github.com/layer5io/layer5/assets/90356410/74580d8c-d994-44a8-8b93-19bdc0067654)
(note: any white flash is the browser taking time to reload the page indicated by the blank page during the flash)

----

**Notes for Reviewers**

Here are my testing notes (please let me know other ways you would have tested this):

- I could only reproduce in production builds.

- if the body's background-color does not use props or variables, but a value like "red", it will not show any flash
![absolute_value](https://github.com/layer5io/layer5/assets/90356410/2187b872-2638-49ae-bf83-ed31b59cf07d)

- the flash is not of the default theme ("light mode"). I changed the light mode and dark mode to have background color of `red` and `blue`, and multiple hard refreshes still show a flash of white:
![redblue_white_flash](https://github.com/layer5io/layer5/assets/90356410/a56c8732-3c77-4e7c-8ce5-de0b18328ab8)

- in the gifs above, you will notice that all the content appears and the navigation header always loads with the correct background-color, while the other components show the flash. What is different about the header is that it specifies the background-color in its style sheet:

`src/sections/General/Navigation/navigation.style.js`
![image](https://github.com/layer5io/layer5/assets/90356410/ea8bc521-a54f-4387-bfdb-596a3803ba53)

and in this example, the project page, does not specify a background-color:
`src/sections/Projects/Project-grid/projectGrid.style.js`
![image](https://github.com/layer5io/layer5/assets/90356410/6ba417a6-3796-4cea-8198-d2cf66a3745c)

also note that we specify the background-color of the `body` element in the globalStyle:
`src/sections/app.style.js`
![image](https://github.com/layer5io/layer5/assets/90356410/67e35103-a895-4207-a321-658363d4b1ac)

>**What happens when an element does not specify a background-color?**
>An element that does not specify a [background is transparent (its initial value)](https://developer.mozilla.org/en-US/docs/Web/CSS/background-color#formal_definition). Background-color is also non-inheritable.
![image](https://github.com/layer5io/layer5/assets/90356410/81ca5a88-aea5-46f6-b7af-421bc833a9e4)

>This is to allow the background color of the body or parent element to show through the transparent element. And if there is no background color set on the body, then the [browser's background will show](https://dev.to/bcalou/why-you-should-always-set-a-background-color-2gb1).

Since the header appears correctly with each page load and it specifies the background-color using a variable, this shows that there is no issue or delay in the correct values resolving in the styled-components.

----

Best guess:

- the white flash that is appearing is the browser's default background (white).
- the browser's background is showing because the `body` tag is correctly being assigned the styling from the globalStyle, but when it is a variable instead of an absolute value, there **can** be a delay in resolving the variable for some reason.

If anyone has any ideas, explanations, or insights on this issue, please let me know as I felt like I was chasing a ghost in the machine.

----

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
