### PR TITLE
Fix: Added max-width to learning path images

### DIFF
--- a/src/components/Learn-Components/Card-Component/learn-card.style.js
+++ b/src/components/Learn-Components/Card-Component/learn-card.style.js
@@ -85,6 +85,8 @@ const CardWrapper = styled.div`
         img{
             height: 8.5rem;
             width: 8.5rem;
+            max-width: 100%;
+            object-fit: contain;
         }
     }
 


### PR DESCRIPTION
**Description**

This PR fixes #6411

The issue was that images in the learning paths were taking up the full width of their container, causing them to appear excessively large and unscalable. This PR adds the `max-width: 100%;` and `object-fit: contain;` CSS properties to ensure that images are properly constrained and maintain their aspect ratios while scaling proportionally.

**Notes for Reviewers**

- Tested the changes locally to ensure that the images now scale appropriately and are responsive across different screen sizes.
- The fix is applied to the `.card-image img` styles in the `learn-card.style.js` file.
- https://github.com/layer5io/layer5/blob/711ee7a918088ec95d53d6ff90812564c377d210/src/components/Learn-Components/Card-Component/learn-card.style.js#L85-L88

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
Thankyou ! 🌻 
