### PR TITLE
Updated debounceTimeout of Blog Search bar

### DIFF
--- a/src/reusecore/Search/index.js
+++ b/src/reusecore/Search/index.js
@@ -37,7 +37,7 @@ const SearchBox = ({
           type="text"
           value={searchQuery}
           minLength={1}
-          debounceTimeout={500}
+          debounceTimeout={5000}
           onChange={(e) => handleChange(e)}
           placeholder="Search..."
         />


### PR DESCRIPTION
**Description**
This PR fixes #4788

Blog page: [https://layer5.io/blog](https://layer5.io/blog)

The initial setting for debounceTimeout was 500ms (0.5 seconds), I propose to increase the debounceTimeout to 5000ms (5 seconds). 
This adjustment allows the search functionality to wait for a slightly longer duration before triggering a search request. As a result, users will experience a smoother and more responsive search process, especially when they are typing multiple search terms or navigating between different search inputs.

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
