### PR TITLE
Add section heading to Code of Conduct page for consistency

### DIFF
--- a/src/sections/Community/Handbook/conduct.js
+++ b/src/sections/Community/Handbook/conduct.js
@@ -16,9 +16,7 @@ const CodeofConduct = () => {
       <div className="page-section conduct-section">
         <Container>
           <div className="content">
-           
-              <h2 className="heading-top">Community Code of Conduct</h2>
-           
+            <h2 className="heading-top">Community Code of Conduct</h2>
             <p>Layer5 follows the <a href="https://github.com/cncf/foundation/blob/master/code-of-conduct.md">CNCF Code of Conduct</a> which states that:</p>
             <p>As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, to post feature requests, to update documentation, to submit pull requests or patches, and other activities.</p>
             <p>We are committed to participating in this project as a harassment-free experience for everyone, regardless of the level of experience, gender, gender identity, and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.</p>

--- a/src/sections/Community/Handbook/conduct.js
+++ b/src/sections/Community/Handbook/conduct.js
@@ -16,6 +16,9 @@ const CodeofConduct = () => {
       <div className="page-section conduct-section">
         <Container>
           <div className="content">
+           
+              <h2 className="heading-top">Community Code of Conduct</h2>
+           
             <p>Layer5 follows the <a href="https://github.com/cncf/foundation/blob/master/code-of-conduct.md">CNCF Code of Conduct</a> which states that:</p>
             <p>As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, to post feature requests, to update documentation, to submit pull requests or patches, and other activities.</p>
             <p>We are committed to participating in this project as a harassment-free experience for everyone, regardless of the level of experience, gender, gender identity, and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.</p>


### PR DESCRIPTION
**Description**

This PR fixes #6627 

**Notes for Reviewers**
This is a simple formatting fix that adds a single heading line to improve consistency across the handbook. The change follows the same pattern established in other handbook sections.


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 