### PR TITLE
Fix placeholder text in Text Input component

### DIFF
--- a/src/sections/Projects/Sistent/components/text-input/guidance.js
+++ b/src/sections/Projects/Sistent/components/text-input/guidance.js
@@ -91,7 +91,7 @@ export const TextInputGuidance = () => {
           </p>
           <Row Hcenter>
             <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
-              <Input placeholder="Placeholder goes here" multiline />
+              <Input placeholder="Placeholder" multiline />
             </SistentThemeProvider>
           </Row>
           <a id="Labelling">

--- a/src/sections/Projects/Sistent/components/text-input/guidance.js
+++ b/src/sections/Projects/Sistent/components/text-input/guidance.js
@@ -80,7 +80,7 @@ export const TextInputGuidance = () => {
           </p>
           <Row Hcenter>
             <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
-              <Input placeholder="Placeholder goes here" />
+              <Input placeholder="PlaceHolder" />
             </SistentThemeProvider>
           </Row>
           <h3>Multiline</h3>


### PR DESCRIPTION
### Description
This PR addresses an issue with the placeholder text in the Text Input component. The current placeholder text reads "PlaceHolder goes here" when it should be "placeHolder". 
Fixes #5738 

### Expected Behavior
The placeholder text should be updated to display "placeHolder" instead of "PlaceHolder goes here". You can review the component at [Sistent Text Input](https://layer5.io/projects/sistent/components/text-input) for reference.

### Changes Made
- Updated the placeholder text from "PlaceHolder goes here" to "placeHolder" in the Text Input component.

Please review the changes and let me know if further adjustments are needed.
