### PR TITLE
fix: duplicate comments by github label commenter bot

### DIFF
--- a/.github/label-commenter-config.yml
+++ b/.github/label-commenter-config.yml
@@ -11,14 +11,20 @@ labels:
       issue:
         body: This issue has been labeled with 'design-required'. Note that prior to commencing on implementation, a design specification needs to be created and reviewed for approval. See [Creating a Functional Specification](https://docs.google.com/document/d/1RP3IWLc-MiQS-QYasqCoVuCH7--G87p5ezE5f_nOzB8/edit?usp=sharing) to create a design spec.
         action: open
+        if: "!contains(github.event.issue.body, 'This issue has been labeled with ''design-required''')"
+
   - name: issue/remind
     labeled:
       issue:
         body: Checking in... it has been awhile since we&#39;ve heard from you on this issue. Are you still working on it? Please let us know and please don&#39;t hesitate to contact a [MeshMate](https://layer5.io/community/meshmates/) or any other [community member](https://layer5.io/community/members) for assistance.
         action: open
+        if: "!contains(github.event.issue.body, 'Checking in...')"
+
       pr:
         body: Checking in... it has been awhile since we&#39;ve heard from you on this issue. Are you still working on it? Please let us know and please don&#39;t hesitate to contact a [MeshMate](https://layer5.io/community/meshmates/) or any other [community member](https://layer5.io/community/members) for assistance.
         action: open
+        if: "!contains(github.event.pull_request.body, 'Checking in...')"
+
   - name: issue/dco
     labeled:
       issue:
@@ -26,27 +32,38 @@ labels:
          To amend the commits in this PR with your signoff using the instructions provided in the DCO check. \n\n
          To configure your dev environment to automatically signoff on your commits in the future, see [these instructions](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)."
         action: open
+        if: "!contains(github.event.issue.body, 'Git Police')"
+
       pr:
         body: "🚨 Alert! Git Police! We couldn’t help but notice that one or more of your commits is missing a sign-off. _A what?_ A commit sign-off (your email address).\n\n
          To amend the commits in this PR with your signoff using the instructions provided in the DCO check. \n\n
          To configure your dev environment to automatically signoff on your commits in the future, see [these instructions](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)."
         action: open
+        if: "!contains(github.event.pull_request.body, 'Git Police')"
+
   - name: component/ui
     labeled:
       issue:
         body: This issue has been labeled with 'component/ui'. 🧰 Here are docs on [Contributing to Meshery UI](https://docs.meshery.io/project/contributing/contributing-ui). 🎨 Here is the [Meshery UI Figma File](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI?node-id=4%3A0) File. Lastly, here are docs on [Contributing to Meshery's End-to-End Tests Using Cypress](https://docs.meshery.io/project/contributing/contributing-cypress).
         action: open
+        if: "!contains(github.event.issue.body, 'component/ui')"
+
       pr:
         body: This PR has been labeled with 'component/ui'. 🧰 Here are docs on [Contributing to Meshery UI](https://docs.meshery.io/project/contributing/contributing-ui). 🎨 Here is the [Meshery UI Figma File](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI?node-id=4%3A0) File. Lastly, here are docs on [Contributing to Meshery's End-to-End Tests Using Cypress](https://docs.meshery.io/project/contributing/contributing-cypress)
         action: open
+        if: "!contains(github.event.pull_request.body, 'component/ui')"
+
   - name: component/mesheryctl
     labeled:
       issue:
         body: This issue has been labeled with 'component/mesheryctl'. Note that after making changes you need to update it in the [mesheryctl command tracker](https://docs.google.com/spreadsheets/d/1q63sIGAuCnIeDs8PeM-0BAkNj8BBgPUXhLbe1Y-318o/edit#gid=0) spreadsheet.
         action: open
+        if: "!contains(github.event.issue.body, 'component/mesheryctl')"
+
       pr:
         body: This PR has been labeled with 'component/mesheryctl'. Note that after making changes you need to update it in the [mesheryctl command tracker](https://docs.google.com/spreadsheets/d/1q63sIGAuCnIeDs8PeM-0BAkNj8BBgPUXhLbe1Y-318o/edit#gid=0) spreadsheet.
         action: open
+        if: "!contains(github.event.pull_request.body, 'component/mesheryctl')"
       # pr:
       #   body: Hi, please note that this issue will need an approved design specification before implementation proceeds. See [Creating a Functional Specification](https://docs.google.com/document/d/1RP3IWLc-MiQS-QYasqCoVuCH7--G87p5ezE5f_nOzB8/edit?usp=sharing) to create a design spec.
       #   action: open


### PR DESCRIPTION
**Description**

This PR fixes #5989 

**Notes for Reviewers**

Added conditional statements to workflow files to check if the comment already exists.


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
