### PR TITLE
feat: list model components on individual integration pages

### DIFF
--- a/src/sections/Meshery/Meshery-integrations/Individual-Integrations/Component.style.js
+++ b/src/sections/Meshery/Meshery-integrations/Individual-Integrations/Component.style.js
@@ -14,38 +14,39 @@ export const ComponentsWrapper = styled.div`
   }
 
   .componentimg {
-    flex-basis: 30%;
+    width: 70px;
+    height: 70px;
   }
   .componentimg img {
     width: 100%;
+    height: 100%;
+    object-fit: contain;
   }
 
   .componentsSection {
     display: flex;
-    justify-content: center;
     flex-wrap: wrap;
-    gap: 2rem;
-
+    gap: 1.5rem;
+    padding: 3rem 2rem 7rem 2rem;
   }
   .maincontainer {
-    height: 150px;
-    width: 300px;
-    border-radius: 10px;
     display: flex;
-    justify-content: center;
     align-items: center;
-    padding: .2rem;
+    gap: 1rem;
+    background-color: ${props => props.theme.grey212121ToGreyEEEEEE};
+    padding: 0.75rem 1.5rem;
+    border-radius: 0.25rem;
+    width: 100%;
+    flex: 30%;
   }
+
   .items {
-    background-color: #D2D8DA; //#E7EFF3;
-    padding: 0.625rem 1.5625rem;
     border-radius: 0.625rem;
     text-transform: uppercase;
-    color: #1e2117;
+    color: ${props => props.theme.text};
     font-size: 0.875rem;
-    cursor: pointer;
     transition: all .1s ease-in-out;
-    
+    line-height: 1.1875rem;
 `;
 
 

--- a/src/sections/Meshery/Meshery-integrations/Individual-Integrations/Component.style.js
+++ b/src/sections/Meshery/Meshery-integrations/Individual-Integrations/Component.style.js
@@ -36,7 +36,7 @@ export const ComponentsWrapper = styled.div`
     gap: 1rem;
     background-color: ${props => props.theme.grey212121ToGreyEEEEEE};
     padding: 0.5rem 1rem;
-    border-radius: 0.25rem;
+    border-radius: 0.85rem;
     width: 100%;
     flex: 30%;
     max-width: 350px;

--- a/src/sections/Meshery/Meshery-integrations/Individual-Integrations/Component.style.js
+++ b/src/sections/Meshery/Meshery-integrations/Individual-Integrations/Component.style.js
@@ -14,8 +14,8 @@ export const ComponentsWrapper = styled.div`
   }
 
   .componentimg {
-    width: 70px;
-    height: 70px;
+    width: 80px;
+    height: 80px;
   }
   .componentimg img {
     width: 100%;
@@ -35,7 +35,7 @@ export const ComponentsWrapper = styled.div`
     align-items: center;
     gap: 1rem;
     background-color: ${props => props.theme.grey212121ToGreyEEEEEE};
-    padding: 0.75rem 1.5rem;
+    padding: 0.5rem 1rem;
     border-radius: 0.25rem;
     width: 100%;
     flex: 30%;
@@ -49,6 +49,7 @@ export const ComponentsWrapper = styled.div`
     font-size: 0.875rem;
     transition: all .1s ease-in-out;
     line-height: 1.1875rem;
+    width: 100%;
 `;
 
 

--- a/src/sections/Meshery/Meshery-integrations/Individual-Integrations/Component.style.js
+++ b/src/sections/Meshery/Meshery-integrations/Individual-Integrations/Component.style.js
@@ -28,6 +28,7 @@ export const ComponentsWrapper = styled.div`
     flex-wrap: wrap;
     gap: 1.5rem;
     padding: 3rem 2rem 7rem 2rem;
+    justify-content: center;
   }
   .maincontainer {
     display: flex;
@@ -38,6 +39,7 @@ export const ComponentsWrapper = styled.div`
     border-radius: 0.25rem;
     width: 100%;
     flex: 30%;
+    max-width: 350px;
   }
 
   .items {

--- a/src/sections/Meshery/Meshery-integrations/Individual-Integrations/Component.style.js
+++ b/src/sections/Meshery/Meshery-integrations/Individual-Integrations/Component.style.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 export const ComponentsWrapper = styled.div`
   .heading {
     text-align: center;
-    margin-top: 5rem;
+    margin-top: 7rem;
 
     h1 {
     }

--- a/src/sections/Meshery/Meshery-integrations/Individual-Integrations/Component.style.js
+++ b/src/sections/Meshery/Meshery-integrations/Individual-Integrations/Component.style.js
@@ -3,9 +3,9 @@ import styled from "styled-components";
 export const ComponentsWrapper = styled.div`
   .heading {
     text-align: center;
+    margin-top: 5rem;
 
     h1 {
-      line-height: 3.75rem;
     }
 
     h2 {
@@ -27,7 +27,7 @@ export const ComponentsWrapper = styled.div`
     display: flex;
     flex-wrap: wrap;
     gap: 1.5rem;
-    padding: 3rem 2rem 7rem 2rem;
+    padding: 3rem 2rem 5rem 2rem;
     justify-content: center;
   }
   .maincontainer {

--- a/src/sections/Meshery/Meshery-integrations/Individual-Integrations/Component.style.js
+++ b/src/sections/Meshery/Meshery-integrations/Individual-Integrations/Component.style.js
@@ -1,0 +1,51 @@
+import styled from "styled-components";
+
+export const ComponentsWrapper = styled.div`
+  .heading {
+    text-align: center;
+
+    h1 {
+      line-height: 3.75rem;
+    }
+
+    h2 {
+      font-weight: normal;
+    }
+  }
+
+  .componentimg {
+    flex-basis: 30%;
+  }
+  .componentimg img {
+    width: 100%;
+  }
+
+  .componentsSection {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 2rem;
+
+  }
+  .maincontainer {
+    height: 150px;
+    width: 300px;
+    border-radius: 10px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: .2rem;
+  }
+  .items {
+    background-color: #D2D8DA; //#E7EFF3;
+    padding: 0.625rem 1.5625rem;
+    border-radius: 0.625rem;
+    text-transform: uppercase;
+    color: #1e2117;
+    font-size: 0.875rem;
+    cursor: pointer;
+    transition: all .1s ease-in-out;
+    
+`;
+
+

--- a/src/sections/Meshery/Meshery-integrations/Individual-Integrations/ComponentsGrid.js
+++ b/src/sections/Meshery/Meshery-integrations/Individual-Integrations/ComponentsGrid.js
@@ -1,0 +1,41 @@
+import React from "react";
+import { ComponentsWrapper } from "./Component.style";
+
+
+const ComponentsGrid = ({ frontmatter }) => {
+
+
+  const components = frontmatter.components.map((component) => {
+    const { name, colorIcon } = component; // currently we don't have description for components
+    return { name, colorIcon };
+  });
+
+
+  return (
+    <ComponentsWrapper>
+      <section className="heading">
+        <h1>
+          {components.length} components of {frontmatter.title}
+        </h1>
+        <h2>Support for your Cloud Native Infrastructure and Apps</h2>
+      </section>
+
+      <section className="componentsSection">
+        {components.map((item) => (
+          <div key={item.id} className="childContainer">
+            <div className="maincontainer">
+              <div className="componentimg">
+                <img src={item.colorIcon.publicURL} alt={item.name} />
+              </div>
+              <div className="textcontent">
+                <p className="items">{item.name}</p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </section>
+    </ComponentsWrapper>
+  );
+};
+
+export default ComponentsGrid;

--- a/src/sections/Meshery/Meshery-integrations/Individual-Integrations/ComponentsGrid.js
+++ b/src/sections/Meshery/Meshery-integrations/Individual-Integrations/ComponentsGrid.js
@@ -15,21 +15,18 @@ const ComponentsGrid = ({ frontmatter }) => {
     <ComponentsWrapper>
       <section className="heading">
         <h1>
-          {components.length} components of {frontmatter.title}
+          {frontmatter.title} Components ({components.length})
         </h1>
-        <h2>Support for your Cloud Native Infrastructure and Apps</h2>
       </section>
 
       <section className="componentsSection">
         {components.map((item) => (
-          <div key={item.id} className="childContainer">
-            <div className="maincontainer">
-              <div className="componentimg">
-                <img src={item.colorIcon.publicURL} alt={item.name} />
-              </div>
-              <div className="textcontent">
-                <p className="items">{item.name}</p>
-              </div>
+          <div key={item.id} className="maincontainer">
+            <div className="componentimg">
+              <img src={item.colorIcon.publicURL} alt={item.name} />
+            </div>
+            <div className="textcontent">
+              <p className="items">{item.name.replaceAll("-", " ")}</p>
             </div>
           </div>
         ))}

--- a/src/sections/Meshery/Meshery-integrations/Individual-Integrations/ComponentsGrid.js
+++ b/src/sections/Meshery/Meshery-integrations/Individual-Integrations/ComponentsGrid.js
@@ -25,9 +25,9 @@ const ComponentsGrid = ({ frontmatter }) => {
             <div className="componentimg">
               <img src={item.colorIcon.publicURL} alt={item.name} />
             </div>
-            <div className="textcontent">
-              <p className="items">{item.name.replaceAll("-", " ")}</p>
-            </div>
+            <p className="items">{item.name.replaceAll("-", " ")}</p>
+            {/* <div className="textcontent">
+            </div> */}
           </div>
         ))}
       </section>

--- a/src/sections/Meshery/Meshery-integrations/Individual-Integrations/howItWork.js
+++ b/src/sections/Meshery/Meshery-integrations/Individual-Integrations/howItWork.js
@@ -12,7 +12,7 @@ const HowIntegrationWorksWrapper = styled.section`
 	.section-data {
 		padding: 1rem 2rem 0;
 		text-align: center;
-		margin-top: 5rem;
+		padding-top: 5rem;
 	}
 
 	.section-header {

--- a/src/sections/Meshery/Meshery-integrations/Individual-Integrations/howItWork.js
+++ b/src/sections/Meshery/Meshery-integrations/Individual-Integrations/howItWork.js
@@ -12,6 +12,7 @@ const HowIntegrationWorksWrapper = styled.section`
 	.section-data {
 		padding: 1rem 2rem 0;
 		text-align: center;
+		margin-top: 5rem;
 	}
 
 	.section-header {

--- a/src/sections/Meshery/Meshery-integrations/Individual-Integrations/index.js
+++ b/src/sections/Meshery/Meshery-integrations/Individual-Integrations/index.js
@@ -97,6 +97,11 @@ const IndividualIntegrations = ({ data }) => {
           </section>
         </div>
       </section>
+      {frontmatter.components && frontmatter.components.length > 0 && (
+        <section className="component-collection">
+          <ModelComponents frontmatter={frontmatter} />
+        </section>
+      )}
       <div>
         {isAwsItem ? (
           <HowMesheryWorksSpecs
@@ -126,11 +131,6 @@ const IndividualIntegrations = ({ data }) => {
         howitworksdetails={frontmatter.howItWorksDetails}
         slides={finalScreenshots}
       />
-      {frontmatter.components && frontmatter.components.length > 0 && (
-        <section className="component-collection">
-          <ModelComponents frontmatter={frontmatter} />
-        </section>
-      )}
       <section className="integration-collection">
         <h2>Related Integrations</h2>
         <RelatedIntegration category={frontmatter.category} />

--- a/src/sections/Meshery/Meshery-integrations/Individual-Integrations/index.js
+++ b/src/sections/Meshery/Meshery-integrations/Individual-Integrations/index.js
@@ -8,6 +8,7 @@ import HowIntegrationWorks from "./howItWork";
 import { IntegrationPageWrapper } from "./individual-integrations.style";
 import RelatedIntegration from "../IntegrationsGrid";
 import HowMesheryWorksSpecs from "../../../../components/specs";
+import ModelComponents from "./ComponentsGrid";
 
 const IndividualIntegrations = ({ data }) => {
   const { frontmatter, body } = data.mdx;
@@ -125,6 +126,12 @@ const IndividualIntegrations = ({ data }) => {
         howitworksdetails={frontmatter.howItWorksDetails}
         slides={finalScreenshots}
       />
+      {frontmatter.components && frontmatter.components.length > 0 && (
+        <section className="component-collection">
+          <h2>Model Components</h2>
+          <ModelComponents frontmatter={frontmatter} />
+        </section>
+      )}
       <section className="integration-collection">
         <h2>Related Integrations</h2>
         <RelatedIntegration category={frontmatter.category} />

--- a/src/sections/Meshery/Meshery-integrations/Individual-Integrations/index.js
+++ b/src/sections/Meshery/Meshery-integrations/Individual-Integrations/index.js
@@ -128,7 +128,6 @@ const IndividualIntegrations = ({ data }) => {
       />
       {frontmatter.components && frontmatter.components.length > 0 && (
         <section className="component-collection">
-          <h2>Model Components</h2>
           <ModelComponents frontmatter={frontmatter} />
         </section>
       )}

--- a/src/sections/Meshery/Meshery-integrations/Individual-Integrations/individual-integrations.style.js
+++ b/src/sections/Meshery/Meshery-integrations/Individual-Integrations/individual-integrations.style.js
@@ -103,7 +103,7 @@ export const IntegrationPageWrapper = styled.section`
 		};
 	}
 
-	.integration-collection{
+	.integration-collection, .component-collection {
 		margin: 2rem auto;
 		max-width: 1200px;
 		


### PR DESCRIPTION
**Description**

Currently the components lack the description, so it makes sense to list the Icon with just the component's name.

![image](https://github.com/layer5io/layer5/assets/110674407/73c0fba3-b1b9-40ae-8719-704674b04436)


This PR fixes #5282 

**Notes for Reviewers**
### This PR needs enhancements in terms of styling..

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
