### PR TITLE
Change the green used for headers on this page to Caribbean green

### DIFF
--- a/src/sections/Meshmap/Meshmap-collaborate/collaboration-feature-team.js
+++ b/src/sections/Meshmap/Meshmap-collaborate/collaboration-feature-team.js
@@ -48,7 +48,7 @@ const CollaborationFeatureWrapper = styled.div`
 
     h2 {
       span {
-        color: #00b39f;
+        color: #00D3A9;
       }
     }
 

--- a/src/sections/Meshmap/Meshmap-collaborate/collaboration-feature-work.js
+++ b/src/sections/Meshmap/Meshmap-collaborate/collaboration-feature-work.js
@@ -39,7 +39,7 @@ const CollaborationFeatureWrapper = styled.div`
 
     h2 {
       span {
-        color: #00b39f;
+        color: #00D3A9;
       }
     }
 


### PR DESCRIPTION
**Description**

The green color used for the headings on the [Collaborate](https://layer5.io/cloud-native-management/meshmap/collaborate) page changed to Caribbean green. Specifically, the headings "Collaborate with your Team" and "Work from Anywhere" used the lighter of the two greens.

![Screenshot (30)](https://github.com/layer5io/layer5/assets/150526286/d4c89c23-6d88-4cf1-b4c4-5ebc58afe8a3)


This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
