### PR TITLE
Fixed full text for "sign into" call to action not visible in light mode 

### DIFF
--- a/src/components/ScenarioCard/ScenarioCard.style.js
+++ b/src/components/ScenarioCard/ScenarioCard.style.js
@@ -78,6 +78,7 @@ export const ScenarioCardWrapper = styled.div`
         justify-content:center; 
         margin-top:4rem;
         width:100%;
+        color: white;
     }
 
 	.active {

--- a/src/sections/Learn/Lab-single/LabSinglePageWrapper.style.js
+++ b/src/sections/Learn/Lab-single/LabSinglePageWrapper.style.js
@@ -56,6 +56,7 @@ const LabSinglePageWrapper = styled.div`
 	}
 	.cardContent {
 		margin: 0 5rem;
+		color: white;
 	}
 	#katacoda-scenario {
 		min-height: 25rem;

--- a/src/sections/Learn/Lab-single/LabSinglePageWrapper.style.js
+++ b/src/sections/Learn/Lab-single/LabSinglePageWrapper.style.js
@@ -57,6 +57,12 @@ const LabSinglePageWrapper = styled.div`
 	.cardContent {
 		margin: 0 5rem;
 		color: white;
+		a {
+			display: flex;
+		    color: ${props => props.theme.linkColor};
+		    &:hover{
+		        color: white;
+			}
 	}
 	#katacoda-scenario {
 		min-height: 25rem;


### PR DESCRIPTION
**Description**

This PR fixes #4931

**Notes for Reviewers**
I fixed the full text for the "sign into" call to action not visible in light mode. Please let me know if there are any changes to be made.


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
