### PR TITLE
chore: added quote to community/community-managers page

### DIFF
--- a/src/components/Inline-quotes/index.js
+++ b/src/components/Inline-quotes/index.js
@@ -24,8 +24,8 @@ text-align: center;
     }
 
     h4 {
-        text-align: right;
-        flex: 0 0 65%;
+        text-align: ${props => props.onlyQuoteIsPresent ? "center" : "right"};
+        flex: ${props => props.onlyQuoteIsPresent ? "0 0 100%" : "0 0 65%"};
         font-weight: 100;
         font-style: italic;
         @media screen and (max-width: 600px) {
@@ -99,10 +99,10 @@ const InlineQuotes = ({ person, title, quote,image }) => {
   }, [inView, quoteInView]);
 
   return (
-    <QuotesWrapper>
+    <QuotesWrapper onlyQuoteIsPresent={!(image || person || title)}>
       <div className={quoteInView ? "quote-box border" : "quote-box"} ref={quoteRef}>
         <h4>❝ {quote} ❞</h4>
-        <hr />
+        {(image || person || title) && <hr />}
         {
           image &&
           <img src={image}></img>

--- a/src/sections/Community/CommunityManagers/index.js
+++ b/src/sections/Community/CommunityManagers/index.js
@@ -5,7 +5,7 @@ import ProfileCard from "../../../components/Profile-card";
 import CommunityManagersWrapper from "./styles";
 import { useStaticQuery, graphql } from "gatsby";
 import { Link } from "gatsby";
-
+import InlineQuotes from "../../../components/Inline-quotes";
 
 const CommunityManagers = () => {
   const data = useStaticQuery(
@@ -58,6 +58,7 @@ const CommunityManagers = () => {
             ))}
           </Row>
         </div>
+        <InlineQuotes quote={"Thank you so much for your kind words. I absolutely love this community."}/>
         <div className="expect">
           <h2> What Does a Community Manager Do? </h2>
           <p> Layer5 Community Managers generally oversee community activities and support ongoing initiatives. They are responsible for the health and growth of the community.

--- a/src/sections/Community/CommunityManagers/index.js
+++ b/src/sections/Community/CommunityManagers/index.js
@@ -58,7 +58,7 @@ const CommunityManagers = () => {
             ))}
           </Row>
         </div>
-        <InlineQuotes quote={"Thank you so much for your kind words. I absolutely love this community."}/>
+        <InlineQuotes quote={"Thank you so much for your kind words. I absolutely love this community."} person={"Naureen Imran"}/>
         <div className="expect">
           <h2> What Does a Community Manager Do? </h2>
           <p> Layer5 Community Managers generally oversee community activities and support ongoing initiatives. They are responsible for the health and growth of the community.


### PR DESCRIPTION
**Description**

This PR fixes #4579 

**Notes for Reviewers**
I have added the inline quote to [https://layer5.io/community/community-managers](https://layer5.io/community/community-managers) after the manager's profile card grid.
![Screenshot (263)](https://github.com/layer5io/layer5/assets/72399705/82516bc9-4d4a-4cff-8ca3-1d5c8342fe0b)


In the `src/components/Inline-quotes/index.js` file, I have made the following changes
- Added a new prop called `onlyQuoteIsPresent` to the `QuotesWrapper` styled component. This prop is used to conditionally style the h4 element that contains the quote. When onlyQuoteIsPresent is true, that is, none of the `image`, `person`, and `title`  props are present, the h4 element will occupy 100% width and be aligned to the center instead of the default 65% width, and right alignment.
- and also checks if only the `quote` prop is present then it will not render the `hr` tag.

Let me know if any changes are required.
**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
