### PR TITLE
fix: join us button

### DIFF
--- a/src/sections/Community/Event-single/EventSingle.style.js
+++ b/src/sections/Community/Event-single/EventSingle.style.js
@@ -9,6 +9,9 @@ const EventSinglePageWrapper = styled.div`
     div.event-title {
         text-align: center;
         margin-bottom: 4rem;
+        h3 {
+        color:black;
+        }
     }
     ul.speakers {
         margin-left:0px;

--- a/src/sections/Community/Event-single/index.js
+++ b/src/sections/Community/Event-single/index.js
@@ -52,8 +52,13 @@ const EventSingle = ({ data }) => {
 
   //const frontmatter = ({speakers = []});
   const { frontmatter, body } = data.mdx;
-
-
+  const isEventPassed = () => {
+    const eventDate = new Date(frontmatter.date);
+    const currentDate = new Date();
+    return eventDate < currentDate;
+  };
+  const isEventUrlSpecified = !!frontmatter.eurl;
+  const showJoinUsButton = !isEventPassed() && isEventUrlSpecified;
   return (
     <EventPageWrapper>
       <PageHeader
@@ -86,13 +91,15 @@ const EventSingle = ({ data }) => {
                   </li>
                 ))}
               </ul>
-              <div className="event-title">
-                <Button primary url={frontmatter.eurl} external={true}>
-                  <h3>
-                    Join us at {frontmatter.title}
-                  </h3>
-                </Button>
-              </div>
+              {showJoinUsButton && (
+                <div className="event-title">
+                  <Button primary url={frontmatter.eurl} external={true}>
+                    <h3>
+                      Join us at {frontmatter.title}
+                    </h3>
+                  </Button>
+                </div>
+              )}
             </div>
             <CTA_Bottom
               category={"Kanvas"}

--- a/src/templates/event-single.js
+++ b/src/templates/event-single.js
@@ -23,7 +23,7 @@ export const query = graphql`query EventsBySlug($slug: String!) {
       type
       speakers
       register
-      date(formatString: "MMM Do, YYYY")
+      date
       thumbnail {
         publicURL
         relativePath


### PR DESCRIPTION
**Description**
This PR ensures:
If `eurl` is not specified, or if the event date has passed, the `Join us" button should not be displayed on events pages.

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
