### PR TITLE
Add description prop to books, careers, integrations and workshops pages SEO

### DIFF
--- a/src/templates/book-single.js
+++ b/src/templates/book-single.js
@@ -48,5 +48,5 @@ export default BookSinglePage;
 
 
 export const Head = ({ data }) => {
-  return <SEO title={data.mdx.frontmatter.title} image={data.mdx.frontmatter.thumbnail.publicURL} />;
+  return <SEO title={data.mdx.frontmatter.title} image={data.mdx.frontmatter.thumbnail.publicURL} description={data.mdx.frontmatter.abstract}/>;
 };

--- a/src/templates/career-single.js
+++ b/src/templates/career-single.js
@@ -14,6 +14,7 @@ export const query = graphql`
                 title,
                 type,
                 location,
+                abstract,
                 start_date,
                 duration,
                 salary,
@@ -41,5 +42,5 @@ const CareerSinglePage = ({ data }) => {
 export default CareerSinglePage;
 
 export const Head = ({ data }) => {
-  return <SEO title={data.mdx.frontmatter.title} />;
+  return <SEO title={data.mdx.frontmatter.title} description={data.mdx.frontmatter.abstract}/>;
 };

--- a/src/templates/integrations.js
+++ b/src/templates/integrations.js
@@ -54,5 +54,5 @@ const Integrations = ({ data }) => {
 export default Integrations;
 
 export const Head = ({ data }) => {
-  return <SEO title={data.mdx.frontmatter.title} image={data.mdx.frontmatter.integrationIcon.publicURL} />;
+  return <SEO title={data.mdx.frontmatter.title} image={data.mdx.frontmatter.integrationIcon.publicURL} description={data.mdx.frontmatter.subtitle}/>;
 };

--- a/src/templates/workshop-single.js
+++ b/src/templates/workshop-single.js
@@ -52,5 +52,5 @@ const WorkshopSingle = ({ data }) => {
 export default WorkshopSingle;
 
 export const Head = ({ data }) => {
-  return  <SEO title={data.mdx.frontmatter.title} image={data.mdx.frontmatter.thumbnail.publicURL} />;
+  return  <SEO title={data.mdx.frontmatter.title} image={data.mdx.frontmatter.thumbnail.publicURL} description={data.mdx.frontmatter.abstract}/>;
 };


### PR DESCRIPTION
**Description**

Follow up PR for #4836 ( [Comment](https://github.com/layer5io/layer5/pull/4836#issuecomment-1710581649) )

**Notes for Reviewers**
- I have checked all the templates for a field to add as a description to the SEO component
- Found some fields suitable in the `books`, `careers`, `integrations`, and `workshops` pages.
- The `news` pages have a field `subtitle` as a suitable field for description but when I look into the `.mdx` files there are majority of empty strings as subtitles so they were not included here.
- Let me know If I need to add `description` to any other pages

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
