### PR TITLE
fix: enhance GraphQL schema

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -771,6 +771,8 @@ exports.createSchemaCustomization = ({ actions }) => {
        community_manager: String,
        docURL: String,
        permalink: String,
+       slug: String,
+       redirect_from: [String]
      }
    `;
   createTypes(typeDefs);


### PR DESCRIPTION
Signed-off-by: Lee Calcote <lee.calcote@layer5.io>


Still have this build warning:

```
success source and transform nodes - 25.094s
info Writing GraphQL type definitions to
/Users/l/code/layer5/.cache/schema.gql
success building schema - 2.173s
 warning  no slug found in frontmatter or fields
 success  created 71 redirects
```