### PR TITLE
Change theme logic to prioritize dark mode

### DIFF
--- a/onRenderBody.js
+++ b/onRenderBody.js
@@ -7,23 +7,31 @@ const themes = { light: lighttheme, dark: darktheme };
 const MagicScriptTag = (props) => {
   const codeToRunOnClient = `
       (function() {
+          // 1. Keeps SYSTEM as the priority preference
           const themeFromLocalStorage = localStorage.getItem('${DarkThemeKey}') || '${ThemeSetting.SYSTEM}';
-          const systemDarkModeSetting = () => window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
-          const isDarkModeActive = () => {
-              return !!systemDarkModeSetting()?.matches;
+
+          // 2. We change the check to look for LIGHT mode explicitly
+          const systemLightModeSetting = () => window.matchMedia ? window.matchMedia('(prefers-color-scheme: light)') : null;
+          
+          const isLightModeActive = () => {
+              return !!systemLightModeSetting()?.matches;
           };
+
           let colorMode;
           switch (themeFromLocalStorage) {
               case '${ThemeSetting.SYSTEM}':
-                colorMode = isDarkModeActive() ? '${ThemeSetting.DARK}' : '${ThemeSetting.LIGHT}'
+                // LOGIC CHANGE: If Light is active -> Light. Otherwise (Dark, No Preference, or Error) -> Dark.
+                colorMode = isLightModeActive() ? '${ThemeSetting.LIGHT}' : '${ThemeSetting.DARK}'
                 break
               case '${ThemeSetting.DARK}':
               case '${ThemeSetting.LIGHT}':
                 colorMode = themeFromLocalStorage
                 break
               default:
-                  colorMode = '${ThemeSetting.LIGHT}'
+                  // 3. Fallback to DARK in case of error
+                  colorMode = '${ThemeSetting.DARK}'
             }
+
           const root = document.documentElement;
           const iterate = (obj) => {
             if (!obj) return;


### PR DESCRIPTION
Updated color mode logic to prioritize light mode when active.

**Description**

1. Honor System: We keep the default setting as SYSTEM.
1. Dark as Default: We invert the check. Instead of asking "Is it Dark?", we ask "Is it Light?". If the system explicitly asks for Light, we give them Light. For everything else (Dark preference, No preference, or unsupported browsers), we default to Dark.
1. Dark Fallback: We update the default error case.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
