### PR TITLE
Replace react-loadable with @loadable/component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,6 @@
         "react-dom": "^18.2.0",
         "react-honeycomb": "^0.1.3",
         "react-intersection-observer": "^9.5.2",
-        "react-loadable": "^5.5.0",
         "react-modal": "^3.16.1",
         "react-player": "^2.12.0",
         "react-scroll": "^1.9.0",
@@ -24047,18 +24046,6 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "license": "MIT"
-    },
-    "node_modules/react-loadable": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/react-loadable/-/react-loadable-5.5.0.tgz",
-      "integrity": "sha512-C8Aui0ZpMd4KokxRdVAm2bQtI03k2RMRNzOB+IipV3yxFTSVICv7WoUr5L9ALB5BmKO1iHgZtWM8EvYG83otdg==",
-      "license": "MIT",
-      "dependencies": {
-        "prop-types": "^15.5.0"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
     },
     "node_modules/react-modal": {
       "version": "3.16.3",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "react-dom": "^18.2.0",
     "react-honeycomb": "^0.1.3",
     "react-intersection-observer": "^9.5.2",
-    "react-loadable": "^5.5.0",
     "react-modal": "^3.16.1",
     "react-player": "^2.12.0",
     "react-scroll": "^1.9.0",

--- a/src/pages/community/calendar.js
+++ b/src/pages/community/calendar.js
@@ -2,7 +2,7 @@ import React from "react";
 import SEO from "../../components/seo";
 
 
-import Loadable from "react-loadable";
+import Loadable from "@loadable/component";
 import Loader from "./Loader.style";
 import LoadingIcon from "../../assets/images/LoadingIcon";
 import FullCalendar from "@fullcalendar/react";


### PR DESCRIPTION
### Description

Updated the project dependencies and code to remove the deprecated `react-loadable` package and use `@loadable/component` instead. This change ensures that the project uses a maintained library for dynamic imports and code splitting.

**Changes Made**

* Removed `react-loadable` from `package.json`
* Replaced all instances of `react-loadable` in the codebase with `@loadable/component`

**Related Issue**
Fixes #6868 
