### PR TITLE
Fix 6312 - Extra spaces in the beginning of handbook pages in layer5 website

### DIFF
--- a/src/sections/Community/Handbook/Handbook.style.js
+++ b/src/sections/Community/Handbook/Handbook.style.js
@@ -38,21 +38,21 @@ export const HandbookWrapper = styled.div`
 
     .page-section{
       h2{
-        padding-top: 7rem;
-        margin-top: -7rem;
+        padding-top: 0rem;
+        margin-top: 0rem;
       }
       h3{
         padding-top: 7rem;
         margin-top: -7rem;
       }
       @media (min-width: 750px) {
-        margin-top: -36rem;
+        margin-top: -53rem;
         margin-left: 20rem;
       }
       display: flex;
 
       @media screen and (min-width: 768px) and (max-height: 1145px) {
-       margin-top : -62vh ;
+       margin-top : -90vh ;
 
 
   }
@@ -62,10 +62,10 @@ export const HandbookWrapper = styled.div`
     }
     .conduct-section{
       @media screen and (min-width: 751px) {
-        margin-top:-43rem;
+        margin-top: -90vh;
       }
             @media screen and (min-width: 768px) and (max-height: 1145px) {
-       margin-top : -66vh ! important;
+       margin-top : -90vh ! important;
 
     }
 

--- a/src/sections/Community/Handbook/Handbook.style.js
+++ b/src/sections/Community/Handbook/Handbook.style.js
@@ -38,21 +38,21 @@ export const HandbookWrapper = styled.div`
 
     .page-section{
       h2{
-        padding-top: 0rem;
-        margin-top: 0rem;
+        padding-top: 7rem;
+        margin-top: -7rem;
       }
       h3{
         padding-top: 7rem;
         margin-top: -7rem;
       }
       @media (min-width: 750px) {
-        margin-top: -53rem;
+        margin-top: -36rem;
         margin-left: 20rem;
       }
       display: flex;
 
       @media screen and (min-width: 768px) and (max-height: 1145px) {
-       margin-top : -90vh ;
+       margin-top : -62vh ;
 
 
   }
@@ -62,10 +62,10 @@ export const HandbookWrapper = styled.div`
     }
     .conduct-section{
       @media screen and (min-width: 751px) {
-        margin-top: -90vh;
+        margin-top:-43rem;
       }
             @media screen and (min-width: 768px) and (max-height: 1145px) {
-       margin-top : -90vh ! important;
+       margin-top : -66vh ! important;
 
     }
 

--- a/src/sections/Community/Handbook/Handbook.style.js
+++ b/src/sections/Community/Handbook/Handbook.style.js
@@ -38,21 +38,21 @@ export const HandbookWrapper = styled.div`
 
     .page-section{
       h2{
-        padding-top: 7rem;
-        margin-top: -7rem;
+        padding-top: 0rem;
+        margin-top: 0rem;
       }
       h3{
         padding-top: 7rem;
         margin-top: -7rem;
       }
       @media (min-width: 750px) {
-        margin-top: -36rem;
+        margin-top: -53rem;
         margin-left: 20rem;
       }
       display: flex;
 
       @media screen and (min-width: 768px) and (max-height: 1145px) {
-       margin-top : -62vh ;
+       margin-top : -90vh ;
 
 
   }
@@ -62,10 +62,10 @@ export const HandbookWrapper = styled.div`
     }
     .conduct-section{
       @media screen and (min-width: 751px) {
-        margin-top:-43rem;
+        margin-top:-90rem;
       }
             @media screen and (min-width: 768px) and (max-height: 1145px) {
-       margin-top : -66vh ! important;
+       margin-top : -90vh ! important;
 
     }
 


### PR DESCRIPTION
**Description**

This PR fixes #https://github.com/layer5io/layer5/issues/6312
Test Documentation: https://docs.google.com/document/d/1dvoVlz9rejB_a-9L90O7u6iwBM7H5TS3KgGJDVUP2rk/edit?usp=sharing

**Notes for Reviewers**



**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
