### PR TITLE
[newcomers-form] fix: accept Google Drive links in profile picture validation

### DIFF
--- a/src/sections/Community/Web-based-from/index.js
+++ b/src/sections/Community/Web-based-from/index.js
@@ -29,13 +29,11 @@ const validatePictureUrl = (value) => {
         new URL(value);
 
         const isGoogleDrive = value.includes("drive.google.com");
-        if (isGoogleDrive) {
-          const isFileLink = value.includes("/file/d/");
-          const isViewLink = value.includes("/view");
-          const isDownloadLink = value.includes("/uc?");
+        const validGoogleDrivePattern = /drive\.google\.com\/file\/d\/.+\/(view|uc\?)/;
 
-          if (!isFileLink || (!isViewLink && !isDownloadLink)) {
-            error = "Please provide a direct Google Drive file link.";
+        if (isGoogleDrive) {
+          if (!validGoogleDrivePattern.test(value)) {
+            error = "Please provide a direct Google Drive file link. Right-click the file in Google Drive and select 'Get link' to get a shareable link that includes '/file/d/' in the URL.";
           }
         } else {
           const allowedImageExtensions = ["jpg", "jpeg", "png", "webp", "svg", "gif"];
@@ -231,7 +229,7 @@ const WebBasedForm = () => {
             setRole("User");
           }}
           >
-            I'm here as a User and Contibutor
+            I'm here as a User and Contributor
           </div>
           <div className={role === "Bystander" ? "option active" : "option"} onClick={() => {
             setRole("Bystander");
@@ -242,7 +240,7 @@ const WebBasedForm = () => {
           <br /><br />
           <div className="btn-wrapper">
             <button onClick={laststep} className="btn-prev"><span className="back">&larr;</span> Previous Step</button>
-            <Button onClick={() => setStepNumber(2)}$secondary type="submit" className="btn-next" title="Next Step" />
+            <Button onClick={() => setStepNumber(2)} $secondary type="submit" className="btn-next" title="Next Step" />
           </div>
         </div>
 


### PR DESCRIPTION
**Description**

This PR fixes #6986

Fixed the profile picture validation to accept Google Drive links. Previously, when users tried to paste Google Drive links as profile pictures, the form showed the error "URL must point to an image file (jpg, jpeg, png, svg, webp or gif)".

**Notes for Reviewers**
- This follows the expected behavior of accepting Google Drive links that point to image files
- No breaking changes to existing functionality
- Maintains file extension validation for non-Google Drive URLs 

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
