### PR TITLE
Fix: Sticky Behavior for currency Dropdown #6951

### DIFF
--- a/src/sections/Pricing/index.js
+++ b/src/sections/Pricing/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import PricingWrapper from "./pricing.style";
 import Comparison from "./comparison";
 import FAQ from "../General/Faq";
@@ -42,58 +42,101 @@ const getCustomToggleButtonStyle = (isActive, baseStyle) => ({
 });
 
 export const CurrencySelect = ({ currency, setCurrency }) => {
+  const [open, setOpen] = useState(false);
+
+  // Lock both <html> and <body> while the dropdown is open
+  useEffect(() => {
+    if (!open) return;
+    const prevBody = document.body.style.overflow;
+    const prevHtml = document.documentElement.style.overflow;
+    document.body.style.overflow = "hidden";
+    document.documentElement.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prevBody;
+      document.documentElement.style.overflow = prevHtml;
+    };
+  }, [open]);
+
+  const handleClose = () => setOpen(false);
+  const handleOpen = () => setOpen(true);
+
   return (
-    <FormControl
-      variant="outlined"
-      size="small"
-      sx={{
-        minWidth: 150,
-        "& .MuiInputLabel-root": {
-          color: "white",
-          "&.Mui-focused": { color: "#00B39F" },
-        },
-        "& .MuiOutlinedInput-root": {
-          color: "white",
-          "& .MuiSelect-icon": { color: "white" },
-          "& .MuiOutlinedInput-notchedOutline": { borderColor: "white" },
-          "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
-            borderColor: "#00B39F",
+    <>
+      {/* Transparent overlay: blocks the page & closes on outside click */}
+      {open && (
+        <Box
+          onMouseDown={handleClose}
+          onTouchStart={handleClose}
+          sx={{
+            position: "fixed",
+            inset: 0,
+            zIndex: 1299, // below MUI Menu (paper is set to 1301)
+          }}
+        />
+      )}
+
+      <FormControl
+        variant="outlined"
+        size="small"
+        sx={{
+          minWidth: 150,
+          "& .MuiInputLabel-root": {
+            color: "white",
+            "&.Mui-focused": { color: "#00B39F" },
           },
-        },
-        "&:hover": {
-          "& .MuiInputLabel-root": { color: "#00B39F" },
-          "& .MuiOutlinedInput-root .MuiOutlinedInput-notchedOutline": {
-            borderColor: "#00B39F",
-            borderWidth: "2px",
+          "& .MuiOutlinedInput-root": {
+            color: "white",
+            "& .MuiSelect-icon": { color: "white" },
+            "& .MuiOutlinedInput-notchedOutline": { borderColor: "white" },
+            "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+              borderColor: "#00B39F",
+            },
           },
-        },
-      }}
-    >
-      <InputLabel id="currency-selector-label">Currency</InputLabel>
-      <Select
-        labelId="currency-selector-label"
-        value={currency}
-        onChange={(e) => {
-          setCurrency(e.target.value);
+          "&:hover": {
+            "& .MuiInputLabel-root": { color: "#00B39F" },
+            "& .MuiOutlinedInput-root .MuiOutlinedInput-notchedOutline": {
+              borderColor: "#00B39F",
+              borderWidth: "2px",
+            },
+          },
         }}
-        label="Currency"
-        renderValue={(value) => (
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1, color: "#fff" }}>
-            <Typography variant="body1">{Currencies[value]?.symbol}</Typography>
-            <Typography variant="body2">{Currencies[value]?.name}</Typography>
-          </Box>
-        )}
       >
-        {Object.entries(Currencies).map(([code, { symbol, name }]) => (
-          <MenuItem key={code} value={code}>
-            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-              <Typography variant="body1">{symbol}</Typography>
-              <Typography variant="body2">{name}</Typography>
+        <InputLabel id="currency-selector-label">Currency</InputLabel>
+        <Select
+          labelId="currency-selector-label"
+          value={currency}
+          label="Currency"
+          open={open}
+          onOpen={handleOpen}
+          onClose={handleClose}
+          onChange={(e) => {
+            setCurrency(e.target.value);
+            handleClose();
+          }}
+          MenuProps={{
+            disableScrollLock: false,
+            keepMounted: true,
+            PaperProps: { sx: { zIndex: 1301 } }, // ensure menu is above overlay
+            ModalProps: { keepMounted: true, disableScrollLock: false },
+          }}
+          renderValue={(value) => (
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1, color: "#fff" }}>
+              <Typography variant="body1">{Currencies[value]?.symbol}</Typography>
+              <Typography variant="body2">{Currencies[value]?.name}</Typography>
             </Box>
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
+          )}
+        >
+          {Object.entries(Currencies).map(([code, { symbol, name }]) => (
+            <MenuItem key={code} value={code}>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                <Typography variant="body1">{symbol}</Typography>
+                <Typography variant="body2">{name}</Typography>
+              </Box>
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </>
   );
 };
 


### PR DESCRIPTION
**Description**

On this [Page](https://layer5.io/pricing) there is the dropdown while click to currency 
* Fixed issue where the currency dropdown stayed open while scrolling and blocked the rest of the page
* Now allows users to interact with the page without needing to close the dropdown manually
<img width="419" height="556" alt="Screenshot from 2025-09-28 20-48-34" src="https://github.com/user-attachments/assets/a428d504-0a9a-4f57-91c3-361b394d43bf" />

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
