### PR TITLE
Redirect url fixed

### DIFF
--- a/src/components/Features/TwoColLayout.js
+++ b/src/components/Features/TwoColLayout.js
@@ -22,7 +22,7 @@ const TwoColLayout = () => {
     <Section>
       <Container>
         <ImageWrapper ref={containerRef}>
-          <Link to="/architecture-diagram/design-architecture-diagram">
+          <Link to="/solutions/architecture-diagram">
             <img src={isDark ? DiagrammingImageDark : DiagrammingImageLight} alt="image" />
           </Link>
         </ImageWrapper>


### PR DESCRIPTION
**Description**
On clicking on the image inside the `Visualize and Simplify Platform Engineering` column on the home page, it was redirecting to the wrong URL. 

This PR fixes the wrong URL with the correct URL.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
