### PR TITLE
Remove sharp plugins from gatsby-config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -474,8 +474,6 @@ module.exports = {
         },
       },
     },
-    "gatsby-plugin-sharp",
-    "gatsby-transformer-sharp",
     {
       resolve: "gatsby-source-filesystem",
       options: {


### PR DESCRIPTION
Removed gatsby-plugin-sharp and gatsby-transformer-sharp from plugins.




**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
