### PR TITLE
Fix: image overflow in announcement cards (mobile view)

### DIFF
--- a/src/sections/Blog/Blog-list/blogList.style.js
+++ b/src/sections/Blog/Blog-list/blogList.style.js
@@ -27,10 +27,9 @@ export const BlogPageWrapper = styled.div`
 		width: 25%;
 		img{
 			padding: 0px;
-			margin-top: 0.5rem;
 			width: 100%;
 			height: 100%;
-			margin-left: 0;
+			margin-left: 0.5rem;
 		}
 	}
 
@@ -69,23 +68,27 @@ export const BlogPageWrapper = styled.div`
 	@media screen and (max-width:992px){
 		.post-block{
 			height: 18rem;
-			width: auto;
-			flex-direction: column;
-			align-items: stretch;
-		}
-		.post-thumb-block{
 			width: 100%;
-			height: 16rem;
-			img{
-				width: 100%;
-				height: 100%;
-				margin-top: 0.5rem;
-				margin-left: 0;
-				object-fit: cover;
-				border-radius: 0.5rem;
-				display: block;
-			}
 		}
+			.post-block{
+				height: 12rem;
+				width: auto;
+			}
+			.post-thumb-block{
+				width: 100%;
+				height: 8rem;
+				display: flex;
+				align-items: center;
+				img{
+					width: 100%;
+					height: 100%;
+					margin-top: 0;
+					margin-left: 0;
+					object-fit: cover;
+					border-radius: 0.5rem;
+					display: block;
+				}
+			}
 	}
 
 	@media screen and (max-width:576px){

--- a/src/sections/Blog/Blog-list/blogList.style.js
+++ b/src/sections/Blog/Blog-list/blogList.style.js
@@ -68,14 +68,22 @@ export const BlogPageWrapper = styled.div`
 
 	@media screen and (max-width:992px){
 		.post-block{
-			height: 10rem;
+			height: 18rem;
 			width: auto;
+			flex-direction: column;
+			align-items: stretch;
 		}
 		.post-thumb-block{
-			height: 15rem;
-	
+			width: 100%;
+			height: 16rem;
 			img{
-				max-height:15rem;
+				width: 100%;
+				height: 100%;
+				margin-top: 0.5rem;
+				margin-left: 0;
+				object-fit: cover;
+				border-radius: 0.5rem;
+				display: block;
 			}
 		}
 	}

--- a/src/sections/Blog/Blog-list/blogList.style.js
+++ b/src/sections/Blog/Blog-list/blogList.style.js
@@ -27,9 +27,10 @@ export const BlogPageWrapper = styled.div`
 		width: 25%;
 		img{
 			padding: 0px;
-			margin-left: 0.5rem;
+			margin-top: 0.5rem;
 			width: 100%;
 			height: 100%;
+			margin-left: 0;
 		}
 	}
 
@@ -81,7 +82,22 @@ export const BlogPageWrapper = styled.div`
 
 	@media screen and (max-width:576px){
 		.post-block{
-			height: 9rem;
+			height: 18rem;
+			flex-direction: column;
+			align-items: stretch;
+		}
+		.post-thumb-block{
+			width: 100%;
+			height: 12rem;
+			img{
+				width: 100%;
+				height: 100%;
+				margin-top: 0.5rem;
+				margin-left: 0;
+				object-fit: cover;
+				border-radius: 0.5rem;
+				display: block;
+			}
 		}
 		.blog-list-wrapper{
 			margin: 1.5rem auto 5rem;
@@ -91,6 +107,7 @@ export const BlogPageWrapper = styled.div`
 		}
 		.post-content-block{
 			height: fit-content;
+			width: 100%;
 		}
 		.tooltip-search{
 			display: block;


### PR DESCRIPTION
**Description**

This PR fixes #6768
This PR fixes the issue where images in the Announcements page (mobile view) were not contained within their respective category cards, causing them to overflow and overlap adjacent content.

**Notes for Reviewers**
Please verify the fix on different screen sizes (especially smaller mobile widths). The change ensures images inside announcement cards are contained properly without breaking layout.

<img width="586" height="757" alt="image" src="https://github.com/user-attachments/assets/a0dba9b8-08f4-409d-8a29-6a078da1032d" />


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
