### PR TITLE
Fixed the positioning and click area of cheveron

### DIFF
--- a/src/components/SistentNavigation/index.js
+++ b/src/components/SistentNavigation/index.js
@@ -3,6 +3,7 @@ import { HiOutlineChevronLeft } from "@react-icons/all-files/hi/HiOutlineChevron
 import { Link } from "gatsby";
 import { IoMdClose } from "@react-icons/all-files/io/IoMdClose";
 import { IoIosArrowDropdownCircle } from "@react-icons/all-files/io/IoIosArrowDropdownCircle";
+import { IoIosArrowForward } from "@react-icons/all-files/io/IoIosArrowForward";
 import { componentsData } from "../../sections/Projects/Sistent/components/content";
 
 import TOCWrapper from "./toc.style";
@@ -35,14 +36,14 @@ const TOC = () => {
         </Link>
         <div className="toc-toggle-btn">
           {expand ? (
-            <IoMdClose
+            <IoIosArrowDown
               className="toc-menu-icon"
               onClick={function () {
                 setExpand(!expand);
               }}
             />
           ) : (
-            <IoIosArrowDropdownCircle
+            <IoIosArrowForward
               className="toc-menu-icon"
               onClick={function () {
                 setExpand(!expand);
@@ -69,7 +70,10 @@ const TOC = () => {
                 onClick={() => setExpandIdentity((prev) => !prev)}
               >
                 Identity
-                {expandIdenity ? <IoIosArrowUp /> : <IoIosArrowDown />}
+                {expandIdenity ?
+                  <IoIosArrowDown style={{ zIndex: 2 }} /> :
+                  <IoIosArrowForward style={{ zIndex: 2 }} />
+                }
               </li>
               {expandIdenity && (
                 <div className="identity-sublinks">
@@ -129,7 +133,10 @@ const TOC = () => {
                 onClick={() => setExpandComponent((prev) => !prev)}
               >
                 Components
-                {expandComponent ? <IoIosArrowUp /> : <IoIosArrowDown />}
+                {expandComponent ?
+                  <IoIosArrowDown style={{ zIndex: 2 }} /> :
+                  <IoIosArrowForward style={{ zIndex: 2 }} />
+                }
               </li>
               {expandComponent && (
                 <div className="components-sublinks">

--- a/src/components/SistentNavigation/toc.style.js
+++ b/src/components/SistentNavigation/toc.style.js
@@ -104,6 +104,7 @@ const TOCWrapper = styled.div`
     width: auto;
     .toc-toggle-btn {
       display: inline-block;
+      z-index: 2;
     }
     .go-back {
       margin-left: 0;


### PR DESCRIPTION
**Description**

This PR fixes #6637

**Notes for Reviewers**
<img width="753" height="980" alt="image" src="https://github.com/user-attachments/assets/a1515feb-57e0-4534-baf4-2c5c11813c0f" />
<img width="742" height="974" alt="image" src="https://github.com/user-attachments/assets/2a8ec491-0e85-44be-8451-4e6177ab5f27" />

Fixed the arrow to expand the content of table, initially pointing right and when expanded points downwards

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
