### PR TITLE
Bug Fix: Text Visibility of Sub-Title For Dark Theme Fixed

### DIFF
--- a/src/sections/Docker-Meshery/docker-extension-CTA.js
+++ b/src/sections/Docker-Meshery/docker-extension-CTA.js
@@ -36,6 +36,9 @@ p {
       color: ${props => props.theme.whiteToBlack};
       padding: 0;
     }
+    p{
+      color: ${props => props.theme.whiteToBlack}
+    }
     Button {
       margin: 1rem 0;
     }


### PR DESCRIPTION
# **Description**

- In the Docker Callout Section, particularly in **dark theme**, we have a sub-title as `Managing cloud native infrastructure has never been easier.` 
- The issue with the sub-title is in dark-theme, the text color is black due to which text is not visible properly. This PR is aimed to fix this particular issue. 

# This PR fixes #

#4134 

# **Notes for Reviewers**

- Please head over directly to https://64877c6612db990cc5f61067--layer5.netlify.app/cloud-native-management/meshery to check out my change.
- Please note the change will be reflected in the dark theme as it is already fine with light theme. 

## Before change screenshot: 

![image](https://github.com/layer5io/layer5/assets/86982322/b94d0ceb-c58c-4928-990e-d29ab93e458a)

## After change screenshot: 

![image](https://github.com/layer5io/layer5/assets/86982322/589cb64d-1074-4519-b3f0-15c347395408)

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
