### PR TITLE
Updated the responsive banner to work correctly with inline styles

### DIFF
--- a/src/collections/service-mesh-labs/meshery_performance_testing/index.mdx
+++ b/src/collections/service-mesh-labs/meshery_performance_testing/index.mdx
@@ -2,8 +2,12 @@
 title: "Running Performance Tests"
 ---
 
-<div style="display:flex; justify-content:center; padding:2rem; width:100%; background-color:black;">
-Sign into the&nbsp;<a href="https://playground.meshery.io">Meshery Playground</a>&nbsp;(free account) to continue your lab.
+<div style="display: flex; justify-content: center; align-items: center; flex-wrap: wrap; padding: 2rem 1rem; width: 100%; background-color: black; color: white; font-size: 1rem; text-align: center;">
+  Sign into the&nbsp;
+  <a href="https://playground.meshery.io" target="_blank" rel="noopener noreferrer" style="color: #00bfff; text-decoration: underline; margin: 0 0.3rem; white-space: nowrap;">
+    Meshery Playground
+  </a>
+  &nbsp;(free account) to continue your lab.
 </div>
 
 

--- a/src/collections/service-mesh-labs/traffic_splitting_with_meshery/index.mdx
+++ b/src/collections/service-mesh-labs/traffic_splitting_with_meshery/index.mdx
@@ -2,7 +2,10 @@
 title: "Traffic Splitting with Meshery"
 ---
 
-<div style="display:flex; justify-content:center; padding:2rem; width:100%; background-color:black;">
-Sign into the&nbsp;<a href="https://playground.meshery.io">Meshery Playground</a>&nbsp;(free account) to continue your lab.
+<div style="display: flex; justify-content: center; align-items: center; flex-wrap: wrap; padding: 2rem 1rem; width: 100%; background-color: black; color: white; font-size: 1rem; text-align: center;">
+  Sign into the&nbsp;
+  <a href="https://playground.meshery.io" target="_blank" rel="noopener noreferrer" style="color: #00bfff; text-decoration: underline; margin: 0 0.3rem; white-space: nowrap;">
+    Meshery Playground
+  </a>
+  &nbsp;(free account) to continue your lab.
 </div>
-

--- a/src/collections/service-mesh-labs/working_with_meshery_and_istio/index.mdx
+++ b/src/collections/service-mesh-labs/working_with_meshery_and_istio/index.mdx
@@ -2,7 +2,11 @@
 title: "Working with Meshery and Istio"
 ---
 
-<div style="display:flex; justify-content:center; padding:2rem; width:100%; background-color:black;">
-Sign into the&nbsp;<a href="https://playground.meshery.io">Meshery Playground</a>&nbsp;(free account) to continue your lab.
+<div style="display: flex; justify-content: center; align-items: center; flex-wrap: wrap; padding: 2rem 1rem; width: 100%; background-color: black; color: white; font-size: 1rem; text-align: center;">
+  Sign into the&nbsp;
+  <a href="https://playground.meshery.io" target="_blank" rel="noopener noreferrer" style="color: #00bfff; text-decoration: underline; margin: 0 0.3rem; white-space: nowrap;">
+    Meshery Playground
+  </a>
+  &nbsp;(free account) to continue your lab.
 </div>
 

--- a/src/collections/service-mesh-labs/working_with_meshery_and_kuma/index.mdx
+++ b/src/collections/service-mesh-labs/working_with_meshery_and_kuma/index.mdx
@@ -2,7 +2,11 @@
 title: "Working with Meshery and Kuma"
 ---
 
-<div style="display:flex; justify-content:center; padding:2rem; width:100%; background-color:black;">
-Sign into the&nbsp;<a href="https://playground.meshery.io">Meshery Playground</a>&nbsp;(free account) to continue your lab.
+<div style="display: flex; justify-content: center; align-items: center; flex-wrap: wrap; padding: 2rem 1rem; width: 100%; background-color: black; color: white; font-size: 1rem; text-align: center;">
+  Sign into the&nbsp;
+  <a href="https://playground.meshery.io" target="_blank" rel="noopener noreferrer" style="color: #00bfff; text-decoration: underline; margin: 0 0.3rem; white-space: nowrap;">
+    Meshery Playground
+  </a>
+  &nbsp;(free account) to continue your lab.
 </div>
 

--- a/src/collections/service-mesh-labs/working_with_meshery_and_linkerd/index.mdx
+++ b/src/collections/service-mesh-labs/working_with_meshery_and_linkerd/index.mdx
@@ -2,7 +2,11 @@
 title: "Working with Meshery and Linkerd"
 ---
 
-<div style="display:flex; justify-content:center; padding:2rem; width:100%; background-color:black;">
-Sign into the&nbsp;<a href="https://playground.meshery.io">Meshery Playground</a>&nbsp;(free account) to continue your lab.
+<div style="display: flex; justify-content: center; align-items: center; flex-wrap: wrap; padding: 2rem 1rem; width: 100%; background-color: black; color: white; font-size: 1rem; text-align: center;">
+  Sign into the&nbsp;
+  <a href="https://playground.meshery.io" target="_blank" rel="noopener noreferrer" style="color: #00bfff; text-decoration: underline; margin: 0 0.3rem; white-space: nowrap;">
+    Meshery Playground
+  </a>
+  &nbsp;(free account) to continue your lab.
 </div>
 

--- a/src/collections/service-mesh-labs/working_with_meshery_and_nsm/index.mdx
+++ b/src/collections/service-mesh-labs/working_with_meshery_and_nsm/index.mdx
@@ -2,6 +2,10 @@
 title: "Working with Meshery and NSM"
 ---
 
-<div style="display:flex; justify-content:center; padding:2rem; width:100%; background-color:black;">
-Sign into the&nbsp;<a href="https://playground.meshery.io">Meshery Playground</a>&nbsp;(free account) to continue your lab.
+<div style="display: flex; justify-content: center; align-items: center; flex-wrap: wrap; padding: 2rem 1rem; width: 100%; background-color: black; color: white; font-size: 1rem; text-align: center;">
+  Sign into the&nbsp;
+  <a href="https://playground.meshery.io" target="_blank" rel="noopener noreferrer" style="color: #00bfff; text-decoration: underline; margin: 0 0.3rem; white-space: nowrap;">
+    Meshery Playground
+  </a>
+  &nbsp;(free account) to continue your lab.
 </div>

--- a/src/collections/service-mesh-labs/working_with_meshery_and_open_service_mesh/index.mdx
+++ b/src/collections/service-mesh-labs/working_with_meshery_and_open_service_mesh/index.mdx
@@ -2,6 +2,10 @@
 title: "Working with Meshery and Open Service Mesh"
 ---
 
-<div style="display:flex; justify-content:center; padding:2rem; width:100%; background-color:black;">
-Sign into the&nbsp;<a href="https://playground.meshery.io">Meshery Playground</a>&nbsp;(free account) to continue your lab.
+<div style="display: flex; justify-content: center; align-items: center; flex-wrap: wrap; padding: 2rem 1rem; width: 100%; background-color: black; color: white; font-size: 1rem; text-align: center;">
+  Sign into the&nbsp;
+  <a href="https://playground.meshery.io" target="_blank" rel="noopener noreferrer" style="color: #00bfff; text-decoration: underline; margin: 0 0.3rem; white-space: nowrap;">
+    Meshery Playground
+  </a>
+  &nbsp;(free account) to continue your lab.
 </div>

--- a/src/collections/service-mesh-labs/working_with_meshery_and_traefik/index.mdx
+++ b/src/collections/service-mesh-labs/working_with_meshery_and_traefik/index.mdx
@@ -2,6 +2,10 @@
 title: "Working with Meshery and Traefik"
 ---
 
-<div style="display:flex; justify-content:center; padding:2rem; width:100%; background-color:black;">
-Sign into the&nbsp;<a href="https://playground.meshery.io">Meshery Playground</a>&nbsp;(free account) to continue your lab.
+<div style="display: flex; justify-content: center; align-items: center; flex-wrap: wrap; padding: 2rem 1rem; width: 100%; background-color: black; color: white; font-size: 1rem; text-align: center;">
+  Sign into the&nbsp;
+  <a href="https://playground.meshery.io" target="_blank" rel="noopener noreferrer" style="color: #00bfff; text-decoration: underline; margin: 0 0.3rem; white-space: nowrap;">
+    Meshery Playground
+  </a>
+  &nbsp;(free account) to continue your lab.
 </div>


### PR DESCRIPTION
 
### **Fix: Description of the Fix**

**Description**

This PR fixes [5640](https://github.com/layer5io/layer5/issues/5640) by updating the responsive banner to work correctly with inline styles.
Reproduce issue: https://layer5.io/learn/service-mesh-labs/working-with-meshery-and-istio scale this doen

**Notes for Reviewers**

* Adjusted the `<div>` with inline styles to ensure responsiveness on both small and large screens.
* Used `flex-wrap`, `white-space: nowrap`, and padding for better layout behavior.
* No additional dependencies or external CSS used — all inline for maximum compatibility.

 

* [x] Yes, I signed my commits.

---

###  Checklist Before Review

* [x] Build and tests pass.
* [x] Follows Layer5 contribution conventions.
* [x] Commit(s) are signed.

---