### PR TITLE
Add docs.layer5.io to repo overview

### DIFF
--- a/src/sections/Community/Handbook/repo-data.js
+++ b/src/sections/Community/Handbook/repo-data.js
@@ -148,6 +148,15 @@ export const repo_data = [
         maintainers_name: ["Antonette Caldwell"],
         link: ["https://layer5.io/community/members/antonette-caldwell"],
         repository: "https://github.com/layer5io/sistent"
+      },
+      {
+        project: "Layer5 Documentation",
+        image: five,
+        site: "https://docs.layer5.io/",
+        language: "Hugo",
+        maintainers_name: ["Pranav Singh"],
+        link: ["https://layer5.io/community/members/pranav-singh"],
+        repository: "https://github.com/layer5io/docs"
       }
     ],
   },


### PR DESCRIPTION
**Description**

This PR fixes #5102 

**Notes for Reviewers**
- Added [docs.layer5.io](https://layer5.io/community/handbook/repository-overview) to Repository overview


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
