### PR TITLE
reword the CTA text

### DIFF
--- a/src/sections/Home/Playground-home/index.js
+++ b/src/sections/Home/Playground-home/index.js
@@ -248,7 +248,7 @@ const MeshmapVisualizerViews = () => {
           </p>
           <Button
             primary
-            title="Use Playground &rarr;"
+            title="Open in Demo System &rarr;"
             external={true}
             url="https://playground.meshery.io/"
           />

--- a/src/sections/Products/index.js
+++ b/src/sections/Products/index.js
@@ -265,7 +265,7 @@ const index = () => {
               <p className="paraInfo">
                 Embrace the future of technology and embark on a transformative journey with our comprehensive range of products prepared to meet your needs. Elevate, Innovate, and conquer the cloud with us today!
               </p>
-              <Button button secondary className="banner-btn two" title="Open Playground" alt="Cloud Native Playground" url="https://play.meshery.io" />
+              <Button button secondary className="banner-btn two" title="Open in Demo System" alt="Cloud Native Playground" url="https://play.meshery.io" />
             </div>
           </div>
           <div className="headers bot_gap">

--- a/src/sections/Products/index.js
+++ b/src/sections/Products/index.js
@@ -265,7 +265,7 @@ const index = () => {
               <p className="paraInfo">
                 Embrace the future of technology and embark on a transformative journey with our comprehensive range of products prepared to meet your needs. Elevate, Innovate, and conquer the cloud with us today!
               </p>
-              <Button button secondary className="banner-btn two" title="Open in Demo System" alt="Cloud Native Playground" url="https://play.meshery.io" />
+              <Button button secondary className="banner-btn two" title="Open Playground" alt="Cloud Native Playground" url="https://play.meshery.io" />
             </div>
           </div>
           <div className="headers bot_gap">

--- a/src/sections/Projects/Sistent/components/text-input/guidance.js
+++ b/src/sections/Projects/Sistent/components/text-input/guidance.js
@@ -91,7 +91,7 @@ export const TextInputGuidance = () => {
           </p>
           <Row Hcenter>
             <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
-              <Input placeholder="Placeholder goes here" multiline />
+              <Input placeholder="PlaceHolder " multiline />
             </SistentThemeProvider>
           </Row>
           <a id="Labelling">


### PR DESCRIPTION
**Description**

This PR fixes #5717 by changing the text "Open Playground" to "Open in Demo System" as requested.

**Desired Situation**

The button text "Open Playground" should be changed to "Open in Demo System".

**Contributor Resources and Handbook**

- The [layer5.io](https://layer5.io) website uses Gatsby, React, and GitHub Pages. Site content is found under the master branch.
- 📚 See [contributing instructions](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md).
- 🎨 Wireframes and designs for Layer5 site in [Figma](https://www.figma.com) (open invite).
- 🙋🏾🙋🏼 Questions: [Discussion Forum](https://discuss.layer5.io) and [Community Slack](https://slack.layer5.io).

Join the Layer5 Community by submitting your [community member form](https://layer5.io/newcomer).

**Notes for Reviewers**

- Ensure that the text change is correctly applied.
- Verify that the new text "Open in Demo System" is displayed appropriately in the UI.
- Check for any typos or formatting issues.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.
