### PR TITLE
Added Docker Extension Badge

### DIFF
--- a/src/sections/Community/Handbook/recognition.js
+++ b/src/sections/Community/Handbook/recognition.js
@@ -7,6 +7,7 @@ import CommunityLogo from "../../../assets/images/community/community-green.svg"
 import PatternsLogo from "../../../assets/images/service-mesh-patterns/service-mesh-pattern.svg";
 import LandscapeGreen from "../../../assets/images/landscape/layer5_landscape_green.svg";
 import ImageHubLogo from "../../../assets/images/image-hub/layer5-image-hub.svg";
+import DockerExtension from "../../../assets/images/docker-extension/docker-extension-meshery-logo.svg";
 import MesheryLogo from "../../../assets/images/meshery/icon-only/meshery-logo-light.svg";
 import MesheryOperator from "../../../assets/images/meshery-operator/meshery-operator-dark.svg";
 import ServiceMeshPerformance from "../../../assets/images/service-mesh-performance/stacked/smp-dark-text.svg";
@@ -102,6 +103,10 @@ const RecognitionPage = () => {
               <li>
                 <img src={LandscapeGreen} style={badgeStyle} />
                 <b>Landscape</b> - awarded community members who make consistent and impactful contributions to the have made impactful contributions to the layer5.io website.
+              </li>
+              <li>
+                <img src={DockerExtension} style={badgeStyle} />
+                <b>Docker</b> - awarded community members who make consistent and impactful contributions to the Docker-Extension of meshery project in recognition and appreciation of their efforts.
               </li>
               <li>
                 <img src={MesheryLogo} style={badgeStyle} />


### PR DESCRIPTION
 This PR solves some part of issue #4209
This adds a Docker Extension Badge

**Description**

There are Two Badges Missing here   https://layer5.io/community/handbook/recognition
Docker Extension Badge and Meshery Catalog Badge to recognition
as mentioned here https://github.com/layer5io/layer5/issues/4209

This PR fixes #

This PR will add the Docker Extension Badge to https://layer5.io/community/handbook/recognition

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

Signed-off-by: Deepak Choudhary <deepakchoudharysl78@gmail.com>