### PR TITLE
#5045: Made learning path cards mobile responsive

### DIFF
--- a/src/components/Learn-Components/Card-Component/learn-card.style.js
+++ b/src/components/Learn-Components/Card-Component/learn-card.style.js
@@ -85,7 +85,7 @@ const CardWrapper = styled.div`
     
     @media (max-width: 500px) {
         max-width: 100%;
-        padding: 0 1rem;
+        padding: 0 0rem;
     
         .card-head h3 {
             font-size: 1.1rem;

--- a/src/components/Learn-Components/Card-Component/learn-card.style.js
+++ b/src/components/Learn-Components/Card-Component/learn-card.style.js
@@ -82,6 +82,35 @@ const CardWrapper = styled.div`
     @media(max-width: 1300px){
         margin: 1rem auto;
     }
+    
+    @media (max-width: 500px) {
+        max-width: 100%;
+        padding: 0 1rem;
+    
+        .card-head h3 {
+            font-size: 1.1rem;
+        }
+    
+        .card-desc .summary {
+            font-size: 0.8rem;
+        }
+    
+        .card-image img {
+            height: 6rem;
+            width: 6rem;
+        }
+        .card-head span {
+            font-size: 0.55rem; 
+            padding: 0.05rem 0.5rem; 
+        }
+        
+        .card-subdata p {
+            font-size: 0.8rem; 
+            bottom: 0.5rem; 
+        }
+    }
+   
+    
 `;
 
 export default CardWrapper;


### PR DESCRIPTION
**Description**

This PR fixes #5045
This PR fixes the mobile responsiveness issue for the learning cards as mentioned in issue #5045.

<img width="326" alt="5" src="https://github.com/layer5io/layer5/assets/122199576/b92f7289-b61d-4b08-a211-09c5c410740f">


**Notes for Reviewers**

Adjusted the CSS for better mobile responsiveness.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
