### PR TITLE
FIX : fixed the mesh operator logo bg low opacity in dark mode.

### DIFF
--- a/src/sections/Meshery/How-meshery-works/hero/index.js
+++ b/src/sections/Meshery/How-meshery-works/hero/index.js
@@ -26,7 +26,7 @@ const HowMesheryWorksHeroWrapper = styled.div`
     }
 
     .hero-img-wrapper{
-      background-color: ${props => props.theme.secondaryLightColorTwo};
+      background-color: ${props => props.theme.meshOperatorBG};
       border-bottom-left-radius: 4.375rem;
       border-bottom-right-radius: 4.375rem;
       vertical-align: top;

--- a/src/theme/app/themeStyles.js
+++ b/src/theme/app/themeStyles.js
@@ -13,6 +13,9 @@ const lighttheme = {
   // charcoal
   primaryColor: "#3c494f",
 
+  //mesh operator bg
+  meshOperatorBG: '#00d3a9',
+
   // silver chalice (light gray)
   primaryLightColor: "#b3b3b3",
 
@@ -238,6 +241,9 @@ export const darktheme = {
   background: "#999",
   backgroundColor: "rgb(33,33,33)",
   scrollbarColor: "#00d3a9",
+
+    //mesh operator bg
+    meshOperatorBG: '#0a0a0a',
 
   // white
   primaryColor: "#FFFFFF",


### PR DESCRIPTION
**Description**

This PR fixes #5424. I have introduced new variables in the themes file which are specifically for defining the bg color of mesh operator logo. The logo container also takes the bg from this variable now.  

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x]  Yes, I signed my commits.

 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
