### PR TITLE
Made the colors boxes wrap in company brand page. Fixed #6031

### DIFF
--- a/src/sections/Company/Brand/Brand-components/catalog.js
+++ b/src/sections/Company/Brand/Brand-components/catalog.js
@@ -123,7 +123,7 @@ const Catalog = () => {
               white when using project colors as the background.
             </p>
           </Col>
-          <Row className="color-code-wrapper">
+          <Row style={{display: "flex", flexWrap: "wrap"}} className="color-code-wrapper">
             <ColorBox name="Keppel" R="0" G="179" B="159" colorCode="#00B39F" />
             <ColorBox
               name="Caribbean Green"

--- a/src/sections/Company/Brand/Brand-components/community.js
+++ b/src/sections/Company/Brand/Brand-components/community.js
@@ -79,7 +79,7 @@ const CommunityBrand = () => {
             monochrome tonal when using a color background.
           </p>
         </Col>
-        <Row className="color-code-wrapper">
+        <Row style={{display: "flex", flexWrap: "wrap"}} className="color-code-wrapper">
           <ColorBox name="Keppel" R="0" G="179" B="159" colorCode="#00B39F" />
           <ColorBox name="Caribbean Green" R="0" G="211" B="169" colorCode="#00D3A9" />
           <ColorBox name="Casper" R="177" G="182" B="184" colorCode="#B1B6B8" />

--- a/src/sections/Company/Brand/Brand-components/imagehub.js
+++ b/src/sections/Company/Brand/Brand-components/imagehub.js
@@ -71,7 +71,7 @@ const ImageHubBrand = () => {
             monochrome tonal when using a color background.
           </p>
         </Col>
-        <Row className="color-code-wrapper">
+        <Row style={{display: "flex", flexWrap: "wrap"}} className="color-code-wrapper">
           <ColorBox name="Charcoal" R="60" G="73" B="79" colorCode="#3C494F" />
           <ColorBox name="Keppel" R="0" G="179" B="159" colorCode="#00B39F" />
           <ColorBox name="Casper" R="177" G="182" B="184" colorCode="#B1B6B8" />

--- a/src/sections/Company/Brand/Brand-components/kanvas.js
+++ b/src/sections/Company/Brand/Brand-components/kanvas.js
@@ -85,7 +85,7 @@ const KanvasBrand = () => {
               monochrome tonal when using a color background.
             </p>
           </Col>
-          <Row className="color-code-wrapper">
+          <Row style={{display: "flex", flexWrap: "wrap"}} className="color-code-wrapper">
             <ColorBox name="Keppel" R="0" G="179" B="159" colorCode="#00B39F" />
             <ColorBox name="Caribbean Green" R="0" G="211" B="169" colorCode="#00D3A9" />
             <ColorBox name="Charcoal" R="60" G="73" B="79" colorCode="#3C494F" />

--- a/src/sections/Company/Brand/Brand-components/layer5.js
+++ b/src/sections/Company/Brand/Brand-components/layer5.js
@@ -85,7 +85,7 @@ const Layer5Brand = () => {
               when using project colors as the background.
             </p>
           </Col>
-          <Row className="color-code-wrapper">
+          <Row style={{display: "flex", flexWrap: "wrap"}} className="color-code-wrapper">
             <ColorBox name="Keppel" R="0" G="179" B="159" colorCode="#00B39F" />
             <ColorBox name="Caribbean Green" R="0" G="211" B="169" colorCode="#00D3A9" />
             <ColorBox name="Saffron" R="235" G="192" B="23" colorCode="#EBC017" />

--- a/src/sections/Company/Brand/Brand-components/meshery-operator.js
+++ b/src/sections/Company/Brand/Brand-components/meshery-operator.js
@@ -78,7 +78,7 @@ const MesheryOperatorBrand = () => {
               monochrome tonal when using a color background.
             </p>
           </Col>
-          <Row className="color-code-wrapper">
+          <Row style={{display: "flex", flexWrap: "wrap"}} className="color-code-wrapper">
             <ColorBox name="Charcoal" R="60" G="73" B="79" colorCode="#3C494F" />
             <ColorBox name="Keppel" R="0" G="179" B="159" colorCode="#00B39F" />
             <ColorBox name="Caribbean Green" R="0" G="211" B="169" colorCode="#00D3A9" />

--- a/src/sections/Company/Brand/Brand-components/meshery.js
+++ b/src/sections/Company/Brand/Brand-components/meshery.js
@@ -81,7 +81,7 @@ const MesheryBrand = () => {
             monochrome tonal when using a color background.
           </p>
         </Col>
-        <Row className="color-code-wrapper">
+        <Row style={{display: "flex", flexWrap: "wrap"}} className="color-code-wrapper">
           <ColorBox name="Charcoal" R="60" G="73" B="79" colorCode="#3C494F" />
           <ColorBox name="Keppel" R="0" G="179" B="159" colorCode="#00B39F" />
           <ColorBox name="Caribbean Green" R="0" G="211" B="169" colorCode="#00D3A9" />

--- a/src/sections/Company/Brand/Brand-components/meshmark.js
+++ b/src/sections/Company/Brand/Brand-components/meshmark.js
@@ -118,7 +118,7 @@ const MeshMarkBrand = () => {
               using project colors as the background.
             </p>
           </Col>
-          <Row className="color-code-wrapper">
+          <Row style={{display: "flex", flexWrap: "wrap"}} className="color-code-wrapper">
             <ColorBox name="Charcoal" R="60" G="73" B="79" colorCode="#3C494F" />
             <ColorBox name="Keppel" R="0" G="179" B="159" colorCode="#00B39F" />
             <ColorBox name="Caribbean Green" R="0" G="211" B="169" colorCode="#00D3A9" />

--- a/src/sections/Company/Brand/Brand-components/meshmaster.js
+++ b/src/sections/Company/Brand/Brand-components/meshmaster.js
@@ -77,7 +77,7 @@ const MeshMasterBrand = () => {
             monochrome tonal when using a color background.
           </p>
         </Col>
-        <Row className="color-code-wrapper">
+        <Row style={{display: "flex", flexWrap: "wrap"}} className="color-code-wrapper">
           <ColorBox name="Charcoal" R="60" G="73" B="79" colorCode="#3C494F" />
           <ColorBox name="Keppel" R="0" G="179" B="159" colorCode="#00B39F" />
           <ColorBox name="Caribbean Green" R="0" G="211" B="169" colorCode="#00D3A9" />

--- a/src/sections/Company/Brand/Brand-components/meshsync.js
+++ b/src/sections/Company/Brand/Brand-components/meshsync.js
@@ -78,7 +78,7 @@ const MeshSyncBrand = () => {
               monochrome tonal when using a color background.
             </p>
           </Col>
-          <Row className="color-code-wrapper">
+          <Row style={{display: "flex", flexWrap: "wrap"}} className="color-code-wrapper">
             <ColorBox name="Keppel" R="0" G="179" B="159" colorCode="#00B39F" />
             <ColorBox name="Caribbean Green" R="0" G="211" B="169" colorCode="#00D3A9" />
             <ColorBox name="Casper" R="177" G="182" B="184" colorCode="#B1B6B8" />

--- a/src/sections/Company/Brand/Brand-components/servicemeshpatterns.js
+++ b/src/sections/Company/Brand/Brand-components/servicemeshpatterns.js
@@ -78,7 +78,7 @@ const ServiceMeshPatterns = () => {
             using project colors as the background.
           </p>
         </Col>
-        <Row className="color-code-wrapper">
+        <Row style={{display: "flex", flexWrap: "wrap"}} className="color-code-wrapper">
           <ColorBox name="Charcoal" R="60" G="73" B="79" colorCode="#3C494F" />
           <ColorBox name="Keppel" R="0" G="179" B="159" colorCode="#00B39F" />
           <ColorBox name="Caribbean Green" R="0" G="211" B="169" colorCode="#00D3A9" />

--- a/src/sections/Company/Brand/Brand-components/smp.js
+++ b/src/sections/Company/Brand/Brand-components/smp.js
@@ -104,7 +104,7 @@ const SMPBrand = () => {
               using project colors as the background.
             </p>
           </Col>
-          <Row style={{display: "flex", flexWrap: "wrap"}} className="color-code-wrapper">
+          <Row style={{display: "flex", flexWrap:"wrap"}} className="color-code-wrapper">
             <ColorBox name="Charcoal" R="60" G="73" B="79" colorCode="#3C494F" />
             <ColorBox name="Keppel" R="0" G="179" B="159" colorCode="#00B39F" />
             <ColorBox name="Caribbean Green" R="0" G="211" B="169" colorCode="#00D3A9" />

--- a/src/sections/Company/Brand/Brand-components/smp.js
+++ b/src/sections/Company/Brand/Brand-components/smp.js
@@ -104,7 +104,7 @@ const SMPBrand = () => {
               using project colors as the background.
             </p>
           </Col>
-          <Row className="color-code-wrapper">
+          <Row style={{display: "flex", flexWrap: "wrap"}} className="color-code-wrapper">
             <ColorBox name="Charcoal" R="60" G="73" B="79" colorCode="#3C494F" />
             <ColorBox name="Keppel" R="0" G="179" B="159" colorCode="#00B39F" />
             <ColorBox name="Caribbean Green" R="0" G="211" B="169" colorCode="#00D3A9" />


### PR DESCRIPTION
Updated the layout of the color boxes wrap in the company/brand page to ensure that all individual color boxes are properly displayed and visible. Previously, the wrapping of the color boxes may have caused some boxes to be hidden or misaligned. This change involves adjusting the CSS styles to create a more responsive and visually appealing layout, ensuring that each color box is fully visible, evenly spaced, and aligned within the container. The update improves the overall user experience by making sure the color options are presented clearly and consistently across different screen sizes.

This PR fixes #6031 

I have tried fixing the page and it is working correctly. Though if it didn`t work then let me know about it.

