### PR TITLE
Add dropdown for component category in the sidebar

### DIFF
--- a/src/components/SistentNavigation/index.js
+++ b/src/components/SistentNavigation/index.js
@@ -3,6 +3,7 @@ import { HiOutlineChevronLeft } from "@react-icons/all-files/hi/HiOutlineChevron
 import { Link } from "gatsby";
 import { IoMdClose } from "@react-icons/all-files/io/IoMdClose";
 import { IoIosArrowDropdownCircle } from "@react-icons/all-files/io/IoIosArrowDropdownCircle";
+import { componentsData } from "../../sections/Projects/Sistent/components";
 
 import TOCWrapper from "./toc.style";
 import { IoIosArrowDown } from "@react-icons/all-files/io/IoIosArrowDown";
@@ -15,6 +16,9 @@ const TOC = () => {
   const location = useLocation();
   const [expandIdenity, setExpandIdentity] = useState(
     location.pathname.includes("/identity")
+  );
+  const [expandComponent, setExpandComponent] = useState(
+    location.pathname.includes("/components")
   );
 
   return (
@@ -114,13 +118,36 @@ const TOC = () => {
             </div>
           </li>
           <li>
-            <Link
-              to="/projects/sistent/components"
-              activeClassName="active"
-              className="toc-sub-heading toc-sub-inline"
-            >
-              Components
-            </Link>
+            <div>
+              <li
+                className="toc-sub-heading components"
+                onClick={() => setExpandComponent((prev) => !prev)}
+              >
+                Components
+                {expandComponent ? <IoIosArrowUp /> : <IoIosArrowDown />}
+              </li>
+              {expandComponent && (
+                <div className="components-sublinks">
+                  <li>
+                    {componentsData.map((component) => (
+                      <li key={component.id}>
+                        <Link
+                          to={component.url}
+                          className={`toc-sub-heading toc-sub-inline components-item ${
+                            location.pathname.includes(component.url)
+                              ? "active"
+                              : ""
+                          }`}
+                          activeClassName="active"
+                        >
+                          {component.name}
+                        </Link>
+                      </li>
+                    ))}
+                  </li>
+                </div>
+              )}
+            </div>
           </li>
         </ul>
       </div>

--- a/src/components/SistentNavigation/toc.style.js
+++ b/src/components/SistentNavigation/toc.style.js
@@ -125,7 +125,7 @@ const TOCWrapper = styled.div`
     background-color: transparent;
   }
 
-  .identity {
+  .identity, .components {
     display: flex;
     width: 100%;
     justify-content: space-between;
@@ -138,10 +138,10 @@ const TOCWrapper = styled.div`
     }
   }
 
-  .identity-sublinks {
+  .identity-sublinks, .components-sublinks {
     padding-left: 0.56rem;
 
-    .identity-item {
+    .identity-item, .components-item {
       font-size: 1.05rem;
       margin-top: 0.45rem;
     }

--- a/src/sections/Projects/Sistent/components/index.js
+++ b/src/sections/Projects/Sistent/components/index.js
@@ -8,7 +8,7 @@ import useDataList from "../../../../utils/usedataList";
 import { FaArrowRight } from "@react-icons/all-files/fa/FaArrowRight";
 import { Link } from "gatsby";
 
-const componentsData = [
+export const componentsData = [
   {
     id: 1,
     name: "Button",


### PR DESCRIPTION
**Description**

This PR introduces a dropdown in the sidebar for the component category, similar to the identity dropdown. The dropdown displays a list of all components, enhancing navigation and usability.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
![image](https://github.com/user-attachments/assets/126b2bd2-b972-46b6-bc4d-0ac5c9a680e6)

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
