### PR TITLE
Resolved Responsive issue with the Subscribe section [Footer]

### DIFF
--- a/src/sections/General/Footer/footer.style.js
+++ b/src/sections/General/Footer/footer.style.js
@@ -154,7 +154,7 @@ const FooterWrapper = styled.section`
 			margin-top: -7rem;
 		}
 	}
-	@media only screen and (max-width:767px) and (min-width: 729px){
+	@media only screen and (max-width:767px) and (min-width: 726px){
 		.subscribe {
 			margin-top: 10px;
 		}


### PR DESCRIPTION
**Description**

This PR fixes #4462 

**Notes for Reviewers**
Fixed Overlap occurring on specific window sizes of the Subscribe section 

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
