### PR TITLE
Added Navigation for "Handling PRs Made Without Being Assigned" in ha…

### DIFF
--- a/src/sections/Community/Handbook/contributing.js
+++ b/src/sections/Community/Handbook/contributing.js
@@ -14,6 +14,7 @@ const contents = [
   { id: 3, link: "#Sign-off commits", text: "Sign-off commits" },
   { id: 4, link: "#Push changes to Github", text: "Push changes to Github" },
   { id: 5, link: "#Create a pull request", text: "Create a pull request" },
+  { id: 6, link: "#Handling PRs Made Without Being Assigned", text: "Handling PRs Made Without Being Assigned" },
 ];
 
 const contributingGuide = () => {
@@ -228,7 +229,7 @@ const contributingGuide = () => {
               </li>
             </ul>
           </div>
-          <h2>Handling PRs Made Without Being Assigned</h2>
+          <h2 id="Handling PRs Made Without Being Assigned">Handling PRs Made Without Being Assigned</h2>
           <p>
           At <a href="https://layer5.io/">Layer5</a>, we usually suggest to contributors that they ask maintainers to assign them to the issue they want to work on. But sometimes, pull requests that aren't assigned to anyone can be found. In such cases, it's important to be flexible and ready to adapt. Here are some simple guidelines for dealing with these unassigned contributions:
           </p>


### PR DESCRIPTION


**Description**

I have added navigation for the "Handling PRs Made Without Being Assigned"
This PR fixes #4965

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
