### PR TITLE
Handbook Table Theme Fix

### DIFF
--- a/src/sections/Community/Handbook/Handbook.style.js
+++ b/src/sections/Community/Handbook/Handbook.style.js
@@ -162,7 +162,7 @@ export const HandbookWrapper = styled.div`
     }
 
     td, th {
-      border: 0.05rem solid ${(props) => props.theme.primaryLightColor};
+      border: 0.05rem solid ${(props) => props.theme.primaryTestLightColor};
       text-align: left;
       padding: 0.5rem;
       transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
@@ -180,7 +180,7 @@ export const HandbookWrapper = styled.div`
     }
 
     tbody:nth-child(even) {
-      background-color: ${(props) => props.theme.secondaryLightColorTwo};
+      background-color: ${(props) => props.theme.secondaryTestLightColorTwo};
       transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
     }
 

--- a/src/theme/app/themeStyles.js
+++ b/src/theme/app/themeStyles.js
@@ -15,6 +15,7 @@ const lighttheme = {
 
   // silver chalice (light gray)
   primaryLightColor: "#b3b3b3",
+  primaryTestLightColor: "#2C2C2C",
 
   // keppel (dark green)
   primaryLightColorTwo: "#00d3a9",
@@ -24,6 +25,7 @@ const lighttheme = {
   secondaryColor: "#00b39f",
   caribbeanGreenColor: "#00d3a9",
   secondaryLightColorTwo: "#F3FFFD",
+  secondaryTestLightColorTwo: "rgba(0,179,159, .4)",
 
   // lighter gray
   secondaryLightColor: "#FAFAFA",
@@ -248,7 +250,7 @@ export const darktheme = {
 
   // silver chalice (light gray)
   primaryLightColor: "#2C2C2C",
-
+  primaryTestLightColor: "#2C2C2C",
   // keppel (dark green)
   primaryLightColorTwo: "#2C2C2C",
   keppelColor: "#00d3a9",
@@ -257,7 +259,7 @@ export const darktheme = {
   secondaryColor: "#00b39f",
   caribbeanGreenColor: "#00d3a9",
   secondaryLightColorTwo: "rgba(0,179,159, .4)",
-
+  secondaryTestLightColorTwo: "rgba(0,179,159, .4)",
   // lighter gray
   secondaryLightColor: "#000000",
 


### PR DESCRIPTION
**Description**

This PR fixes #
The Theme Toggle issue faced by Handbook Tables and some Other components
This 1st PR is only to fix the table 

**Before**
![image](https://github.com/user-attachments/assets/ec694faf-b297-4a6b-9604-82cbc1bc9f14)
![image](https://github.com/user-attachments/assets/0e301c2a-6f17-49ea-bbbd-0913d6650ae5)

**After**
![image](https://github.com/user-attachments/assets/27c931c4-ec6e-41a7-8219-e821b69d4e59)
![image](https://github.com/user-attachments/assets/5a8c9980-6767-4921-a88a-8428fd44ee61)

**Notes for Reviewers**
The same table issue was found in all handbook pages 
There is also problem is invite-only class colors and some text classes , if this goes well will update similar to them also

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
