### PR TITLE
Fix LCP request discovery by optimizing initial blog image loading

### DIFF
--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -6,7 +6,7 @@ import Image from "../image";
 import { CardWrapper } from "./Card.style";
 import { useStyledDarkMode } from "../../theme/app/useStyledDarkMode";
 
-const Card = ({ frontmatter, fields }) => {
+const Card = ({ frontmatter, fields, loading = "lazy", fetchpriority = "auto" }) => {
 
   const { isDark } = useStyledDarkMode();
 
@@ -18,6 +18,8 @@ const Card = ({ frontmatter, fields }) => {
             {...((isDark && frontmatter.darkthumbnail && frontmatter.darkthumbnail.publicURL !== frontmatter.thumbnail.publicURL)
               ? frontmatter.darkthumbnail : frontmatter.thumbnail)}
             imgStyle={{ objectFit: "contain" }}
+            loading={loading}
+            fetchpriority={fetchpriority}
             alt={frontmatter.title}
           />
         </div>

--- a/src/sections/Blog/Blog-grid/index.js
+++ b/src/sections/Blog/Blog-grid/index.js
@@ -61,9 +61,9 @@ const BlogGrid = ({
                     </Col>
                   )}
 
-                  {searchedPosts.length > 0 && searchedPosts.map(({ id, frontmatter, fields }) => (
+                  {searchedPosts.length > 0 && searchedPosts.map(({ id, frontmatter, fields }, index) => (
                     <Col key={id} $xs={12} $sm={6}>
-                      <Card frontmatter={frontmatter} fields={fields} />
+                      <Card frontmatter={frontmatter} fields={fields} loading={index === 0 ? "eager" : "lazy"} fetchpriority={index === 0 ? "high" : "auto"} />
                     </Col>
                   ))}
                   <Col>

--- a/src/sections/Blog/Blog-list/index.js
+++ b/src/sections/Blog/Blog-list/index.js
@@ -74,9 +74,9 @@ const BlogList = ({
                 }}
                 className="blog-lists">
                   {searchedPosts.length > 0 &&
-                    searchedPosts?.map(({ id, frontmatter, fields }) => (
+                    searchedPosts?.map(({ id, frontmatter, fields }, index) => (
                       <Col $xs={12} key={id}>
-                        <Card frontmatter={frontmatter} fields={fields} />
+                        <Card frontmatter={frontmatter} fields={fields} loading={index === 0 ? "eager" : "lazy"} fetchpriority={index === 0 ? "high" : "auto"} />
                       </Col>
                     ))}
                   <Col>


### PR DESCRIPTION
**Description**

This PR addresses the "LCP request discovery" performance issue flagged in #6930 regarding the blog page. I updated the Card component to accept dynamic loading properties and modified the blog list and grid views to explicitly set loading="eager" and fetchpriority="high" for the first post's image. This ensures the Largest Contentful Paint element is prioritized and not lazy-loaded, significantly improving the page's initial render metrics while maintaining lazy loading for subsequent images.

This PR fixes #6930

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
