### PR TITLE
fix spelling mistake in getting started guide

### DIFF
--- a/src/sections/Meshery/Meshery-terminal/index.js
+++ b/src/sections/Meshery/Meshery-terminal/index.js
@@ -231,7 +231,7 @@ const MesheryTerminal = () => {
                     Patternfiles stems from multiple open needs, one of which is the desire to define a common practice of both configuring and operating service mesh functionality in a single, universal file.
                   </p>
                   <p>
-                    With a patternfile, you cancapture service mesh behavior in a single file. You can access service mesh-specific differentiation while keeping your patterns short and simple.
+                    With a patternfile, you can capture service mesh behavior in a single file. You can access service mesh-specific differentiation while keeping your patterns short and simple.
                   </p>
                 </>
               ),


### PR DESCRIPTION
**Description**

This PR fixes a small spelling mistake in the patterns section in [getting started guide](https://layer5.io/cloud-native-management/meshery/getting-started).

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
