### PR TITLE
[Resolved: 5563] Changed <Link> tag to <a> tag for External links. 

### DIFF
--- a/src/sections/General/Footer/index.js
+++ b/src/sections/General/Footer/index.js
@@ -107,9 +107,9 @@ const Footer = ({ location }) => {
                 </h3>
                 <ul className="section-categories">
                   <li>
-                    <Link className="category-link" href="https://docs.layer5.io">
+                    <a className="category-link" href="https://docs.layer5.io">
                       Docs
-                    </Link>
+                    </a>
                   </li>
                   <li>
                     <Link className="category-link" to="/blog">
@@ -199,9 +199,9 @@ const Footer = ({ location }) => {
                     </Link>
                   </li>
                   <li>
-                    <Link className="category-link" href="https://badges.layer5.io/">
+                    <a className="category-link" href="https://badges.layer5.io/">
                     Recognition Program
-                    </Link>
+                    </a>
                   </li>
                 </ul>
               </div>


### PR DESCRIPTION
**Description**
As suggested from Gatsby.js documentation: https://www.gatsbyjs.com/docs/linking-between-pages/#using-a-for-external-links
I just changed `<Link>` tag with `<a>` tag for External linking.

This PR fixes # 5563

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
