### PR TITLE
Solved Cards not fitting on smaller screens in Community Handbook page

### DIFF
--- a/src/components/AdventuresVol/adventures-vol.style.js
+++ b/src/components/AdventuresVol/adventures-vol.style.js
@@ -13,7 +13,19 @@ export const AdventuresVolWrapper = styled.div`
 	  overflow: hidden;
 	  height: 19rem;
 	  position: relative;
-		transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
+	  transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
+
+	  @media (max-width: 450px) {
+      width: 24.5rem;
+      }
+
+	  @media (max-width: 420px) {
+      width: 23rem;
+      }
+
+	  @media (max-width: 390px) {
+      width: 19.5rem;
+      }
 	}
 
 	.handbook__card--head {
@@ -96,6 +108,13 @@ export const AdventuresVolWrapper = styled.div`
 
 	.handbook__card:hover {
 	  scale: 1.07;
+
+	 @media (max-width: 420px) {
+      scale: 1.03;
+     }
+	 @media (max-width: 390px) {
+      scale: 1.01;
+     }
 	}
 
 	.handbook__card:hover .handbook__card--head {

--- a/src/components/HandbookCard/HandbookCard.style.js
+++ b/src/components/HandbookCard/HandbookCard.style.js
@@ -13,7 +13,15 @@ export const HandbookCardWrapper = styled.div`
 	  overflow: hidden;
 	  height: 19rem;
 	  position: relative;
-		transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
+	  transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
+
+	  @media (max-width: 420px) {
+      width: 23rem;
+      }
+
+	  @media (max-width: 390px) {
+      width: 20rem;
+      }
 	}
 
 	.handbook__card--head {
@@ -54,7 +62,10 @@ export const HandbookCardWrapper = styled.div`
 	  letter-spacing: 0px;
 	  font-weight: 400;
 	  font-size: 1.1rem;
-		transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
+	  transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
+		@media (max-width: 420px) {
+        font-size: 1rem;
+        }
 	}
 
 	.handbook__card--lm__container {
@@ -96,6 +107,14 @@ export const HandbookCardWrapper = styled.div`
 
 	.handbook__card:hover {
 	  scale: 1.07;
+
+	@media (max-width: 420px) {
+      scale: 1.03;
+    }
+
+	 @media (max-width: 390px) {
+      scale: 1.01;
+    }
 	}
 
 	.handbook__card:hover .handbook__card--head {


### PR DESCRIPTION

**Description**

This PR fixes #5639

**Notes for Reviewers**
@Ashparshp  kindly review this 


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
the community cards have a fixed width of 25rem and a hover scale effect. However, this setup is causing issues on small mobile screens. To address this, I've added a media query that adjusts the card styling for smaller mobile screens, ensuring a better user experience across devices.