### PR TITLE
Solved Overflowing of project-page-wrapper, nav and footer.

### DIFF
--- a/src/sections/Projects/Project-grid/projectGrid.style.js
+++ b/src/sections/Projects/Project-grid/projectGrid.style.js
@@ -314,32 +314,7 @@ export const ProjectWrapper = styled.div`
         }
         
     }
-    @media only screen and (max-width: 991px) {
-        padding: 5px 0 0 0;
-        .project-text{
-        }
-        .project__card h5{
-            font-size: 12px;
-        }
-        .project__card.two{
-            img{
-                height: 100px;
-                width: 100px;
-            }
-            h5{
-                font-size: 25px;
-            }
-        }
-        .project__card.three img{
-            width: 70px;
-        }
-        .project__card.four h5{
-            width: 100%;
-            font-size: 12px;
-        }
-        
-     }
-     @media only screen and (max-width: 740px) {
+     @media only screen and (max-width: 991px) {
         .project__grid{
             margin: 50px 0;
             display: flex;


### PR DESCRIPTION
## **Description**
Solved Overflowing of project-page-wrapper, nav and footer in page of layer5/projects in between 991px to 780px.

This PR fixes #4533

<img width="871" alt="Screenshot 2023-07-12 at 10 20 11 PM" src="https://github.com/layer5io/layer5/assets/90668597/6c4564a9-12f3-49dc-8d70-a0ac55d853c6">

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
