### PR TITLE
fix: Ensure modal appears above iframe by adjusting z-index

### DIFF
--- a/src/sections/General/Navigation/navigation.style.js
+++ b/src/sections/General/Navigation/navigation.style.js
@@ -16,6 +16,7 @@ const NavigationWrap = styled.header`
     }
   }
   .meshery-cta {
+    z-index: 999;
     position: relative;
     display: flex;
     align-items: center;
@@ -618,12 +619,12 @@ const NavigationWrap = styled.header`
     .mobile-nav-item {
       padding: 1px;
       ul:after {
-          content: "";
-          display: block;
-          height: 1px;
-          width: 40%;
-          margin: 10px;
-          background: ${(props) => props.theme.greyC1C1C1ToGreyB3B3B3};
+        content: "";
+        display: block;
+        height: 1px;
+        width: 40%;
+        margin: 10px;
+        background: ${(props) => props.theme.greyC1C1C1ToGreyB3B3B3};
       }
       .menu-item {
         font-size: 16px;
@@ -757,7 +758,8 @@ const NavigationWrap = styled.header`
   }
   .dark-theme-toggle {
     /* margin-left: 2rem; */
-    visibility: ${(props) => typeof props.theme.DarkTheme === "boolean" ? "visible" : "hidden"};
+    visibility: ${(props) =>
+  typeof props.theme.DarkTheme === "boolean" ? "visible" : "hidden"};
   }
 
   .toggle {


### PR DESCRIPTION
**Description**

This PR fixes #6150  issue where the modal was being obscured by the iframe. Adjusted the z-index in the navigation styles to resolve the problem.

Signed-off-by: Faheem Mushtaq <faheemmushtaq89@gmail.com>

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
