### PR TITLE
enhance logic to display thumbnail based on theme

### DIFF
--- a/src/collections/news/2024/2024-11-12-layer5-launches-kanvas-a-collaborative-platform-for-cloud-native-infrastructure/index.mdx
+++ b/src/collections/news/2024/2024-11-12-layer5-launches-kanvas-a-collaborative-platform-for-cloud-native-infrastructure/index.mdx
@@ -66,7 +66,10 @@ Like Figma for engineers, Kanvas users can access Kanvas from any computer with 
   <li><strong>Design Reviews</strong>: Collaboratively review and provide feedback on designs and prototypes.</li>
 </ul>
 
-
+<div>
+<iframe width="100%" height="315" style="margin-right: 1.5rem;margin-left:1.5rem;" src="https://www.youtube.com/embed/4WcofErPTx4?si=UfouUV7mhADg3zkk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<p style="font-style:italic;font-size:1rem;margin-left:1rem;">Birth of Kanvas from Meshery</p>
+</div>
 #### Kanvas caters to a wide range of users, including:
 <ul>
   <li>Teams and engineering managers for brainstorming, diagramming, wireframing, and interviewing.</li>

--- a/src/sections/Company/News-single/index.js
+++ b/src/sections/Company/News-single/index.js
@@ -8,8 +8,10 @@ import NewsSidebar from "./Sidebar";
 
 import NewsPageWrapper from "./NewsSingle.style.js";
 import RelatedPosts from "../../../components/Related-Posts";
+import { useStyledDarkMode } from "../../../theme/app/useStyledDarkMode";
 
 const NewsSingle = ({ data }) => {
+  const { isDark } = useStyledDarkMode();
   const { frontmatter, body, fields } = data.mdx;
   const newsData = useStaticQuery(
     graphql`query relatedNewsPosts {
@@ -54,7 +56,8 @@ const NewsSingle = ({ data }) => {
         subtitle={frontmatter.subtitle}
         category={frontmatter.category}
         author={{ name: frontmatter.author }}
-        thumbnail={frontmatter.thumbnail}
+        thumbnail={ isDark && frontmatter.darkthumbnail && frontmatter.darkthumbnail.publicURL !== frontmatter.thumbnail.publicURL
+          ? frontmatter.darkthumbnail : frontmatter.thumbnail}
         date={frontmatter.date}
       />
       <div className="single-post-wrapper">

--- a/src/templates/news-single.js
+++ b/src/templates/news-single.js
@@ -24,6 +24,13 @@ export const query = graphql`
           extension
           publicURL
         }
+        darkthumbnail {
+          childImageSharp {
+            gatsbyImageData(width: 500, layout: CONSTRAINED)
+          }
+          extension
+          publicURL
+        }
       }
       fields {
         slug


### PR DESCRIPTION
**Description**

This PR: 
![image](https://github.com/user-attachments/assets/3707cfab-6dfa-4f47-9c22-db2b05444283)
![image](https://github.com/user-attachments/assets/8f20a74d-c64a-4967-9f49-1dc75f8d26c7)


**Notes for Reviewers**

Also adds `birth of kanvas` logo video as `iframe`:
![image](https://github.com/user-attachments/assets/95ebaf13-59b0-4eb3-8614-373f5246fbf1)

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
