### PR TITLE
Updated Incorrect Meshery Catalog Link In Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ alt="Nighthawk" align="left" />
 
 
 <p style="clear:both;">
-<h2><a href="https://layer5.io/projects/catalog">Meshery Catalog</a></h2>
+<h2><a href="https://layer5.io/catalog">Meshery Catalog</a></h2>
 <a href="">
   <img src=".github/assets/images/catalog/catalog.svg"
 style="float:left;margin:10px;" width="125px"


### PR DESCRIPTION
Fixed broken Meshery Catalog link

**Description**

This PR fixes #5061 

**Notes for Reviewers**
There was an Incorrect Meshery Catalog Link In Readme file which was corrected in this commit.


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

