### PR TITLE
add product frontamatter

### DIFF
--- a/src/collections/blog/2024/11-05-what-is-the-kanvas-catalog/post.mdx
+++ b/src/collections/blog/2024/11-05-what-is-the-kanvas-catalog/post.mdx
@@ -13,6 +13,7 @@ tags:
 featured: false
 published: true
 resource: true
+product: Kanvas
 ---
 
 import { BlogWrapper } from "../../Blog.style.js";

--- a/src/collections/news/2024/2024-11-12-layer5-launches-kanvas-a-collaborative-platform-for-cloud-native-infrastructure/index.mdx
+++ b/src/collections/news/2024/2024-11-12-layer5-launches-kanvas-a-collaborative-platform-for-cloud-native-infrastructure/index.mdx
@@ -14,6 +14,7 @@ type: News
 presskit: ""
 resource: false
 published: true
+product: Kanvas
 ---
 import { Link } from "gatsby";
 import Kanvas from "./kanvas-icon-color.svg";

--- a/src/collections/news/2024/2024-11-12-layer5-launches-kanvas-a-collaborative-platform-for-cloud-native-infrastructure/index.mdx
+++ b/src/collections/news/2024/2024-11-12-layer5-launches-kanvas-a-collaborative-platform-for-cloud-native-infrastructure/index.mdx
@@ -14,7 +14,6 @@ type: News
 presskit: ""
 resource: false
 published: true
-product: Kanvas
 ---
 import { Link } from "gatsby";
 import Kanvas from "./kanvas-icon-color.svg";


### PR DESCRIPTION
**Description**:

All content in `news`, `blog`, `resources`, and `events` collections that contain a `product:<value>` frontmatter field in their `*.mdx` files will contribute to a `<value>` Product filter on [layer5.io/resources](https://layer5.io/resources).
- This merge request adds the appropriate product frontmatter to relevant blog post.

**Notes for Reviewers**:

We need to ensure that products such as `Kanvas` and `Cloud` are represented in the filter.
> [!Important]
> `resource` frontmatter mustn't have value set to `false` i.e. `resource: false`

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
