### PR TITLE
Made ebpf logo visible in dark mode

### DIFF
--- a/src/sections/Meshmap/meshmap-catalog.js
+++ b/src/sections/Meshmap/meshmap-catalog.js
@@ -428,7 +428,7 @@ const Catalog = () => {
               <p>Cloud Native Patterns</p>
             </div>
             <div>
-              <img src={Ebpf} />
+              <img src={Ebpf} style={{ filter: "drop-shadow(0.8px 1.5px 1.3px white) contrast(110%)" }}/>
               <p className="ebpf-text">eBPF Programs</p>
             </div>
             <div>


### PR DESCRIPTION
**Description**

This PR fixes #5070 

**Notes for Reviewers**
Earlier the eBPF logo [on](https://layer5.io/cloud-native-management/meshmap) was not visible clearly.

![Screenshot 2023-10-22 182412](https://github.com/layer5io/layer5/assets/70795867/311732d7-032f-4e11-b5e4-a21177d64e4d)

Added a white shadow to make the logo visible

![Screenshot 2023-10-22 182726](https://github.com/layer5io/layer5/assets/70795867/350c425d-a061-4607-83a1-7cd83f303ce7)



**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
