### PR TITLE
add posthog identity and exclude some path

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -35,6 +35,9 @@ export const onClientEntry = () => {
       {
         api_host: "https://us.i.posthog.com",
         person_profiles: "always",
+        autocapture: {
+          url_ignorelist: ["community/newcomers", "/calendar", "/newcomers"]
+        }
       }
     );
   }

--- a/src/sections/General/Navigation/index.js
+++ b/src/sections/General/Navigation/index.js
@@ -21,6 +21,7 @@ import CloudIcon from "./utility/CloudIcon.js";
 import LogoutIcon from "./utility/LogoutIcon.js";
 // import LogoutIcon from "./utility/LogoutIcon.js";
 import KanvasIcon from "./utility/KanvasIcon.js";
+import posthog from "posthog-js";
 const Navigation = () => {
   let data = useStaticQuery(
     graphql`
@@ -212,6 +213,14 @@ const Navigation = () => {
         }
 
         const data = response.data;
+        if (data){
+          posthog.identify(
+            data?.id,
+            {
+              email: data?.email
+            }
+          );
+        }
         setUserData(data);
       } catch (error) {
         console.error("There was a problem with your fetch operation:", error);


### PR DESCRIPTION
**Description**

This PR fixes two things.
1. It use the autocapture event to ignore few path to capture user interaction like newcomers and calendar because they are taking enough usage.
2. It implements the posthog identify to track the user email and id for interaction instead anonymous users only.

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
3. Build and test your changes before submitting a PR. 
4. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
