### PR TITLE
Learning path link fixed

### DIFF
--- a/src/collections/service-mesh-books/the-enterprise-path-to-service-mesh-architectures-2nd-Edition/index.mdx
+++ b/src/collections/service-mesh-books/the-enterprise-path-to-service-mesh-architectures-2nd-Edition/index.mdx
@@ -48,7 +48,7 @@ This updated edition discusses several service meshes available and the tools yo
     <span
       dangerouslySetInnerHTML={{
         __html:
-          'While waiting for your copy to arrive, take a free <a href="https://layer5.io/learn/learning-path">learning path</a>.',
+          'While waiting for your copy to arrive, take a free <a href="https://layer5.io/learn/learning-paths">learning path</a>.',
       }}
     />
   }

--- a/src/collections/service-mesh-books/the-enterprise-path-to-service-mesh-architectures/index.mdx
+++ b/src/collections/service-mesh-books/the-enterprise-path-to-service-mesh-architectures/index.mdx
@@ -49,7 +49,7 @@ Three most important things readers will learn from this book:
     <span
       dangerouslySetInnerHTML={{
         __html:
-          'While waiting for your copy to arrive, take a free <a href="https://layer5.io/learn/learning-path">learning path</a>.',
+          'While waiting for your copy to arrive, take a free <a href="https://layer5.io/learn/learning-paths">learning path</a>.',
       }}
     />
   }


### PR DESCRIPTION
**Description**

This PR fixes #4695 

**Notes for Reviewers**
fixes two pages : 
1) https://layer5.io/learn/service-mesh-books/the-enterprise-path-to-service-mesh-architectures
2) https://layer5.io/learn/service-mesh-books/the-enterprise-path-to-service-mesh-architectures-2nd-edition


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
