### PR TITLE
update gatsby-plugin-mdx to version 5.15.0 in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "gatsby-plugin-image": "^3.11.0",
         "gatsby-plugin-loadable-components-ssr": "^4.3.2",
         "gatsby-plugin-manifest": "^5.15.0",
-        "gatsby-plugin-mdx": "^5.0.0",
+        "gatsby-plugin-mdx": "^5.15.0",
         "gatsby-plugin-meta-redirect": "github:layer5labs/gatsby-plugin-meta-redirect",
         "gatsby-plugin-netlify": "^5.1.1",
         "gatsby-plugin-preload-fonts": "^4.11.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "gatsby-plugin-image": "^3.11.0",
     "gatsby-plugin-loadable-components-ssr": "^4.3.2",
     "gatsby-plugin-manifest": "^5.15.0",
-    "gatsby-plugin-mdx": "^5.0.0",
+    "gatsby-plugin-mdx": "^5.15.0",
     "gatsby-plugin-meta-redirect": "github:layer5labs/gatsby-plugin-meta-redirect",
     "gatsby-plugin-netlify": "^5.1.1",
     "gatsby-plugin-preload-fonts": "^4.11.0",


### PR DESCRIPTION
Signed-off-by: Lee Calcote <lee.calcote@layer5.io>
