### PR TITLE
4ddx:Fix/Text-color-hover Signed off by Ishan Kumar <ishanakshar@gmail.com>

### DIFF
--- a/src/components/AdventuresVol/adventures-vol.style.js
+++ b/src/components/AdventuresVol/adventures-vol.style.js
@@ -99,6 +99,6 @@ export const AdventuresVolWrapper = styled.div`
 	}
 
 	.handbook__card:hover .handbook__card--head {
-	  color: ${props => props.theme.text};
+	  color: white;
 	}
 `;


### PR DESCRIPTION
**Description**

This PR fixes #4615

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
Signed-off-by: Ishan Kumar <ishanakshar@gmail.com>
- [ * ] Yes, I signed my commits.
 

Fixed card's text-color on hover at [page](https://layer5.io/community/adventures-of-five-and-friends) to "white" instead of rgb(0,0,0)