### PR TITLE
[Handbook] Repository Overview: Add new project - kubectl-kanvas-snapshot plugin

### DIFF
--- a/src/sections/Community/Handbook/repo-data.js
+++ b/src/sections/Community/Handbook/repo-data.js
@@ -332,6 +332,15 @@ export const repo_data = [
         "The Kanvas Snapshot Helm Plugin allows users to generate a visual snapshot of their Helm charts directly from the command line.",
         repository: "https://github.com/meshery/helm-kanvas-snapshot",
       },
+      {
+        project: "Kubectl kanvas snapshot",
+        image: kanvasLogo,
+        language: "Golang",
+        maintainers_name: ["Vacant"],
+        link: [""],
+        description: "A Kubectl Kanvas Snapshot is a native kubectl plugin designed to conveniently create a visual snapshot of the combination of multiple Kubernetes manifest files.",
+        repository: "https://github.com/meshery/kubectl-kanvas-snapshot",
+      },
     ],
   },
 


### PR DESCRIPTION
**Description**

This PR fixes #5927
By adding an entry in the backend projects table, for the new repository https://github.com/meshery/kubectl-kanvas-snapshot. 

**Notes for Reviewers**
I have added an entry for the kubectl-kanvas-snapshot on the respository overview page, under the backend projects table(Cloud Native Management Repos)

Could you review the updates and let me know if any additional changes or content updates are required?

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 