### PR TITLE
Fixing filter tab overlapping with the top nav bar when hovered

### DIFF
--- a/src/sections/Community/Members-grid/Dropdown.js
+++ b/src/sections/Community/Members-grid/Dropdown.js
@@ -20,9 +20,11 @@ const Dropdown = (props) => {
         <div
           style={{
             display: "flex",
+            position: "relative",
             alignItems: "center",
             justifyContent: "flex-end",
             width: "100%",
+            zIndex: 100
           }}
         >
           <Select


### PR DESCRIPTION
**Description**

I modified the [filter tab](https://layer5.io/community/members) so that it does not appear above the top nav when hovered

This PR fixes #6220 

**Notes for Reviewers**
![image](https://github.com/user-attachments/assets/aeeb0e6e-ad10-4976-aaeb-2aebfc63c2a9)
![image](https://github.com/user-attachments/assets/3ffd3c52-ea69-4f36-8f0f-0b61622fbc9c)
![image](https://github.com/user-attachments/assets/b9c4bc24-b88c-4ed3-9460-ff5b39239bfc)
![image](https://github.com/user-attachments/assets/810d2868-9d21-449e-8a94-b9bf9c02012a)


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [✓ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
