### PR TITLE
correct Order of Section Titles on Recognition Page

### DIFF
--- a/src/sections/Community/Handbook/recognition.js
+++ b/src/sections/Community/Handbook/recognition.js
@@ -32,12 +32,12 @@ import StreamerLogo from "../../../assets/images/streamer/streamer.svg";
 const contents = [
   { id: 0, link: "#Profile Bages", text: "Profile Bages" },
   { id: 1, link: "#Membership", text: "Membership to GitHub" },
-  { id: 2, link: "#Badges", text: "Community Member Profile Badges" },
   {
-    id: 3,
+    id: 2,
     link: "#Community_member_profile",
     text: "Community Member Profile",
   },
+  { id: 3, link: "#Badges", text: "Community Member Profile Badges" },
   { id: 4, link: "#SocialMedia", text: "Recognition on Social Media Platforms" },
 ];
 


### PR DESCRIPTION
### Before
![282225094-9ca36b4d-2bd0-4293-819f-19d2936a9e48](https://github.com/layer5io/layer5/assets/95649718/3e2d15c4-82c6-4ec4-8a28-722e8c92b2ba)
### After Update
![Screenshot 2023-11-11 214447](https://github.com/layer5io/layer5/assets/95649718/3f0d1616-8a48-4418-be59-84d261d97587)

**Description**
This pull request addresses an issue where the section titles on the Recognition Page were displayed in an incorrect order. The table of contents has been adjusted to ensure the proper sequence of section titles.  The issue has been successfully resolved, and the corrected section title order improves the overall user experience on the Recognition Page.

**Resolved Issue:**
The section titles on the Recognition Page were initially presented in a swapped order, leading to confusion for users. This pull request corrects the table of contents, ensuring that section titles are now displayed in the expected and logical sequenc

This PR fixes #5111

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
