### PR TITLE
Fix #4305 - Buttons in hero banner redirect to a bad url & 404 after Meshery page is reloaded

### DIFF
--- a/src/components/CommonForm/index.js
+++ b/src/components/CommonForm/index.js
@@ -137,7 +137,7 @@ const CommonForm = ({ form, title, submit_title, submit_body }) => {
         {validateRole && <p style={{ margin: "0px", color: "red", fontSize: "12px" }}>{errorRole}</p>}
         <div role="group" className="formRight" aria-labelledby="select">
           <Field as="select" name="role">
-            <option selected hidden>Select your role</option>
+            <option defaultValue hidden>Select your role</option>
             <option value="Architect">Architect</option>
             <option value="Business Operations">Business Operations</option>
             <option value="Developer">Developer</option>

--- a/src/components/Features-carousel/index.js
+++ b/src/components/Features-carousel/index.js
@@ -92,11 +92,14 @@ const Feature = ({ children, title, active, onClick, learnMoreLink, id, Element 
       )}
       <div className="body" id={`feature-${id}`} >
         <p>{children}</p>
-        {learnMoreLink && (
-          <Link className="learn-more-link" to={learnMoreLink}>
+        {learnMoreLink && learnMoreLink.startsWith("/")
+          ? <Link className="learn-more-link" to={learnMoreLink}>
             Explore <IoIosArrowRoundForward />
           </Link>
-        )}
+          : <a href={learnMoreLink} className="learn-more-link">
+           Explore <IoIosArrowRoundForward />
+          </a>
+        }
       </div>
     </Element>
   );

--- a/src/components/Learn-Components/what-await-section/index.js
+++ b/src/components/Learn-Components/what-await-section/index.js
@@ -25,7 +25,7 @@ const WhatAwaitsSection = () => {
                 code: "✓ Deployment successfully rolled out!",
                 color: "green",
               },
-              { code: "\n" },
+              { code: " " },
               { code: "» Traffic splitting...", color: "navy" },
               {
                 code: "✓ 5% of user requests to v3.",
@@ -47,7 +47,7 @@ const WhatAwaitsSection = () => {
                 code: "✓ 100% of user requests to v3.",
                 color: "green",
               },
-              { code: "\n" },
+              { code: " " },
               {
                 code: "Pattern successfully applied. Rollout of 'canary-v3' completed.",
                 color: "navy",

--- a/src/components/Terminal/index.js
+++ b/src/components/Terminal/index.js
@@ -57,9 +57,7 @@ const Terminal = ({ lines, title, noScroll }) => {
           <div className="code-wrapper">
             {lines && lines.map((line, index) => (
               <Fragment key={index}>
-                {line.code === "\n"
-                  ? <pre>{line.code}</pre>
-                  : <pre className={`${line.short ? "short" : ""} ${line.color ? line.color : "blue"}`} >
+                <pre className={`${line.short ? "short" : ""} ${line.color ? line.color : "blue"}`} >
                     {line.indent &&
                             new Array(line.indent * 2)
                               .fill({})
@@ -68,7 +66,6 @@ const Terminal = ({ lines, title, noScroll }) => {
                               ))}
                     {line.code}
                   </pre>
-                }
               </Fragment>
             ))}
           </div>

--- a/src/components/Terminal/index.js
+++ b/src/components/Terminal/index.js
@@ -57,15 +57,18 @@ const Terminal = ({ lines, title, noScroll }) => {
           <div className="code-wrapper">
             {lines && lines.map((line, index) => (
               <Fragment key={index}>
-                <pre className={`${line.short ? "short" : ""} ${line.color ? line.color : "blue"}`} >
-                  {line.indent &&
+                {line.code === "\n"
+                  ? <pre>{line.code}</pre>
+                  : <pre className={`${line.short ? "short" : ""} ${line.color ? line.color : "blue"}`} >
+                    {line.indent &&
                             new Array(line.indent * 2)
                               .fill({})
                               .map((_, index) => (
                                 <Fragment key={index}>&nbsp;</Fragment>
                               ))}
-                  {line.code}
-                </pre>
+                    {line.code}
+                  </pre>
+                }
               </Fragment>
             ))}
           </div>

--- a/src/sections/Docker-Meshery/docker-extension-meshery.js
+++ b/src/sections/Docker-Meshery/docker-extension-meshery.js
@@ -125,7 +125,7 @@ const DockerExtensionMeshery = () => {
           </Col>
           <Col md={6} sm={12}>
             <p className="installButton">
-              <Button primary title="Install Meshery Docker Extension" url="https://hub.docker.com/extensions/meshery/docker-extension-meshery" external="true" /></p>
+              <Button primary title="Install Meshery Docker Extension" url="https://hub.docker.com/extensions/meshery/docker-extension-meshery" external={true} /></p>
             <CommonForm
               title="Learn All Meshery Docker Extension Features"
               form="docker-extension"

--- a/src/sections/Learn-Layer5/index.js
+++ b/src/sections/Learn-Layer5/index.js
@@ -120,7 +120,7 @@ const LearnPathsPage = () => {
           <div className="service-mesh-patterns_text-and_button">
             <h1>Use Service Mesh Patterns</h1>
             <p>Service mesh patterns help you get the most out of any service mesh. Each pattern can be used as a template and is customizable.</p>
-            <Button secondary title="Visit Service Mesh Patterns website" url="https://service-mesh-patterns.github.io/service-mesh-patterns/" external="true" />
+            <Button secondary title="Visit Service Mesh Patterns website" url="https://service-mesh-patterns.github.io/service-mesh-patterns/" external={true} />
           </div>
         </div>
         <JoinCommunity

--- a/src/sections/Learn/Lab-single/index.js
+++ b/src/sections/Learn/Lab-single/index.js
@@ -38,7 +38,7 @@ const LabSinglePage = ({ frontmatter, body }) => {
         <div className="join-community_text-and_button">
           <h1>Use Service Mesh Patterns</h1>
           <p>Service mesh patterns help you get the most out of any service mesh. Each pattern can be used as a template and is customizable.</p>
-          <Button primary title="Visit Service Mesh Patterns website" url="https://service-mesh-patterns.github.io/service-mesh-patterns/" external="true" />
+          <Button primary title="Visit Service Mesh Patterns website" url="https://service-mesh-patterns.github.io/service-mesh-patterns/" external={true} />
         </div>
       </div>
     </LabSinglePageWrapper>

--- a/src/sections/Learn/Service-Mesh-Labs/index.js
+++ b/src/sections/Learn/Service-Mesh-Labs/index.js
@@ -82,7 +82,7 @@ const ServiceMeshLabs = ({ selectedIndex, setSelectedIndex }) => {
           <div className="join-community_text-and_button">
             <h1>Use Service Mesh Patterns</h1>
             <p>Service mesh patterns help you get the most out of any service mesh. Each pattern can be used as a template and is customizable.</p>
-            <Button primary title="Visit Service Mesh Patterns website" url="https://service-mesh-patterns.github.io/service-mesh-patterns/" external="true" />
+            <Button primary title="Visit Service Mesh Patterns website" url="https://service-mesh-patterns.github.io/service-mesh-patterns/" external={true} />
           </div>
         </div>
       </div>

--- a/src/sections/Meshery/Features-Col/index.js
+++ b/src/sections/Meshery/Features-Col/index.js
@@ -11,14 +11,18 @@ import {
   FeatureInfoContainer,
   CountBlockContainer,
 } from "./featuresColSection.style.js";
+
 function getServiceFeature(service, index) {
   return (
     <table className="table" key={index}>
-      <tr>
-        <td className="icon">
-          <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" fill="none" viewBox="0 0 40 40"><rect width="40" height="40" fill="#C9FCF6" rx="5" /><path stroke="#00B39F" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M28 14L17 25L12 20" /></svg>        </td>
-        <td className="service">{service.content}</td>
-      </tr>
+      <tbody>
+        <tr>
+          <td className="icon">
+            <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" fill="none" viewBox="0 0 40 40"><rect width="40" height="40" fill="#C9FCF6" rx="5" /><path stroke="#00B39F" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M28 14L17 25L12 20" /></svg>
+          </td>
+          <td className="service">{service.content}</td>
+        </tr>
+      </tbody>
     </table>
   );
 }
@@ -65,6 +69,7 @@ const Features = () => {
   }, []);
 
   const data = LifecycleFeature().features;
+
   return (
     <FeaturesSectionWrapper>
       <TitleContainer>

--- a/src/sections/Meshery/How-meshery-works/feature/index.js
+++ b/src/sections/Meshery/How-meshery-works/feature/index.js
@@ -1,22 +1,19 @@
-import React from "react";
-import LogoList from "../../../../components/Logo-List";
+import React, { useEffect } from "react";
 import FeatureWrapper from "./feature.style";
 import { useInView } from "react-intersection-observer";
-import { useState } from "react";
 
 export default function Feature({
   title,
   description,
   icon,
-  logos,
+  index,
   onInViewStatusChanged,
 }) {
   const [ref, inView] = useInView({ threshold: 0.8 });
-  const [inViewStatus, setInViewStatus] = useState(false);
-  if (inView !== inViewStatus) {
-    setInViewStatus(inView);
-    onInViewStatusChanged(inView);
-  }
+
+  useEffect(() => {
+    onInViewStatusChanged(inView, index);
+  }, [inView]);
 
   return (
     <FeatureWrapper>
@@ -30,8 +27,6 @@ export default function Feature({
         <div className="text">
           <h4>{title}</h4>
           {description}
-          <br/>
-          {logos ? <LogoList logos={logos} /> : null}
         </div>
       </div>
     </FeatureWrapper>

--- a/src/sections/Meshery/How-meshery-works/index.js
+++ b/src/sections/Meshery/How-meshery-works/index.js
@@ -11,6 +11,19 @@ export default function HowItWorks({ title, description, features }) {
     new Array(features.length).fill(false)
   );
 
+  const onInViewStatusChanged = (state, index) => {
+    const newStatusArray = [...viewportStatus];
+    newStatusArray[index] = state;
+    setViewportStatus(newStatusArray);
+    // Calculate the first element in focus, set that as
+    // our new activeExampleIndex. If it's been updated
+    // notify the subscriber.
+    const newExampleIndex = newStatusArray.lastIndexOf(true);
+    if ( activeExampleIndex !== newExampleIndex && newExampleIndex !== -1) {
+      setActiveExampleIndex(newExampleIndex);
+    }
+  };
+
   return (
     <HowitworksWrapper>
       <Container>
@@ -28,18 +41,8 @@ export default function HowItWorks({ title, description, features }) {
                 <li key={index}>
                   <Feature
                     {...feature}
-                    onInViewStatusChanged={(state) => {
-                      const newStatusArray = [...viewportStatus];
-                      newStatusArray[index] = state;
-                      setViewportStatus(newStatusArray);
-                      // Calculate the first element in focus, set that as
-                      // our new activeExampleIndex. If it's been updated
-                      // notify the subscriber.
-                      const newExampleIndex = newStatusArray.lastIndexOf(true);
-                      if ( activeExampleIndex !== newExampleIndex && newExampleIndex !== -1) {
-                        setActiveExampleIndex(newExampleIndex);
-                      }
-                    }}
+                    index={index}
+                    onInViewStatusChanged={onInViewStatusChanged}
                   />
                 </li>
               ))}

--- a/src/sections/Meshery/Meshery-features/index.js
+++ b/src/sections/Meshery/Meshery-features/index.js
@@ -75,7 +75,7 @@ const MesheryFeatures = () => {
                       code: "✓ Deployment successfully rolled out!",
                       color: "green",
                     },
-                    { code: "\n" },
+                    { code: " " },
                     { code: "» Traffic splitting...", color: "navy" },
                     {
                       code: "✓ 5% of user requests to v3.",
@@ -97,7 +97,7 @@ const MesheryFeatures = () => {
                       code: "✓ 100% of user requests to v3.",
                       color: "green",
                     },
-                    { code: "\n" },
+                    { code: " " },
                     {
                       code: "Pattern successfully applied. Rollout of 'canary-v3' completed.",
                       color: "navy",

--- a/src/sections/Meshery/Meshery-integrations/Card.js
+++ b/src/sections/Meshery/Meshery-integrations/Card.js
@@ -16,6 +16,7 @@ const Card = () => {
           secondary
           title="Learn about Extension Points"
           url="https://docs.meshery.io/extensibility"
+          external={true}
         />
       </div>
       <div className="container">

--- a/src/sections/Meshery/index.js
+++ b/src/sections/Meshery/index.js
@@ -29,10 +29,12 @@ const MesheryPage = () => {
                 {/* Meshery is the cloud native manager. <br /> */}
                 Confidently design, deploy, and operate your infrastructure and workloads with Meshery.
               </p>
-              <Button primary className="banner-btn" title="How Meshery Works" url="./operating-service-meshes">
+              <Button primary className="banner-btn" title="How Meshery Works"
+                url="/cloud-native-management/meshery/operating-service-meshes">
                 <GiClockwork size={21} className="button-icon" />
               </Button>
-              <Button secondary className="banner-btn" title="Run Meshery" url="./getting-started">
+              <Button secondary className="banner-btn" title="Run Meshery"
+                url="/cloud-native-management/meshery/getting-started">
                 <FiDownloadCloud size={21} className="button-icon" />
               </Button>
             </Col>

--- a/src/sections/Meshmap/FeaturesSection/Collaborate/CollaboratorFeatures_diagram.js
+++ b/src/sections/Meshmap/FeaturesSection/Collaborate/CollaboratorFeatures_diagram.js
@@ -11,6 +11,7 @@ import { useInView } from "react-intersection-observer";
 
 const CollaboratorFeaturesDiagram = ({ activeExampleIndex }) => {
   const [ref, inView] = useInView({ threshold: 0.6 });
+  const [ref2, inView2] = useInView({ threshold: 0.4 });
 
   return (
     <DiagramStyles>
@@ -18,10 +19,10 @@ const CollaboratorFeaturesDiagram = ({ activeExampleIndex }) => {
         <div className="avatars">
           <img id="avatar-1" ref={ref} className={inView && activeExampleIndex == 0 ? "show" : "render"} src={Avatar1} alt="" />
           <img id="avatar-2" className={(activeExampleIndex == 1) ? "show" : "render"} src={Avatar2} alt="" />
-          <img id="avatar-3" className={(activeExampleIndex >= 2) ? "show" : "render"} src={Avatar3} alt="" />
+          <img id="avatar-3" className={(activeExampleIndex >= 2) ? "show" : "render"} src={Avatar3} alt=""  />
         </div>
-        <div className="root" style={{ minHeight: "25rem", minWidth: "41rem" }}>
-          <Collab1 id="collaborate-image1" ref={ref} className={inView && activeExampleIndex == 0 ? "show" : "render"} alt="collaborate-image1" />
+        <div className="root" ref={ref2} style={{ minHeight: "25rem", minWidth: "41rem" }}>
+          <Collab1 id="collaborate-image1" className={inView2 && activeExampleIndex == 0 ? "show" : "render"} alt="collaborate-image1"  />
           <Collab2 id="collaborate-image2" className={(activeExampleIndex == 1) ? "show" : "render"} alt="collaborate-image2" />
           <Collab3 id="collaborate-image3" className={(activeExampleIndex == 2) ? "show" : "render"} alt="collaborate-image3" />
           <Collab4 id="collaborate-image4" className={(activeExampleIndex >= 3) ? "show" : "render"} alt="collaborate-image4" />

--- a/src/sections/Meshmap/FeaturesSection/useGsapTimeline.js
+++ b/src/sections/Meshmap/FeaturesSection/useGsapTimeline.js
@@ -1,22 +1,17 @@
 import { gsap } from "gsap";
 import ScrollTrigger from "gsap/dist/ScrollTrigger";
 import { useEffect, useLayoutEffect } from "react";
-import useHasMounted from "../../../utils/useHasMounted";
 
 gsap.registerPlugin(ScrollTrigger);
 
 const useGsapTimeline = ({ trigger, featureContainerName,yPercent }) => {
 
-  const hasMounted = useHasMounted();
-
   const useIsomorphicLayoutEffect =
-  hasMounted ? useLayoutEffect : useEffect;
-
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
   const GOLDEN_RATIO = (1 + Math.sqrt(3)) / 5;
   const RECIPROCAL_GR = 1 / GOLDEN_RATIO;
   const DURATION = RECIPROCAL_GR;
-
 
   useIsomorphicLayoutEffect(() => {
     let mm = gsap.matchMedia();

--- a/src/sections/Meshmap/features/index.js
+++ b/src/sections/Meshmap/features/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import FeatureWrapper from "./features.style";
 import { useInView } from "react-intersection-observer";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 export default function Feature({
   title,
@@ -12,10 +12,13 @@ export default function Feature({
 }) {
   const [ref, inView] = useInView({ threshold: 0.4 });
   const [inViewStatus, setInViewStatus] = useState(false);
-  if (inView !== inViewStatus) {
-    setInViewStatus(inView);
-    onInViewStatusChanged(inView);
-  }
+
+  useEffect(() => {
+    if (inView !== inViewStatus) {
+      setInViewStatus(inView);
+      onInViewStatusChanged(inView);
+    }
+  },[inView, inViewStatus]);
 
   return (
     <FeatureWrapper>


### PR DESCRIPTION
**Description**

This PR fixes #4305. 

before:

[redirect error](https://github.com/layer5io/layer5/assets//114604338/241587137-16fda1ce-c63e-4329-acae-08094b528dfb)

after:

[issue4305fix.webm](https://github.com/layer5io/layer5/assets/90356410/86968db6-c5e6-4e8b-b8e0-b9e2a252d738)


This PR also clears a number of dev console warnings on related pages (in detail below).

---

**Notes for Reviewers**

Possible explanation for fix: The button url links were relative with "./" and I believe the "." somehow made the link created for the buttons originate from the **file link path** instead of the browser displayed link path.

So instead of getting:
`https://layer5.io/cloud-native-management/meshery/operating-service-meshes`

the result was (note: the `.html`):
`https://layer5.io/cloud-native-management/meshery.html/operating-service-meshes`

Unfortunately as of this PR, I couldn't find documentation supporting this possibility.

---

This PR also clears the following dev warnings on these pages:

`https://layer5.io/cloud-native-management/meshery/operating-service-meshes`
>Warning: Cannot update a component (`HowItWorks`) while rendering a different component (`Feature`). To locate the bad setState() call inside `Feature`

---

`https://layer5.io/cloud-native-management/meshery`
>Warning: Expected server HTML to contain a matching \<tr\> in \<table\>.

>Warning: validateDOMNesting(...): \<tr\> cannot appear as a child of \<tabl\e>. Add a \<tbody\>, \<thead\> or \<tfoot\> to your code to match the DOM tree generated by the browser.

>External link https://docs.meshery.io/extensibility was detected in a Link component. Use the Link component only for internal links.

note: cleared this warning on other pages with the same code

---

`https://layer5.io/cloud-native-management/meshmap`
>Warning: Cannot update a component (`DesignerFeatures`) while rendering a different component (`Feature`).

>Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()

>Warning: React has detected a change in the order of Hooks called by DesignerFeatures. This will lead to bugs and errors if not fixed.

>Warning: Use the `defaultValue` or `value` props on \<select\> instead of setting `selected` on \<option\>.

---

`https://layer5.io/learn/learning-paths`
>Warning: Expected server HTML to contain a matching text node for "
" in \<pre\>.


cheers!

---

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
