### PR TITLE
Fix: Github Link in Contributing Section in handbook

### DIFF
--- a/src/sections/Community/Handbook/contributing.js
+++ b/src/sections/Community/Handbook/contributing.js
@@ -70,9 +70,9 @@ const contributingGuide = () => {
                   To do this, you'll need to add a remote. An example of the
                   command is given below:
                   <div className="codes">
-                    <Code codeString="git remote add upstream https://github.com/layer5io/meshery.git " />
+                    <Code codeString="git remote add upstream https://github.com/layer5io/layer5.git " />
                   </div>
-                  Here “meshery" is used as the example repo. Be sure to
+                  Here “layer5" is used as the example repo. Be sure to
                   reference the actual repo you are contributing to.
                 </span>
               </li>


### PR DESCRIPTION
**Description**

This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
