### PR TITLE
[CI] Add project/sistent label automatically to pull requests related to sistent project

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -97,3 +97,9 @@ project/kanvas:
 - changed-files:
   - any-glob-to-any-file:
     - "src/sections/Kanvas/**/*"
+project/sistent:
+- changed-files:
+  - any-glob-to-any-file:
+    - "src/components/SistentNavigation/**/*"
+    - "src/pages/projects/sistent/**/*"
+    - "src/sections/Projects/Sistent/**/*"


### PR DESCRIPTION
**Description**

- Updated `.github/labeler.yml` to automatically apply the `project/sistent` label to pull requests that modify files within the **Sistent** project.
- Added file path patterns for **Sistent-related** components, pages, and sections to ensure consistent labeling of PRs.
- This helps streamline the PR review process by automatically tagging relevant PRs.

This PR fixes #6016

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
