### PR TITLE
Rename placeholder text from 'PlaceHolder goes here' to 'placeHolder' #5738

### DIFF
--- a/src/sections/Projects/Sistent/components/text-input/guidance.js
+++ b/src/sections/Projects/Sistent/components/text-input/guidance.js
@@ -80,7 +80,7 @@ export const TextInputGuidance = () => {
           </p>
           <Row Hcenter>
             <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
-              <Input placeholder="Placeholder goes here" />
+              <Input placeholder="Placeholder" />
             </SistentThemeProvider>
           </Row>
           <h3>Multiline</h3>
@@ -91,7 +91,7 @@ export const TextInputGuidance = () => {
           </p>
           <Row Hcenter>
             <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
-              <Input placeholder="Placeholder goes here" multiline />
+              <Input placeholder="Placeholder" multiline />
             </SistentThemeProvider>
           </Row>
           <a id="Labelling">

--- a/src/sections/Projects/Sistent/components/text-input/index.js
+++ b/src/sections/Projects/Sistent/components/text-input/index.js
@@ -81,7 +81,7 @@ const SistentTextInput = () => {
           </p>
           <Row Hcenter>
             <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
-              <Input placeholder="Placeholder goes here" type="text" />
+              <Input placeholder="Placeholder" type="text" />
             </SistentThemeProvider>
           </Row>
           <a id="Sizes">
@@ -105,7 +105,7 @@ const SistentTextInput = () => {
           <Row Hcenter>
             <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
               <Input
-                placeholder="Placeholder goes here"
+                placeholder="Placeholder"
                 type="text"
                 size="medium"
               />
@@ -120,7 +120,7 @@ const SistentTextInput = () => {
           <Row Hcenter>
             <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
               <Input
-                placeholder="Placeholder goes here"
+                placeholder="Placeholder"
                 type="text"
                 size="small"
               />


### PR DESCRIPTION


### **Description**
This PR addresses issue #5738 by renaming the placeholder text in the text input component. The current placeholder text "PlaceHolder goes here" has been updated to "placeHolder" as per the request.

**Changes Made**
Updated the placeholder text in the text input component.
**Related Issue**
Resolves #5738 

Environment
Host OS:
Browser:
