### PR TITLE
Improved the mobile view of GitOps page

### DIFF
--- a/src/sections/gitops/gitops.style.js
+++ b/src/sections/gitops/gitops.style.js
@@ -34,6 +34,7 @@ export const GitOpsWrapper = styled.section`
         padding-bottom: 4rem;
         padding-left: 1.25rem;
         padding-right: 1.25rem;
+        padding-top: 4.3rem;
 
         @media only screen and (min-width: 1024px) {
             padding-bottom: 13rem;


### PR DESCRIPTION
**Description**

This PR fixes # 5690

**Notes for Reviewers**
Initially "What is GitOps?" was overlapping first section of the page but now it is separated which enhances the overall view of the mobile user.
<img width="348" alt="Screenshot 2024-07-25 at 11 46 29 PM" src="https://github.com/user-attachments/assets/aed6c2fe-1d03-4aa3-aa29-171811f8db00">


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
