### PR TITLE
Community Handbook: recognition page spelling mistake corrected

### DIFF
--- a/src/sections/Community/Handbook/recognition.js
+++ b/src/sections/Community/Handbook/recognition.js
@@ -70,7 +70,7 @@ const RecognitionPage = () => {
               <h2 id="communityGuidelines">Your Efforts Do Not Go Unnoticed or Unappreciated</h2>
             </a>
             <p>
-              As an open source-first community, we very much appreciate the engagement of individuals within the Layer5 community. We wouldn't be here without you. Our success is a collective one.Consequently, we are quite intentional about defining and encouraging the journey for each individual community member. No small part of their journey is that of recongizing their accomplishments and publicly celebrating their accolades. We do so in a number of ways.
+              As an open source-first community, we very much appreciate the engagement of individuals within the Layer5 community. We wouldn't be here without you. Our success is a collective one.Consequently, we are quite intentional about defining and encouraging the journey for each individual community member. No small part of their journey is that of recognizing their accomplishments and publicly celebrating their accolades. We do so in a number of ways.
             </p>
             <a id="Membership">
               <h3>Membership to the Github organizations</h3>


### PR DESCRIPTION
**Description**
I have corrected the spelling in the file with path : **/layer5/src/sections/Community/Handbook/recognition.js**

Screenshot is attached:

<img width="933" alt="Screenshot 2024-01-27 132124" src="https://github.com/layer5io/layer5/assets/86592220/ff4d6930-258e-4950-bb71-bc2d198988f0">


This PR fixes #5350 

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
