### PR TITLE
Added Docker Extension Badge on :/Community/Handbook/recognition.js

### DIFF
--- a/src/sections/Community/Handbook/recognition.js
+++ b/src/sections/Community/Handbook/recognition.js
@@ -98,7 +98,7 @@ const RecognitionPage = () => {
               </li>
               <li>
                 <img src={DockerExtension} style={badgeStyle} />
-                <b>Docker Extension</b> - awarded community members who make consistent and impactful contributions to the Docker-Extension of meshery project in recognition and appreciation of their efforts.
+                <b>Docker Extension</b> - awarded community members who make consistent and impactful contributions to the Docker Extension of meshery project in recognition and appreciation of their efforts.
               </li>
               <li>
                 <img src={ImageHubLogo} style={badgeStyle} />

--- a/src/sections/Community/Handbook/recognition.js
+++ b/src/sections/Community/Handbook/recognition.js
@@ -7,6 +7,7 @@ import CommunityLogo from "../../../assets/images/community/community-green.svg"
 import PatternsLogo from "../../../assets/images/service-mesh-patterns/service-mesh-pattern.svg";
 import LandscapeGreen from "../../../assets/images/landscape/layer5_landscape_green.svg";
 import ImageHubLogo from "../../../assets/images/image-hub/layer5-image-hub.svg";
+import DockerExtension from "../../../assets/images/docker-extension/docker-extension-meshery-logo.svg";
 import MesheryLogo from "../../../assets/images/meshery/icon-only/meshery-logo-light.svg";
 import MesheryOperator from "../../../assets/images/meshery-operator/meshery-operator-dark.svg";
 import ServiceMeshPerformance from "../../../assets/images/service-mesh-performance/stacked/smp-dark-text.svg";
@@ -102,6 +103,10 @@ const RecognitionPage = () => {
               <li>
                 <img src={LandscapeGreen} style={badgeStyle} />
                 <b>Landscape</b> - awarded community members who make consistent and impactful contributions to the have made impactful contributions to the layer5.io website.
+              </li>
+              <li>
+                <img src={DockerExtension} style={badgeStyle} />
+                <b>Docker-Extension</b> - awarded community members who make consistent and impactful contributions to the Docker-Extension of meshery project in recognition and appreciation of their efforts.
               </li>
               <li>
                 <img src={MesheryLogo} style={badgeStyle} />

--- a/src/sections/Community/Handbook/recognition.js
+++ b/src/sections/Community/Handbook/recognition.js
@@ -97,16 +97,16 @@ const RecognitionPage = () => {
                 <b>Community</b> - awarded given to the community members who repeatedly engage in welcoming, encouraging, and supporting other Layer5 community members. Community members who earn this badge occasionally graduate to undertaking the Community Manager role.
               </li>
               <li>
+                <img src={DockerExtension} style={badgeStyle} />
+                <b>Docker Extension</b> - awarded community members who make consistent and impactful contributions to the Docker-Extension of meshery project in recognition and appreciation of their efforts.
+              </li>
+              <li>
                 <img src={ImageHubLogo} style={badgeStyle} />
                 <b>Image Hub</b> - awarded community members who make consistent and impactful contributions the Image Hub project in recognition and appreciation of their efforts.
               </li>
               <li>
                 <img src={LandscapeGreen} style={badgeStyle} />
                 <b>Landscape</b> - awarded community members who make consistent and impactful contributions to the have made impactful contributions to the layer5.io website.
-              </li>
-              <li>
-                <img src={DockerExtension} style={badgeStyle} />
-                <b>Docker-Extension</b> - awarded community members who make consistent and impactful contributions to the Docker-Extension of meshery project in recognition and appreciation of their efforts.
               </li>
               <li>
                 <img src={MesheryLogo} style={badgeStyle} />


### PR DESCRIPTION
**Description**

There are two badges missing in recognition of community handbook

1.Docker-Extension
2.Meshery Catalog

See here:
https://layer5.io/community/handbook/recognition

Docker Extension Badge and Meshery Catalog Badge to recognition
as mentioned here https://github.com/layer5io/layer5/issues/4209

![before](https://github.com/layer5io/layer5/assets/114693662/78c9eb9f-dfe3-4a01-93e5-4d3df11de977)


This PR fixes #

This PR will add the Docker Extension Badge to https://layer5.io/community/handbook/recognition

![after](https://github.com/layer5io/layer5/assets/114693662/645e8466-0c33-46f7-913b-d762000e24b8)


**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
