### PR TITLE
Fix text and image overlap in careers page

### DIFF
--- a/src/collections/programs/gsoc-2025/index.mdx
+++ b/src/collections/programs/gsoc-2025/index.mdx
@@ -39,6 +39,7 @@ import playground from "./meshery-playground-alt-4.webp";
 </div>
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 ## GSoC 2025 Project Ideas
 <br />
 
@@ -76,6 +77,9 @@ import playground from "./meshery-playground-alt-4.webp";
 - **Upstream Issue (URL):**  https://github.com/meshery/meshery/issues/13555
 =======
 ## GSoC 2024 Project Ideas
+=======
+## GSoC 2025 Project Ideas
+>>>>>>> 1f319413 (update year)
 <br />
 
 #### Multi-player Collaboration: Resilient Websockets and GraphQL Subscriptions

--- a/src/collections/programs/gsoc-2025/index.mdx
+++ b/src/collections/programs/gsoc-2025/index.mdx
@@ -38,6 +38,7 @@ import playground from "./meshery-playground-alt-4.webp";
   </ul>
 </div>
 
+<<<<<<< HEAD
 ## GSoC 2025 Project Ideas
 <br />
 
@@ -73,6 +74,46 @@ import playground from "./meshery-playground-alt-4.webp";
 - **Expected project size:** large (175 hours)
 - **Difficulty:** Hard
 - **Upstream Issue (URL):**  https://github.com/meshery/meshery/issues/13555
+=======
+## GSoC 2024 Project Ideas
+<br />
+
+#### Meshery Model Support for kro ResourceGraphDefinitions (RGDs)
+
+- **Description:** Enhance Meshery's existing orchestration capabilities to include support for kro ResourceGraphDefinitions (RGDs) as first-class <a href="https://docs.meshery.io/concepts/logical/models">Meshery Models</a>. This involves enabling Meshery to manage and orchestrate RGDs, similar to how it handles other Kubernetes resources. The project will also include generating support for ResourceGraphDefinition in Meshery's Model generator.
+- **Expected outcome:** 
+  - Meshery will be able to orchestrate and manage kro RGDs. This includes the ability to deploy, configure, and manage the lifecycle of RGDs through Meshery.
+  - The Meshery Model generator will be updated to automatically generate models for kro RGDs, simplifying their integration and management within Meshery. This will be an officially supported feature of Meshery.
+- **Recommended Skills:** Golang, Cuelang, Well-written and well-spoken English, Kubernetes, DevOps
+- **Mentor(s):** <Link to="/community/members/lee-calcote">Lee Calcote</Link>, <Link to="mailto:mia.grenell2337@gmail.com">Mia Grenell</Link>
+- **Expected project size:** 350 hours
+- **Difficulty:** Medium
+- **Upstream Issue (URL):** https://github.com/meshery/meshery/issues/13520
+
+#### Hands-on tutorials using Meshery Playground
+
+- **Description:** Learning paths with hands-on labs are a crucial resource for DevOps engineers and cloud-native practitioners. The Meshery Playground provides a live cluster environment, making it an ideal platform for learning every kind of cloud and cloud native technology. Meshery Docs is in need of comprehensive tutorials and scenarios covering common infrastructure management use cases. Mission is to create and publish a series of hands-on tutorials using Meshery Playground. Each tutorial will include step-by-step guides, live demonstrations, and interactive labs using the Playground allowing learners to apply their knowledge directly without the hassle of any configuration.These tutorials will be reviewed by various project maintainers and then published in <a href="https://docs.meshery.io/guides/tutorials">guides/tutorials</a>.
+- **Expected outcome:** 
+  - 10+ new tutorials published in Meshery Docs.
+  - Each tutorial should be interactive, guiding users through infrastructure.
+  - Tutorials should vary in complexity, catering to beginners and advanced learners.
+- **Recommended Skills:** written English, Markdown, Kubernetes, DevOps, and hands-on experience with cloud-native tools
+- **Mentor(s):** <Link to="/community/members/lee-calcote">Lee Calcote</Link>, <Link to=""mailto:mailto:james.horton2337@gmail.com">James Horti</Link>
+- **Expected project size:** large (350 hours)
+- **Difficulty:** Hard
+- **Upstream Issue (URL):** https://github.com/meshery/meshery/issues/13521
+
+#### Expanding end-to-end test coverage in Meshery using Playwright
+
+- **Description:** Description: Meshery integrates with many other CNCF projects and technologies. Sustaining those integrations is only possible through automation. To automate functional integration and end-to-end testing, Meshery now uses Playwright as one of the tools for browser testing. End-to-end tests run with each pull request to ensure that changes do not break existing functionality. Expanding the coverage of E2E tests is crucial to improving the reliability of Meshery’s UI and workflows. This project focuses on writing Playwright-based tests for more Meshery components, ensuring robust test coverage across the platform.
+- **Expected outcome:** 
+  - Development of comprehensive E2E test cases for additional Meshery components using Playwright.
+- **Recommended Skills:** JavaScript, Playwright, GitHub Workflows, familiarity with React or Nextjs would be helpful, CI/CD
+- **Mentor(s):** <Link to="/community/members/lee-calcote">Lee Calcote</Link>, <Link to="/community/members/aabid-sofi">Aabid Sofi</Link>
+- **Expected project size:** medium (175 hours)
+- **Difficulty:** Hard
+- **Upstream Issue (URL):**   https://github.com/meshery/meshery/issues/13514
+>>>>>>> 6ec42010 (gsoc-2025-ideas)
 
 ### Cloud Native Playground
 
@@ -81,6 +122,18 @@ import playground from "./meshery-playground-alt-4.webp";
 </a>
 
 
+<<<<<<< HEAD
+=======
+#### In-browser OPA policy evaluation in WASM and Rego
+
+- **Description:** Meshery's highly dynamic infrastructure configuration capabilities require real-time evaluation of complex policies. Policies of various types and with a high number of parameters need to be evaluted client-side. With policies expressed in Rego, the goal of this project is to incorporate use of the https://github.com/open-policy-agent/golang-opa-wasm project into Meshery UI, so that a powerful, real-time user experience is possible.
+- **Expected outcome:**
+- **Recommended Skills:** Golang, Open Policy Agent, WASM
+- **Mentor(s):** <Link to="/community/members/lee-calcote">Lee Calcote</Link>, <Link to="/community/members/abhishek-kumar">Abhishek Kumar</Link>
+- **Expected project size:** 350 hours
+- **Difficulty:** Hard
+- **Upstream Issue (URL):** https://github.com/meshery/meshery/issues/7019
+>>>>>>> 6ec42010 (gsoc-2025-ideas)
 
 <br />
 <hr />
@@ -142,10 +195,17 @@ We interact daily over Slack, and have an open source project <Link to="/communi
 <div className="apply-button">
   <h3>
     <Button
+<<<<<<< HEAD
       $primary
       title="Participate"
       $url="https://discuss.layer5.io"
       $external={ true }
+=======
+      primary
+      title="Participate"
+      url="https://discuss.layer5.io"
+      external={ true }
+>>>>>>> 6ec42010 (gsoc-2025-ideas)
     />
   </h3>
 </div>

--- a/src/collections/programs/gsoc-2025/index.mdx
+++ b/src/collections/programs/gsoc-2025/index.mdx
@@ -98,22 +98,26 @@ import playground from "./meshery-playground-alt-4.webp";
   - Each tutorial should be interactive, guiding users through infrastructure.
   - Tutorials should vary in complexity, catering to beginners and advanced learners.
 - **Recommended Skills:** written English, Markdown, Kubernetes, DevOps, and hands-on experience with cloud-native tools
-- **Mentor(s):** <Link to="/community/members/lee-calcote">Lee Calcote</Link>, <Link to=""mailto:mailto:james.horton2337@gmail.com">James Horti</Link>
+- **Mentor(s):** <Link to="/community/members/lee-calcote">Lee Calcote</Link>, <Link to="mailto:james.horton2337@gmail.com">James Horti</Link>
 - **Expected project size:** large (350 hours)
 - **Difficulty:** Hard
 - **Upstream Issue (URL):** https://github.com/meshery/meshery/issues/13521
 
 #### Expanding end-to-end test coverage in Meshery using Playwright
 
-- **Description:** Description: Meshery integrates with many other CNCF projects and technologies. Sustaining those integrations is only possible through automation. To automate functional integration and end-to-end testing, Meshery now uses Playwright as one of the tools for browser testing. End-to-end tests run with each pull request to ensure that changes do not break existing functionality. Expanding the coverage of E2E tests is crucial to improving the reliability of Meshery’s UI and workflows. This project focuses on writing Playwright-based tests for more Meshery components, ensuring robust test coverage across the platform.
+- **Description:** Meshery integrates with many other CNCF projects and technologies. Sustaining those integrations is only possible through automation. To automate functional integration and end-to-end testing, Meshery now uses Playwright as one of the tools for browser testing. End-to-end tests run with each pull request to ensure that changes do not break existing functionality. Expanding the coverage of E2E tests is crucial to improving the reliability of Meshery’s UI and workflows. This project focuses on writing Playwright-based tests for more Meshery components, ensuring robust test coverage across the platform.
 - **Expected outcome:** 
   - Development of comprehensive E2E test cases for additional Meshery components using Playwright.
 - **Recommended Skills:** JavaScript, Playwright, GitHub Workflows, familiarity with React or Nextjs would be helpful, CI/CD
 - **Mentor(s):** <Link to="/community/members/lee-calcote">Lee Calcote</Link>, <Link to="/community/members/aabid-sofi">Aabid Sofi</Link>
 - **Expected project size:** medium (175 hours)
 - **Difficulty:** Hard
+<<<<<<< HEAD
 - **Upstream Issue (URL):**   https://github.com/meshery/meshery/issues/13514
 >>>>>>> 6ec42010 (gsoc-2025-ideas)
+=======
+- **Upstream Issue (URL):**  https://github.com/meshery/meshery/issues/13514
+>>>>>>> 7e558222 (lfx-2025-term-1)
 
 ### Cloud Native Playground
 

--- a/src/collections/programs/gsoc-2025/index.mdx
+++ b/src/collections/programs/gsoc-2025/index.mdx
@@ -203,6 +203,7 @@ We interact daily over Slack, and have an open source project <Link to="/communi
   <h3>
     <Button
 <<<<<<< HEAD
+<<<<<<< HEAD
       $primary
       title="Participate"
       $url="https://discuss.layer5.io"
@@ -213,6 +214,12 @@ We interact daily over Slack, and have an open source project <Link to="/communi
       url="https://discuss.layer5.io"
       external={ true }
 >>>>>>> 6ec42010 (gsoc-2025-ideas)
+=======
+      $primary
+      title="Participate"
+      $url="https://discuss.layer5.io"
+      $external={ true }
+>>>>>>> 1fbda854 (Fix participate button in gsoc)
     />
   </h3>
 </div>

--- a/src/collections/programs/gsoc-2025/index.mdx
+++ b/src/collections/programs/gsoc-2025/index.mdx
@@ -127,6 +127,7 @@ import playground from "./meshery-playground-alt-4.webp";
 
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 #### In-browser OPA policy evaluation in WASM and Rego
 
@@ -138,6 +139,8 @@ import playground from "./meshery-playground-alt-4.webp";
 - **Difficulty:** Hard
 - **Upstream Issue (URL):** https://github.com/meshery/meshery/issues/7019
 >>>>>>> 6ec42010 (gsoc-2025-ideas)
+=======
+>>>>>>> 694da1b9 (Update src/collections/programs/gsoc-2025/index.mdx)
 
 <br />
 <hr />

--- a/src/collections/programs/gsoc-2025/index.mdx
+++ b/src/collections/programs/gsoc-2025/index.mdx
@@ -78,46 +78,47 @@ import playground from "./meshery-playground-alt-4.webp";
 ## GSoC 2024 Project Ideas
 <br />
 
-#### Meshery Model Support for kro ResourceGraphDefinitions (RGDs)
+#### Multi-player Collaboration: Resilient Websockets and GraphQL Subscriptions
 
-- **Description:** Enhance Meshery's existing orchestration capabilities to include support for kro ResourceGraphDefinitions (RGDs) as first-class <a href="https://docs.meshery.io/concepts/logical/models">Meshery Models</a>. This involves enabling Meshery to manage and orchestrate RGDs, similar to how it handles other Kubernetes resources. The project will also include generating support for ResourceGraphDefinition in Meshery's Model generator.
+- **Description:** Meshery's current implementation of websockets and GraphQL subscriptions is in need of refactoring for increased reliability and resiliency. This client and server-side refactoring includes use of webworkers and separation of concerns for the client-side, and the use of a message broker for the server-side. The project has implications on Meshery's implementation of multi-player collaboration functionality.
 - **Expected outcome:** 
-  - Meshery will be able to orchestrate and manage kro RGDs. This includes the ability to deploy, configure, and manage the lifecycle of RGDs through Meshery.
-  - The Meshery Model generator will be updated to automatically generate models for kro RGDs, simplifying their integration and management within Meshery. This will be an officially supported feature of Meshery.
-- **Recommended Skills:** Golang, Cuelang, Well-written and well-spoken English, Kubernetes, DevOps
-- **Mentor(s):** <Link to="/community/members/lee-calcote">Lee Calcote</Link>, <Link to="mailto:mia.grenell2337@gmail.com">Mia Grenell</Link>
-- **Expected project size:** 350 hours
-- **Difficulty:** Medium
-- **Upstream Issue (URL):** https://github.com/meshery/meshery/issues/13520
-
-#### Hands-on tutorials using Meshery Playground
-
-- **Description:** Learning paths with hands-on labs are a crucial resource for DevOps engineers and cloud-native practitioners. The Meshery Playground provides a live cluster environment, making it an ideal platform for learning every kind of cloud and cloud native technology. Meshery Docs is in need of comprehensive tutorials and scenarios covering common infrastructure management use cases. Mission is to create and publish a series of hands-on tutorials using Meshery Playground. Each tutorial will include step-by-step guides, live demonstrations, and interactive labs using the Playground allowing learners to apply their knowledge directly without the hassle of any configuration.These tutorials will be reviewed by various project maintainers and then published in <a href="https://docs.meshery.io/guides/tutorials">guides/tutorials</a>.
-- **Expected outcome:** 
-  - 10+ new tutorials published in Meshery Docs.
-  - Each tutorial should be interactive, guiding users through infrastructure.
-  - Tutorials should vary in complexity, catering to beginners and advanced learners.
-- **Recommended Skills:** written English, Markdown, Kubernetes, DevOps, and hands-on experience with cloud-native tools
-- **Mentor(s):** <Link to="/community/members/lee-calcote">Lee Calcote</Link>, <Link to="mailto:james.horton2337@gmail.com">James Horti</Link>
-- **Expected project size:** large (350 hours)
-- **Difficulty:** Hard
-- **Upstream Issue (URL):** https://github.com/meshery/meshery/issues/13521
-
-#### Expanding end-to-end test coverage in Meshery using Playwright
-
-- **Description:** Meshery integrates with many other CNCF projects and technologies. Sustaining those integrations is only possible through automation. To automate functional integration and end-to-end testing, Meshery now uses Playwright as one of the tools for browser testing. End-to-end tests run with each pull request to ensure that changes do not break existing functionality. Expanding the coverage of E2E tests is crucial to improving the reliability of Meshery’s UI and workflows. This project focuses on writing Playwright-based tests for more Meshery components, ensuring robust test coverage across the platform.
-- **Expected outcome:** 
-  - Development of comprehensive E2E test cases for additional Meshery components using Playwright.
-- **Recommended Skills:** JavaScript, Playwright, GitHub Workflows, familiarity with React or Nextjs would be helpful, CI/CD
+  - Resilient websockets and GraphQL subscriptions for Meshery, enabling multi-player collaboration functionality.
+- **Recommended Skills:** Golang, Kubernetes, Azure, well-written and well-spoken English
 - **Mentor(s):** <Link to="/community/members/lee-calcote">Lee Calcote</Link>, <Link to="/community/members/aabid-sofi">Aabid Sofi</Link>
-- **Expected project size:** medium (175 hours)
+- **Expected project size:** 175 hours
+- **Difficulty:** Medium
+- **Upstream Issue (URL):** https://github.com/meshery/meshery/issues/13554
+
+#### Support for Azure in Meshery
+
+- **Description:** Enhance Meshery's existing orchestration capabilities to include support for Azure. The <a href="https://azure.github.io/azure-service-operator">Azure Service Operator</a>(ASO) provides a wide variety of Azure Resources via Kubernetes custom resources as first-class <a href="https://docs.meshery.io/concepts/logical/models">Meshery Models</a>. This involves enabling Meshery to manage and orchestrate Azure services and their resources, similar to how it handles other Kubernetes resources. The project will also include generating support for Azure services and their resources in Meshery's Model generator.
+- **Expected outcome:** 
+  - Meshery will be able to orchestrate and manage all Azure services supported by ASO. This includes the ability to discover, configure, deploy, and operate the lifecycle of Azure services through Meshery. The Meshery Model generator will be updated to automatically generate models for Azure services, simplifying their integration and management within Meshery. This will be an officially supported feature of Meshery.
+- **Recommended Skills:** Golang, Kubernetes, Azure, well-written and well-spoken English
+- **Mentor(s):** <Link to="/community/members/lee-calcote">Lee Calcote</Link>, <Link to="mailto:mailto:mia.grenell2337@gmail.co">Mia Grenell</Link>
+- **Expected project size:** large (175 hours)
 - **Difficulty:** Hard
+<<<<<<< HEAD
 <<<<<<< HEAD
 - **Upstream Issue (URL):**   https://github.com/meshery/meshery/issues/13514
 >>>>>>> 6ec42010 (gsoc-2025-ideas)
 =======
 - **Upstream Issue (URL):**  https://github.com/meshery/meshery/issues/13514
 >>>>>>> 7e558222 (lfx-2025-term-1)
+=======
+- **Upstream Issue (URL):** https://github.com/meshery/meshery/issues/11244
+
+#### Distributed client-side inference (policy evaluation) with WebAssembly (WASM) and OPA in Meshery
+
+- **Description:** Meshery's highly dynamic infrastructure configuration capabilities require real-time evaluation of complex policies. Policies of various types and with a high number of parameters need to be evaluted client-side. With policies expressed in Rego, the goal of this project is to incorporate use of the <a href="https://github.com/open-policy-agent/golang-opa-wasm">https://github.com/open-policy-agent/golang-opa-wasm</a> project into Meshery UI, so that a powerful, real-time user experience is possible.
+- **Expected outcome:** 
+  - The goal of this project is to enhance Meshery's infrastructure configuration capabilities by incorporating real-time policy evaluation using the golang-opa-wasm project. This project will integrate the capabilities of golang-opa-wasm into the Meshery UI, enabling users to experience the existing, powerful, server-side policy evaluation client-side.
+- **Recommended Skills:** WebAssembly, Golang, Open Policy Agent, well-written and well-spoken English
+- **Mentor(s):** <Link to="/community/members/lee-calcote">Lee Calcote</Link>, <Link to="james.horton2337@gmail.com">James Horton</Link>
+- **Expected project size:** large (175 hours)
+- **Difficulty:** Hard
+- **Upstream Issue (URL):**  https://github.com/meshery/meshery/issues/13555
+>>>>>>> 7bdc458f (update gsoc 2025 program)
 
 ### Cloud Native Playground
 

--- a/src/collections/programs/gsoc-2025/index.mdx
+++ b/src/collections/programs/gsoc-2025/index.mdx
@@ -95,7 +95,7 @@ import playground from "./meshery-playground-alt-4.webp";
 - **Expected outcome:** 
   - Meshery will be able to orchestrate and manage all Azure services supported by ASO. This includes the ability to discover, configure, deploy, and operate the lifecycle of Azure services through Meshery. The Meshery Model generator will be updated to automatically generate models for Azure services, simplifying their integration and management within Meshery. This will be an officially supported feature of Meshery.
 - **Recommended Skills:** Golang, Kubernetes, Azure, well-written and well-spoken English
-- **Mentor(s):** <Link to="/community/members/lee-calcote">Lee Calcote</Link>, <Link to="mailto:mailto:mia.grenell2337@gmail.co">Mia Grenell</Link>
+- **Mentor(s):** <Link to="/community/members/lee-calcote">Lee Calcote</Link>, <Link to="mailto:mia.grenell2337@gmail.co">Mia Grenell</Link>
 - **Expected project size:** large (175 hours)
 - **Difficulty:** Hard
 <<<<<<< HEAD
@@ -114,7 +114,7 @@ import playground from "./meshery-playground-alt-4.webp";
 - **Expected outcome:** 
   - The goal of this project is to enhance Meshery's infrastructure configuration capabilities by incorporating real-time policy evaluation using the golang-opa-wasm project. This project will integrate the capabilities of golang-opa-wasm into the Meshery UI, enabling users to experience the existing, powerful, server-side policy evaluation client-side.
 - **Recommended Skills:** WebAssembly, Golang, Open Policy Agent, well-written and well-spoken English
-- **Mentor(s):** <Link to="/community/members/lee-calcote">Lee Calcote</Link>, <Link to="james.horton2337@gmail.com">James Horton</Link>
+- **Mentor(s):** <Link to="/community/members/lee-calcote">Lee Calcote</Link>, <Link to="mailto:james.horton2337@gmail.com">James Horton</Link>
 - **Expected project size:** large (175 hours)
 - **Difficulty:** Hard
 - **Upstream Issue (URL):**  https://github.com/meshery/meshery/issues/13555

--- a/src/collections/programs/gsoc-2025/index.mdx
+++ b/src/collections/programs/gsoc-2025/index.mdx
@@ -61,6 +61,7 @@ import playground from "./meshery-playground-alt-4.webp";
   - Meshery will be able to orchestrate and manage all Azure services supported by ASO. This includes the ability to discover, configure, deploy, and operate the lifecycle of Azure services through Meshery. The Meshery Model generator will be updated to automatically generate models for Azure services, simplifying their integration and management within Meshery. This will be an officially supported feature of Meshery.
 - **Recommended Skills:** Golang, Kubernetes, Azure, well-written and well-spoken English
 - **Mentor(s):** <Link to="/community/members/lee-calcote">Lee Calcote</Link>, <Link to="mailto:mia.grenell2337@gmail.com">Mia Grenell</Link>
+<<<<<<< HEAD
 - **Expected project size:** large (175 hours)
 - **Difficulty:** Hard
 - **Upstream Issue (URL):** https://github.com/meshery/meshery/issues/11244
@@ -100,6 +101,8 @@ import playground from "./meshery-playground-alt-4.webp";
   - Meshery will be able to orchestrate and manage all Azure services supported by ASO. This includes the ability to discover, configure, deploy, and operate the lifecycle of Azure services through Meshery. The Meshery Model generator will be updated to automatically generate models for Azure services, simplifying their integration and management within Meshery. This will be an officially supported feature of Meshery.
 - **Recommended Skills:** Golang, Kubernetes, Azure, well-written and well-spoken English
 - **Mentor(s):** <Link to="/community/members/lee-calcote">Lee Calcote</Link>, <Link to="mailto:mia.grenell2337@gmail.co">Mia Grenell</Link>
+=======
+>>>>>>> f22b09d5 (Update src/collections/programs/gsoc-2025/index.mdx)
 - **Expected project size:** large (175 hours)
 - **Difficulty:** Hard
 <<<<<<< HEAD

--- a/src/collections/programs/lfx-2025/lfx-2025.mdx
+++ b/src/collections/programs/lfx-2025/lfx-2025.mdx
@@ -115,6 +115,7 @@ We interact daily over Slack, and have an open source project [meeting everyday]
   <h3>
     <Button
 <<<<<<< HEAD
+<<<<<<< HEAD
       $primary
       title="Participate"
       $url="https://slack.layer5.io"
@@ -125,6 +126,12 @@ We interact daily over Slack, and have an open source project [meeting everyday]
       url="https://slack.layer5.io"
       external={ true }
 >>>>>>> 7e558222 (lfx-2025-term-1)
+=======
+      $primary
+      title="Participate"
+      $url="https://slack.layer5.io"
+      $external={ true }
+>>>>>>> 62f12b41 (Fix button in lfx)
     />
   </h3>
 </div>

--- a/src/collections/programs/lfx-2025/lfx-2025.mdx
+++ b/src/collections/programs/lfx-2025/lfx-2025.mdx
@@ -114,10 +114,17 @@ We interact daily over Slack, and have an open source project [meeting everyday]
 <div className="apply-button">
   <h3>
     <Button
+<<<<<<< HEAD
       $primary
       title="Participate"
       $url="https://slack.layer5.io"
       $external={ true }
+=======
+      primary
+      title="Participate"
+      url="https://slack.layer5.io"
+      external={ true }
+>>>>>>> 7e558222 (lfx-2025-term-1)
     />
   </h3>
 </div>

--- a/src/reusecore/PageHeader/pageHeader.style.js
+++ b/src/reusecore/PageHeader/pageHeader.style.js
@@ -9,6 +9,7 @@ const PageHeaderWrapper = styled.div`
             text-align: center;
             position: relative;
             height: auto;
+            margin-top: 3rem;
             margin-bottom: 2rem;
             padding: 0 1rem 0;
             z-index: 99;

--- a/src/reusecore/PageHeader/pageHeader.style.js
+++ b/src/reusecore/PageHeader/pageHeader.style.js
@@ -9,7 +9,6 @@ const PageHeaderWrapper = styled.div`
             text-align: center;
             position: relative;
             height: auto;
-            margin-top: 3rem;
             margin-bottom: 2rem;
             padding: 0 1rem 0;
             z-index: 99;

--- a/src/sections/Careers/Careers-Programs-grid/ProgramGrid.style.js
+++ b/src/sections/Careers/Careers-Programs-grid/ProgramGrid.style.js
@@ -108,7 +108,7 @@ export const ProgramsPageWrapper = styled.div`
     }
     .opensource-section-img{
         margin-top: -8rem;
-        margin-bottom: 8rem;
+        margin-bottom: 10rem;
         position: relative;
         top: 10rem;
     }

--- a/src/sections/Careers/Careers-Programs-grid/ProgramGrid.style.js
+++ b/src/sections/Careers/Careers-Programs-grid/ProgramGrid.style.js
@@ -94,7 +94,7 @@ export const ProgramsPageWrapper = styled.div`
         margin-right: -50vw;
     }
     .opensource-section-text{
-        padding-top: 4rem;
+        padding: 4rem 2.5rem 0;
     }
     .opensource-section-text > h1{
         margin-bottom: 1rem;

--- a/src/sections/Careers/Careers-Programs-grid/ProgramGrid.style.js
+++ b/src/sections/Careers/Careers-Programs-grid/ProgramGrid.style.js
@@ -108,6 +108,7 @@ export const ProgramsPageWrapper = styled.div`
     }
     .opensource-section-img{
         margin-top: -8rem;
+        margin-bottom: 8rem;
         position: relative;
         top: 10rem;
     }


### PR DESCRIPTION
**Description**
This PR fixes the text overlap issue in the Open Source Internship section by increasing the margin below the image and adjusting `PageHeader` spacing to ensure proper separation.

This PR fixes #6225

Before:  
<img src="https://github.com/user-attachments/assets/d368a9c5-4035-4c60-b243-f4702dc02e51" width="600"/>

After:  
<img src="https://github.com/user-attachments/assets/1d44b72c-cafe-4cf3-bb42-f486f516c231" width="600"/>


**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
