### PR TITLE
 prevent-skewing-of-images-in-side-menu-on-integrations-individual-pages-howItWorks-section

### DIFF
--- a/src/sections/Meshery/Meshery-integrations/Individual-Integrations/howItWork.js
+++ b/src/sections/Meshery/Meshery-integrations/Individual-Integrations/howItWork.js
@@ -83,6 +83,7 @@ const HowIntegrationWorksWrapper = styled.section`
 							img {
 								height: 5rem;
 								vertical-align: middle;
+								object-fit: contain;
 							}
 						}
 					}
@@ -108,6 +109,7 @@ const HowIntegrationWorksWrapper = styled.section`
 
 				li a img {
 					height: 4rem;
+					object-fit: contain;
 				}
 			}
 		}
@@ -164,6 +166,7 @@ const HowIntegrationWorksWrapper = styled.section`
 
 					li a img {
 						height: 2.5rem;
+						object-fit: contain;
 					}
 				}
 			}


### PR DESCRIPTION
**Description**

This PR fixes #5156
- adds `object-fit: contain` property so that images within side navigator are resized to fit and maintain their aspect ratio.

i.e.  page: [aws-target-group-binding page](https://layer5.io/cloud-native-management/meshery/integrations/aws-target-group-binding):

**Current**:

<img width="570" alt="Screenshot 2023-12-05 011528" src="https://github.com/layer5io/layer5/assets/110674407/4a6100ae-de61-469a-bb59-b099f5db4c03">
<hr />

**After the changes**:

<img width="524" alt="Screenshot 2023-12-05 011543" src="https://github.com/layer5io/layer5/assets/110674407/cdce89a9-0286-48cb-8b47-fa81a34e7c9d">


**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
