### PR TITLE
Fix: Removed extra spacing below header on Mentorship Programs page

### DIFF
--- a/src/sections/Community/Handbook/mentorships.js
+++ b/src/sections/Community/Handbook/mentorships.js
@@ -10,10 +10,10 @@ import TocPagination from "../../../components/handbook-navigation/TocPagination
 const ConductWrapper = styled.div`
 
     padding: 0 5rem 3rem 20rem;
-    margin-top: -48rem; 
+    margin-top: -52rem; 
 
     @media screen and (min-width: 768px) and (max-height: 1145px) {
-       margin-top : -50rem;
+       margin-top : -55rem;
 
   }
 


### PR DESCRIPTION
**Description**

This PR fixes #6975 

Removed excess vertical space below the header on the Mentorship Programs page (desktop view) for better visual balance and alignment.

**Before:**
<img width="1280" height="686" alt="Screenshot from 2025-10-02 21-57-16" src="https://github.com/user-attachments/assets/db89a1dc-0bb5-4147-bd8d-91529882f680" />

**After:**
<img width="1273" height="619" alt="Screenshot from 2025-10-21 00-05-17" src="https://github.com/user-attachments/assets/c2973f26-d78b-4afc-9190-ed11dbbb93bc" />


**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
