### PR TITLE
gatsby-config: svgo options - keep ViewBox, removeDimensions

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -79,6 +79,7 @@ module.exports = {
         svgoConfig: {
           plugins: [
             "prefixIds",
+            "removeDimensions",
             {
               name: "preset-default",
               params: {
@@ -86,6 +87,7 @@ module.exports = {
                   // or disable plugins
                   inlineStyles: false,
                   cleanupIds: false,
+                  removeViewBox: false,
                 },
               },
             },


### PR DESCRIPTION
Signed-off-by: Lee Calcote <lee.calcote@layer5.io>
