### PR TITLE
Add Full Images of books in Navigation

### DIFF
--- a/src/collections/service-mesh-books/service-mesh-patterns/index.mdx
+++ b/src/collections/service-mesh-books/service-mesh-patterns/index.mdx
@@ -2,7 +2,7 @@
 title: "Service Mesh Patterns"
 date: 2020-04-08 21:15:05 +0000
 cover: ./service-mesh-patterns.png
-thumbnail: ./service-mesh-patterns-small.png
+thumbnail: ./service-mesh-patterns.png
 author: Lee Calcote and Nic Jackson
 abstract: "Patterns, recipes and best practices for deploying and operating service meshes."
 published: true

--- a/src/collections/service-mesh-books/the-enterprise-path-to-service-mesh-architectures-2nd-Edition/index.mdx
+++ b/src/collections/service-mesh-books/the-enterprise-path-to-service-mesh-architectures-2nd-Edition/index.mdx
@@ -2,7 +2,7 @@
 title: "The Enterprise Path to Service Mesh Architectures (2nd Edition)"
 date: 2020-10-23 21:15:05 +0000
 cover: ./The-Enterprise-path-to-service-mesh-Architectures-2nd-Edition.png
-thumbnail: ./The-Enterprise-path-to-service-mesh-Architectures-2nd-Edition-small.png
+thumbnail: ./The-Enterprise-path-to-service-mesh-Architectures-2nd-Edition.png
 author: "Lee Calcote"
 abstract: "Planning to build a microservice-driven cloud native application or looking to modernize existing application services?"
 published: true

--- a/src/sections/General/Navigation/index.js
+++ b/src/sections/General/Navigation/index.js
@@ -33,10 +33,9 @@ const Navigation = () => {
         thumbnail {
           childImageSharp {
             gatsbyImageData(
-              width: 240
-              height: 160
-              transformOptions: {cropFocus: CENTER}
-              layout: FIXED
+              width: 1050
+              height:1360
+              layout: CONSTRAINED
             )
           }
           publicURL


### PR DESCRIPTION
**Description**

This PR fixes #3419 

**Notes for Reviewers**

Changed Thumbnail for the images from small image to large one. Did not delete small images from `src/collection/books/<book>`

![image](https://github.com/layer5io/layer5/assets/75237697/81114bbc-1e76-40e1-91ed-74d7cd6ee79e)


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
