### PR TITLE
Fix : Github icon on footer is dimmer than other icons [UI} #4480

### DIFF
--- a/src/components/Case-study-banner/index.js
+++ b/src/components/Case-study-banner/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import MesheryLogo from "../../assets/images/meshery/icon-only/meshery-logo-light.svg";
 import SpireLogo from "../../collections/integrations/spire/icon/color/spire-color.svg";

--- a/src/components/SocialLinks-Color/sociallinkscolor.style.js
+++ b/src/components/SocialLinks-Color/sociallinkscolor.style.js
@@ -21,6 +21,9 @@ const SocialLinksWrapper = styled.div`
         .github:hover {
             filter: grayscale(0) invert(1);
         }
+        .github {
+            filter: grayscale(1.5) invert(0.38);
+        }
 
         .mail_icon {
             img {

--- a/src/sections/Community/Member-single/index.js
+++ b/src/sections/Community/Member-single/index.js
@@ -264,7 +264,7 @@ const MemberSingle = ({ frontmatter }) => {
                       </a>
                     </li>
                   )}
-                    {layer5 && (
+                  {layer5 && (
                     <li>
                       <a href={`https://meshery.layer5.io/user/${layer5}`}>
                         <img src={mesheryLogo} alt="meshery-icon"></img>


### PR DESCRIPTION
**Description**

This PR fixes #4480

**Notes for Reviewers**
Before : 
![250661041-aa5aefe8-bde5-4902-b72b-cec13bc89378](https://github.com/layer5io/layer5/assets/97088265/68cfcaf5-9f1b-4081-baa4-07283a608494)

After : 
![Screenshot from 2023-07-10 21-51-10](https://github.com/layer5io/layer5/assets/97088265/4c786499-0a34-45b7-8933-abe3b9121cc6)


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
