### PR TITLE
Changed <img /> to <StaticImage /> to improve performance

### DIFF
--- a/src/components/Case-study-banner/index.js
+++ b/src/components/Case-study-banner/index.js
@@ -1,8 +1,6 @@
 import React, { useState } from "react";
 import styled from "styled-components";
-import MesheryLogo from "../../assets/images/meshery/icon-only/meshery-logo-light.svg";
-import SpireLogo from "../../collections/integrations/spire/icons/color/spire-color.svg";
-import MesheryAndSpire from "../../collections/resources/case-study/hpes-adoption-of-meshery-and-kanvas/meshery-and-hpe.svg";
+import { StaticImage } from "gatsby-plugin-image";
 
 
 const BannerWrapper = styled.div`
@@ -41,6 +39,14 @@ const BannerWrapper = styled.div`
   transform: skewX(25deg); /* Counteract the parent's skew */
   width: 40%;
 
+}
+
+.left-img > .gatsby-image-wrapper {
+  border-radius: 50%;
+  width: 50%;
+  overflow: hidden;
+  height: auto;
+  object-fit: contain;
 }
 
 .desc {
@@ -215,12 +221,12 @@ const CaseStudyBanner = () => {
               <h2>Discover how HPE uses Meshery to manage SPIRE</h2>
             </div>
             <div className="meshery-and-spire">
-              <img src={MesheryAndSpire} alt="meshery-and-spire" />
+              <StaticImage src="../../collections/resources/case-study/hpes-adoption-of-meshery-and-kanvas/meshery-and-hpe.svg" />
             </div>
           </div>
           <div className="large-screen">
             <div className={`left-img ${hover ? "scale-on-hover" : ""}`} onMouseEnter={handleHover} onMouseLeave={handleLeave}>
-              <img src={MesheryLogo} alt="meshery-logo" />
+              <StaticImage src="../../assets/images/meshery/icon-only/meshery-logo-light.svg" /* style={{ borderRadius: "50%" }} */ />
             </div>
             <div className={`desc ${hover ? "desc-hover" : ""}`} onMouseEnter={handleHover} onMouseLeave={handleLeave}>
               <h2>Discover how HPE uses Meshery to manage SPIRE</h2>
@@ -229,7 +235,7 @@ const CaseStudyBanner = () => {
               </div>
             </div>
             <div className={`right-img ${hover ? "scale-on-hover" : ""}`} onMouseEnter={handleHover} onMouseLeave={handleLeave}>
-              <img src={SpireLogo} alt="spire-logo" />
+              <StaticImage src="../../collections/integrations/spire/icons/color/spire-color.svg" />
             </div>
           </div>
         </BannerWrapper>


### PR DESCRIPTION
**Description**

This PR fixes #5842 

These 2 images were using the `<img />` tag to be rendered, this PR changes this to `<StaticImage />` to improve the performance.

![image](https://github.com/user-attachments/assets/1a2ed8c4-126d-487a-bc69-3fda5efbf30f)


**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.