### PR TITLE
[UI] data display update based on new data format from pricing page

### DIFF
--- a/src/sections/Pricing/generateDetails.js
+++ b/src/sections/Pricing/generateDetails.js
@@ -25,11 +25,11 @@ function generateDetails(data) {
 
   return categories.map(category => {
     const features = data
-      .filter(item => item.entire_row["Theme (also: Keychain Name)"] === category.name)
+      .filter(item => item.theme === category.name)
       .map(item => {
-        const featureName = item.entire_row.Function;
-        const description = item.entire_row.Feature;
-        const documentedLink = item.entire_row["Documented?"];
+        const featureName = item.function;
+        const description = item.feature;
+        const documentedLink = item.documented;
         const featureWithLink = documentedLink ? (
           <a href={documentedLink} target="_blank" rel="noopener noreferrer" className="feature-link">
             {featureName}
@@ -41,9 +41,9 @@ function generateDetails(data) {
         return {
           feature: featureWithLink,
           description,
-          free: item.entire_row["Subscription Tier"] === "Free" ? <GiCheckMark className="yes-icon" /> : <MdClose className="no-icon" />,
-          teamDesigner: item.entire_row["Subscription Tier"] === "TeamDesigner" || item.entire_row["Subscription Tier"] === "Free" ? <GiCheckMark className="yes-icon" /> : <MdClose className="no-icon" />,
-          teamOperator: item.entire_row["Subscription Tier"] === "TeamOperator" || item.entire_row["Subscription Tier"] === "Free" ? <GiCheckMark className="yes-icon" /> : <MdClose className="no-icon" />,
+          free: item.subscription_tier === "Free" ? <GiCheckMark className="yes-icon" /> : <MdClose className="no-icon" />,
+          teamDesigner: item.subscription_tier === "TeamDesigner" || item.subscription_tier === "Free" ? <GiCheckMark className="yes-icon" /> : <MdClose className="no-icon" />,
+          teamOperator: item.subscription_tier === "TeamOperator" || item.subscription_tier === "Free" ? <GiCheckMark className="yes-icon" /> : <MdClose className="no-icon" />,
           enterprise: <GiCheckMark className="yes-icon" />,
         };
       });

--- a/src/sections/Pricing/generateOptions.js
+++ b/src/sections/Pricing/generateOptions.js
@@ -3,6 +3,8 @@ import comingSoon from "./icons/coming-soon.webp";
 import React from "react";
 
 function generateOptions(data) {
+  console.log("Initial feature data:", data);
+
   const tiers = {
     "Free": {
       tier: "Personal",
@@ -43,29 +45,42 @@ function generateOptions(data) {
     },
   };
 
+  console.log("Tiers configuration:", tiers);
+
   const options = Object.entries(tiers).map(([tierName, tierInfo]) => {
+    console.log(`Processing tier: ${tierName}`, tierInfo);
+
     const summary = data
-      .filter((item) =>
-        (tierName === "Team" &&
-          (item.entire_row["Subscription Tier"] === "Team" || item.entire_row["Subscription Tier"] === "Team-Beta")) ||
-        (item.entire_row["Subscription Tier"] === tierName && item.pricing_page === "true")
-      )
-      .map((item, index) => ({
-        id: index,
-        category: item.entire_row.Function,
-        description: item.entire_row.Feature,
-        tier: item.entire_row["Subscription Tier"]
-      }));
+      .filter((item) => {
+        const matches = item.subscription_tier === tierName && (item.pricing_page === "true" || item.pricing_page === "X" ) ;
+        return matches;
+      })
+      .map((item, index) => {
+        const mappedItem = {
+          id: index,
+          category: item.function,
+          description: item.feature,
+          tier: item.subscription_tier,
+        };
+
+        console.log("Mapped item:", mappedItem);
+        return mappedItem;
+      });
+
+    console.log(`Summary for tier ${tierName}:`, summary);
 
     return {
       ...tierInfo,
-      summary: summary.length > 0 ? summary : []
+      summary: summary.length > 0 ? summary : [],
     };
   });
 
+  console.log("Final generated options:", options);
   return options;
 }
 
 const options = generateOptions(featureData);
+
+console.log("Exporting options:", options);
 
 export default options;


### PR DESCRIPTION
**Description**

This PR fixes the build failure caused because of new data's structure being different.
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/fda85aef-ca1d-4dff-82b8-f778f4efa0a7">


**Notes for Reviewers**

The previous data was: 
```
 {
    "pricing_page": "true",
    "entire_row": {
      "Category": "Notification Integrations",
      "Documented?": "",
      "Feature": "Access a variety of third-party applications, right from Kanvas. Send a message to Slack, identify an on-duty team to page, or raise an alarm in Datadog.",
      "Function": "Notification Integrations",
      "Pricing page?": "X",
      "Subscription Tier": "Enterprise",
      "Tech": "Cloud",
      "Theme (also: Keychain Name)": "Incident Management"
    }
  },
```
  
  Current data is :
```
  {
    "theme": "Incident Management",
    "category": "Notification Integrations",
    "function": "Notification Integrations",
    "feature": "Access a variety of third-party applications, right from Kanvas. Send a message to Slack, identify an on-duty team to page, or raise an alarm in Datadog.",
    "subscription_tier": "Enterprise",
    "pricing_page": "X",
    "documented": "",
    "comparison_tiers": {
      "free": "",
      "teamDesigner": "",
      "teamOperator": "",
      "enterprise": ""
    }
  }
```

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
