### PR TITLE
Added spacing on Recognition page between Badges

### DIFF
--- a/src/sections/Community/Handbook/recognition.js
+++ b/src/sections/Community/Handbook/recognition.js
@@ -61,7 +61,6 @@ const badgeListStyle = {
 const recognitionsstyle = {
   marginBottom: "0.5rem",
 };
-
 const RecognitionPage = () => {
   return (
     <HandbookWrapper>
@@ -111,120 +110,120 @@ const RecognitionPage = () => {
             <ul style={badgeListStyle}>
               <p><b>Activity badges:</b></p>
               <li>
-                <img src={DesignPioneerLogo} style={badgeStyle} />
+                <img src={DesignPioneerLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Design Pioneer</b> - awarded to the Layer5 cloud users when they create their first design.
               </li>
               <li>
-                <img src={ApplicationPioneerLogo} style={badgeStyle} />
+                <img src={ApplicationPioneerLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Application Pioneer</b> - awarded to the Layer5 cloud users when they create their first application.
               </li>
               <li>
-                <img src={SharingIsCaringLogo} style={badgeStyle} />
+                <img src={SharingIsCaringLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Sharing is Caring</b> - This badge is awarded upon first-time sharing one of your designs.
               </li>
               <li>
-                <img src={ShippedLogo} style={badgeStyle} />
+                <img src={ShippedLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Shipped</b> - This badge is awarded upon the success of your first design deployment.
               </li>
               <li>
-                <img src={NeedForSpeedLogo} style={badgeStyle} />
+                <img src={NeedForSpeedLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Need for Speed</b> - This badge is awarded upon successful execution of your first performance test.
               </li>
               <li>
-                <img src={HipHackerLogo} style={badgeStyle} />
+                <img src={HipHackerLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Hip Hacker</b> - First Interactive Terminal Session - awarded the first time that you establish an interactive terminal session with a Kubernetes Pod.
               </li>
               <li>
-                <img src={StreamerLogo} style={badgeStyle} />
+                <img src={StreamerLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Streamer</b> - First Log Streaming Session - awarded the first time that you stream logs from a Kubernetes Pod.
               </li>
               <li>
-                <img src={GitOPsWithFriendsLogo} style={badgeStyle} />
+                <img src={GitOPsWithFriendsLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>GitOps with Friends</b> - First Collaborator - awarded the first time a collaborator saves changes to one of your designs.
               </li>
               <li>
-                <img src={BringABuddyLogo} style={badgeStyle} />
+                <img src={BringABuddyLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Bring a Buddy</b> - awarded to the users who invite someone to Layer5 cloud.
               </li>
               <li>
-                <img src={CodeCleanupCrewLogo} style={badgeStyle} />
+                <img src={CodeCleanupCrewLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Code Cleanup Crew</b> - awarded to contributors who help maintain code quality and cleanliness.
               </li>
               <li>
-                <img src={SecuritySentinelLogo} style={badgeStyle} />
+                <img src={SecuritySentinelLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Security Sentinel</b> - awarded to individuals who contribute to identifying and fixing security vulnerabilities.
               </li>
               <li>
-                <img src={LogevityLegendLogo} style={badgeStyle} />
+                <img src={LogevityLegendLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Longevity Legend</b> - awarded for long-term, sustained contributions to the project over the years.
               </li>
               <li>
-                <img src={ReviewRockstarLogo} style={badgeStyle} />
+                <img src={ReviewRockstarLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Review Rockstar</b> - awarded to individuals who provide thorough and valuable code reviews.
               </li>
               <li>
-                <img src={MeshmapSnapshotLogo} style={badgeStyle} />
+                <img src={MeshmapSnapshotLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>MeshMap Snapshot</b> - awarded to users upon creation of their first infrastructure screenshot directly in their pull request.
               </li>
               <li>
-                <img src={ContinuousContributorLogo} style={badgeStyle} />
+                <img src={ContinuousContributorLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Continuous Contributor</b> - awarded to the community members who make consistent and impactful contributions for a long period of time in Layer5 projects in recognition and appreciation of their efforts.
               </li>
               <p><b>Projects:</b></p>
               <li>
-                <img src={ImageHubLogo} style={badgeStyle} />
+                <img src={ImageHubLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Image Hub</b> - awarded to the community members who make consistent and impactful contributions to the Image Hub project in recognition and appreciation of their efforts.
               </li>
               <li>
-                <img src={meshmapLogo} style={badgeStyle} />
+                <img src={meshmapLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>MeshMap</b> - awarded to the community members who make consistent and impactful contributions to the <Link to="/cloud-native-management/meshmap">MeshMap</Link> project in recognition and appreciation of their efforts. Community members who earn this badge occasionally become a project maintainer.
               </li>
               <li>
-                <img src={ServiceMeshPerformance} style={badgeStyle} />
+                <img src={ServiceMeshPerformance} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Cloud Native Performance</b> - awarded to the community members who make consistent and impactful contributions to the Cloud Native Performance project. Community members who earn this badge occasionally become a project maintainer.
               </li>
               <li>
-                <img src={CommunityLogo} style={badgeStyle} />
+                <img src={CommunityLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Community</b> - awarded to the community members who repeatedly engage in welcoming, encouraging, and supporting other Layer5 community members. Community members who earn this badge occasionally graduate to undertaking the Community Manager role.
               </li>
               <li>
-                <img src={MesheryLogo} style={badgeStyle} />
+                <img src={MesheryLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Meshery</b> - awarded to the community members who make consistent and impactful contributions to the Meshery project. Community members who earn this badge occasionally become a project maintainer.
               </li>
               <li>
-                <img src={MesheryOperator} style={badgeStyle} />
+                <img src={MesheryOperator} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Meshery Operator</b> - awarded to the community members who make consistent and impactful contributions to Meshery Operator of the Meshery project in recognition and appreciation of their efforts.
               </li>
               <li>
-                <img src={PatternsLogo} style={badgeStyle} />
+                <img src={PatternsLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Patterns</b> - awarded to the community members who make consistent and impactful contributions to the <Link to="/learn/service-mesh-books/service-mesh-patterns">Cloud Native Patterns</Link> project in recognition and appreciation of their efforts.
               </li>
               <li>
-                <img src={LandscapeGreen} style={badgeStyle} />
+                <img src={LandscapeGreen} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Landscape</b> - awarded to the community members who make consistent and impactful contributions to the layer5.io website.
               </li>
               <li>
-                <img src={writersLogo} style={badgeStyle} />
+                <img src={writersLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Writer's Program</b> - awarded to the community members who make with two or more published writings whether in article, blog post, project documentation or other form in recognition and appreciation of their efforts.
               </li>
               <li>
-                <img src={NightHawkLogo} style={badgeStyle} />
+                <img src={NightHawkLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Nighthawk</b> - awarded to the community members who make consistent and impactful contributions to the NightHawk project in recognition and appreciation of their efforts. Community members who earn this badge occasionally become a project maintainer.
               </li>
               <li>
-                <img src={uiuxrLogo} style={badgeStyle} />
+                <img src={uiuxrLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>UI/UX</b> - awarded to the community members who create or improve designs for visual aspects or user flow for any of the websites, flyers, promotions, Meshery UI, and so on in recognition and appreciation of their efforts.
               </li>
               <li>
-                <img src={MesheryCatalogLogo} style={badgeStyle} />
+                <img src={MesheryCatalogLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Meshery Catalog</b> - awarded to the community members who make consistent and impactful contributions to the <a href="https://meshery.io/catalog">Meshery Catalog</a> of Meshery project in recognition and appreciation of their efforts.
               </li>
               <li>
-                <img src={DockerExtension} style={badgeStyle} />
+                <img src={DockerExtension} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Docker Extension</b> - awarded to the community members who make consistent and impactful contributions to the Docker Extension of meshery project in recognition and appreciation of their efforts.
               </li>
               <li>
-                <img src={DocsLogo} style={badgeStyle} />
+                <img src={DocsLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
                 <b>Docs</b> - awarded to the community members who make consistent and impactful contributions to the <a href="https://docs.meshery.io/">Meshery docs</a> in recognition and appreciation of their efforts.
               </li>
             </ul>

--- a/src/sections/Community/Handbook/recognition.js
+++ b/src/sections/Community/Handbook/recognition.js
@@ -50,8 +50,8 @@ const contents = [
 const badgeStyle = {
   height: "25px",
   width: "25px",
-  marginRight: "5px",
   verticalAlign: "middle",
+  marginRight: "1rem",
 };
 
 const badgeListStyle = {
@@ -110,120 +110,120 @@ const RecognitionPage = () => {
             <ul style={badgeListStyle}>
               <p><b>Activity badges:</b></p>
               <li>
-                <img src={DesignPioneerLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={DesignPioneerLogo} style={badgeStyle} />
                 <b>Design Pioneer</b> - awarded to the Layer5 cloud users when they create their first design.
               </li>
               <li>
-                <img src={ApplicationPioneerLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={ApplicationPioneerLogo} style={badgeStyle} />
                 <b>Application Pioneer</b> - awarded to the Layer5 cloud users when they create their first application.
               </li>
               <li>
-                <img src={SharingIsCaringLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={SharingIsCaringLogo} style={badgeStyle} />
                 <b>Sharing is Caring</b> - This badge is awarded upon first-time sharing one of your designs.
               </li>
               <li>
-                <img src={ShippedLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={ShippedLogo} style={badgeStyle} />
                 <b>Shipped</b> - This badge is awarded upon the success of your first design deployment.
               </li>
               <li>
-                <img src={NeedForSpeedLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={NeedForSpeedLogo} style={badgeStyle} />
                 <b>Need for Speed</b> - This badge is awarded upon successful execution of your first performance test.
               </li>
               <li>
-                <img src={HipHackerLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={HipHackerLogo} style={badgeStyle} />
                 <b>Hip Hacker</b> - First Interactive Terminal Session - awarded the first time that you establish an interactive terminal session with a Kubernetes Pod.
               </li>
               <li>
-                <img src={StreamerLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={StreamerLogo} style={badgeStyle} />
                 <b>Streamer</b> - First Log Streaming Session - awarded the first time that you stream logs from a Kubernetes Pod.
               </li>
               <li>
-                <img src={GitOPsWithFriendsLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={GitOPsWithFriendsLogo} style={badgeStyle} />
                 <b>GitOps with Friends</b> - First Collaborator - awarded the first time a collaborator saves changes to one of your designs.
               </li>
               <li>
-                <img src={BringABuddyLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={BringABuddyLogo} style={badgeStyle} />
                 <b>Bring a Buddy</b> - awarded to the users who invite someone to Layer5 cloud.
               </li>
               <li>
-                <img src={CodeCleanupCrewLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={CodeCleanupCrewLogo} style={badgeStyle} />
                 <b>Code Cleanup Crew</b> - awarded to contributors who help maintain code quality and cleanliness.
               </li>
               <li>
-                <img src={SecuritySentinelLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={SecuritySentinelLogo} style={badgeStyle} />
                 <b>Security Sentinel</b> - awarded to individuals who contribute to identifying and fixing security vulnerabilities.
               </li>
               <li>
-                <img src={LogevityLegendLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={LogevityLegendLogo} style={badgeStyle} />
                 <b>Longevity Legend</b> - awarded for long-term, sustained contributions to the project over the years.
               </li>
               <li>
-                <img src={ReviewRockstarLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={ReviewRockstarLogo} style={badgeStyle} />
                 <b>Review Rockstar</b> - awarded to individuals who provide thorough and valuable code reviews.
               </li>
               <li>
-                <img src={MeshmapSnapshotLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={MeshmapSnapshotLogo} style={badgeStyle} />
                 <b>MeshMap Snapshot</b> - awarded to users upon creation of their first infrastructure screenshot directly in their pull request.
               </li>
               <li>
-                <img src={ContinuousContributorLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={ContinuousContributorLogo} style={badgeStyle} />
                 <b>Continuous Contributor</b> - awarded to the community members who make consistent and impactful contributions for a long period of time in Layer5 projects in recognition and appreciation of their efforts.
               </li>
               <p><b>Projects:</b></p>
               <li>
-                <img src={ImageHubLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={ImageHubLogo} style={badgeStyle} />
                 <b>Image Hub</b> - awarded to the community members who make consistent and impactful contributions to the Image Hub project in recognition and appreciation of their efforts.
               </li>
               <li>
-                <img src={meshmapLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={meshmapLogo} style={badgeStyle} />
                 <b>MeshMap</b> - awarded to the community members who make consistent and impactful contributions to the <Link to="/cloud-native-management/meshmap">MeshMap</Link> project in recognition and appreciation of their efforts. Community members who earn this badge occasionally become a project maintainer.
               </li>
               <li>
-                <img src={ServiceMeshPerformance} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={ServiceMeshPerformance} style={badgeStyle} />
                 <b>Cloud Native Performance</b> - awarded to the community members who make consistent and impactful contributions to the Cloud Native Performance project. Community members who earn this badge occasionally become a project maintainer.
               </li>
               <li>
-                <img src={CommunityLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={CommunityLogo} style={badgeStyle} />
                 <b>Community</b> - awarded to the community members who repeatedly engage in welcoming, encouraging, and supporting other Layer5 community members. Community members who earn this badge occasionally graduate to undertaking the Community Manager role.
               </li>
               <li>
-                <img src={MesheryLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={MesheryLogo} style={badgeStyle} />
                 <b>Meshery</b> - awarded to the community members who make consistent and impactful contributions to the Meshery project. Community members who earn this badge occasionally become a project maintainer.
               </li>
               <li>
-                <img src={MesheryOperator} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={MesheryOperator} style={badgeStyle} />
                 <b>Meshery Operator</b> - awarded to the community members who make consistent and impactful contributions to Meshery Operator of the Meshery project in recognition and appreciation of their efforts.
               </li>
               <li>
-                <img src={PatternsLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={PatternsLogo} style={badgeStyle} />
                 <b>Patterns</b> - awarded to the community members who make consistent and impactful contributions to the <Link to="/learn/service-mesh-books/service-mesh-patterns">Cloud Native Patterns</Link> project in recognition and appreciation of their efforts.
               </li>
               <li>
-                <img src={LandscapeGreen} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={LandscapeGreen} style={badgeStyle} />
                 <b>Landscape</b> - awarded to the community members who make consistent and impactful contributions to the layer5.io website.
               </li>
               <li>
-                <img src={writersLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={writersLogo} style={badgeStyle} />
                 <b>Writer's Program</b> - awarded to the community members who make with two or more published writings whether in article, blog post, project documentation or other form in recognition and appreciation of their efforts.
               </li>
               <li>
-                <img src={NightHawkLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={NightHawkLogo} style={badgeStyle} />
                 <b>Nighthawk</b> - awarded to the community members who make consistent and impactful contributions to the NightHawk project in recognition and appreciation of their efforts. Community members who earn this badge occasionally become a project maintainer.
               </li>
               <li>
-                <img src={uiuxrLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={uiuxrLogo} style={badgeStyle} />
                 <b>UI/UX</b> - awarded to the community members who create or improve designs for visual aspects or user flow for any of the websites, flyers, promotions, Meshery UI, and so on in recognition and appreciation of their efforts.
               </li>
               <li>
-                <img src={MesheryCatalogLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={MesheryCatalogLogo} style={badgeStyle} />
                 <b>Meshery Catalog</b> - awarded to the community members who make consistent and impactful contributions to the <a href="https://meshery.io/catalog">Meshery Catalog</a> of Meshery project in recognition and appreciation of their efforts.
               </li>
               <li>
-                <img src={DockerExtension} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={DockerExtension} style={badgeStyle} />
                 <b>Docker Extension</b> - awarded to the community members who make consistent and impactful contributions to the Docker Extension of meshery project in recognition and appreciation of their efforts.
               </li>
               <li>
-                <img src={DocsLogo} style={{ ...badgeStyle, marginRight: "1rem" }} />
+                <img src={DocsLogo} style={badgeStyle} />
                 <b>Docs</b> - awarded to the community members who make consistent and impactful contributions to the <a href="https://docs.meshery.io/">Meshery docs</a> in recognition and appreciation of their efforts.
               </li>
             </ul>


### PR DESCRIPTION
This PR fixes #5520 

**Desired Behaviour :**
Added spacing between content and badges of 1 rem using Inline CSS

**Current Behaviour :**
![1](https://github.com/user-attachments/assets/b83f2591-9916-4124-80ab-ce90e9ffeed8)



**Contributor Resources and Handbook :**
The Layer5 website uses Gatsby, React, and GitHub Pages. Site content is found under the master branch.

📚 [See contributing instructions](https://github.com/layer5io/layer5/pull/5771#)
🎨 [Wireframes and designs for Layer5 site in Figma (open invite)](https://github.com/layer5io/layer5/pull/5771#)
🙋🏾🙋🏼 [Questions: Discussion Forum and Community Slack](https://github.com/layer5io/layer5/pull/5771#)
Join the Layer5 Community by [submitting your community member form](https://github.com/layer5io/layer5/pull/5771#).

**Notes for Reviewers :**

[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)

☑️Yes, I signed my commits.
