### PR TITLE
fix typo in 'Explore Kanvasoperator'

### DIFF
--- a/src/sections/Kanvas/Kanvas-visualize/kanvas-visualize-banner.js
+++ b/src/sections/Kanvas/Kanvas-visualize/kanvas-visualize-banner.js
@@ -93,7 +93,7 @@ const KanvasisualizeBanner = () => {
         <div className="banner-text">
           <h1>Operate your infrastructure </h1>
           <h4>See your designs <span>in action.</span> Operate with <span>best practices.</span></h4>
-          <KanvasBtn title="Explore Kanvasoperator" />
+          <KanvasBtn title="Explore Kanvas Operator" />
         </div>
         {/* <div className="banner-image">
           <img src={BannerImage} alt="" />


### PR DESCRIPTION
**Description**

This PR fixes #

This PR fixes a minor typo in the Kanvas section heading. The text was previously written as "Explore Kanvasoperator" and has been corrected to "Explore Kanvas Operator".
