### PR TITLE
Add green glow hover effect to cards

### DIFF
--- a/src/components/Learn-Components/Card-Component/index.js
+++ b/src/components/Learn-Components/Card-Component/index.js
@@ -40,7 +40,7 @@ const CardComponent = ({ tutorial, path, courseCount }) => {
         <Link to={path} className="card-link">
           <div
             style={{ borderTop: `5px solid ${tutorial.frontmatter.themeColor}` }}
-            className="card-parent"
+            className="card-parent card-active"
           >
 
             <div>

--- a/src/components/Learn-Components/Card-Component/learn-card.style.js
+++ b/src/components/Learn-Components/Card-Component/learn-card.style.js
@@ -6,11 +6,11 @@ const CardWrapper = styled.div`
     margin: auto;
     border-radius: 1rem;
     cursor: pointer;
-    box-shadow: rgba(0, 179, 158, 0.9) 0px 2px 10px 1px;
+    box-shadow: rgba(0, 179, 158, 0.4) 0px 0px 15px 8px;
     transition: all 0.8s cubic-bezier(0.2, 0.8, 0.2, 1) 0.1s;
 
     &:hover{
-        box-shadow: rgba(0, 179, 158, 0.7) 0px 2px 18px 5px;
+        box-shadow: rgba(0, 179, 158, 0.9) 0px 0px 19px 6px;
     }
 
     .card-link{

--- a/src/components/Learn-Components/Card-Component/learn-card.style.js
+++ b/src/components/Learn-Components/Card-Component/learn-card.style.js
@@ -5,12 +5,14 @@ const CardWrapper = styled.div`
     min-height: 16rem;
     margin: auto;
     border-radius: 1rem;
-    cursor: pointer;
-    box-shadow: rgba(0, 179, 158, 0.4) 0px 0px 15px 8px;
-    transition: all 0.8s cubic-bezier(0.2, 0.8, 0.2, 1) 0.1s;
 
-    &:hover{
-        box-shadow: rgba(0, 179, 158, 0.9) 0px 0px 19px 6px;
+    .card-active{
+        cursor: pointer;
+        transition: all 0.8s cubic-bezier(0.2, 0.8, 0.2, 1) 0.1s;
+
+        &:hover{
+            box-shadow: rgba(0, 179, 158, 0.9) 0px 0px 19px 6px;
+        }
     }
 
     .card-link{

--- a/src/components/Learn-Components/Card-Component/learn-card.style.js
+++ b/src/components/Learn-Components/Card-Component/learn-card.style.js
@@ -5,6 +5,13 @@ const CardWrapper = styled.div`
     min-height: 16rem;
     margin: auto;
     border-radius: 1rem;
+    cursor: pointer;
+    box-shadow: rgba(0, 179, 158, 0.9) 0px 2px 10px 1px;
+    transition: all 0.8s cubic-bezier(0.2, 0.8, 0.2, 1) 0.1s;
+
+    &:hover{
+        box-shadow: rgba(0, 179, 158, 0.7) 0px 2px 18px 5px;
+    }
 
     .card-link{
         color: black;


### PR DESCRIPTION
**Description**
The Cards on the Learning Path page had no hover effect unlike the rest of the website
![image](https://github.com/layer5io/layer5/assets/93793691/390e8765-ce88-4607-a188-11ad8b41cefd)

This PR fixes #4986 
Added the green hover effect to the cards, similar to the pricing page cards.
![image](https://github.com/layer5io/layer5/assets/93793691/962f14ad-8619-4467-9f9e-6d9046d3506d)

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
