### PR TITLE
Increment in z-index Value for Scroll Up Button

### DIFF
--- a/src/components/Scrolltotop-button/ScrollToTopStyles.js
+++ b/src/components/Scrolltotop-button/ScrollToTopStyles.js
@@ -14,7 +14,7 @@ export const BackToTopButton = styled.button`
     background-color: #3c494f;
     box-shadow: 0 2px 5px 0 rgba(0,0,0,.26);
     cursor: pointer;
-    z-index: 999
+    z-index: 9999
 `;
 
 const onMountBtnAnimation = keyframes`


### PR DESCRIPTION
**Description**

This PR fixes #4663 

**Notes for Reviewers**
I have changed the value of z-index from stop overlapping with subscribe button.

**Output**
<img width="305" alt="Screenshot 2023-07-31 193147" src="https://github.com/layer5io/layer5/assets/96860884/88ea9650-dcdd-428e-8db7-b5b24b4939ea">


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
