### PR TITLE
Added Word Wrapping and set Max Width to terminal text

### DIFF
--- a/src/components/Terminal/Terminal.style.js
+++ b/src/components/Terminal/Terminal.style.js
@@ -16,6 +16,7 @@ export const TerminalWrapper = styled.div`
   --terminal-body-color: var(--gray-1);
 
   width: 837px;
+  max-width: 90%;
 
   .title-bar {
     display: flex;
@@ -106,7 +107,6 @@ export const TerminalWrapper = styled.div`
       }
 
       wrap-word: normal;
-      max-width: 17rem;
       
       @media (min-width: 768px){
         font-size: 13.5px;

--- a/src/components/Terminal/Terminal.style.js
+++ b/src/components/Terminal/Terminal.style.js
@@ -88,7 +88,7 @@ export const TerminalWrapper = styled.div`
       height: 100%;
       font-style: normal;
       font-weight: normal;
-      font-size: 10px;
+      font-size: 12px;
       line-height: 27px;
       white-space: pre-wrap;
       color: ${props => props.theme.secondaryColor};

--- a/src/components/Terminal/Terminal.style.js
+++ b/src/components/Terminal/Terminal.style.js
@@ -59,7 +59,6 @@ export const TerminalWrapper = styled.div`
     background: var(--terminal-body-color);
     border-radius: 0 0 var(--terminal-radius) var(--terminal-radius);
     padding: 24px 32px;
-
     @media (min-width: 768px) {
       height: 525px;
     }
@@ -80,16 +79,16 @@ export const TerminalWrapper = styled.div`
     width: 0;
     height: 0;
   }
-
+  
   .code-wrapper {
-     pre {
+    pre {
       padding: 0;
       margin: 0;
       width: 100%;
       height: 100%;
       font-style: normal;
       font-weight: normal;
-      font-size: 12px;
+      font-size: 10px;
       line-height: 27px;
       white-space: pre-wrap;
       color: ${props => props.theme.secondaryColor};
@@ -106,6 +105,9 @@ export const TerminalWrapper = styled.div`
         color: var(--white);
       }
 
+      wrap-word: normal;
+      max-width: 17rem;
+      
       @media (min-width: 768px){
         font-size: 13.5px;
         line-height: 26px;


### PR DESCRIPTION
**Description**

This PR fixes #4241

**Notes for Reviewers**

The new Terminal looks like this in mobile view:
![Screen Shot 2023-05-18 at 17 51 48](https://github.com/layer5io/layer5/assets/71827366/86591ede-182e-4ca1-9dea-4fb42f9da37f)


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
