### PR TITLE
Fix Button Color on brand page

### DIFF
--- a/src/sections/Company/Brand/Brand-components/social-backgrounds.js
+++ b/src/sections/Company/Brand/Brand-components/social-backgrounds.js
@@ -18,7 +18,7 @@ const SocialBackgrounds = () => {
         </Col>
         <Col xs={12} sm={6} className="download-button">
           <a href="/brand/layer5-social-backgrounds.zip">
-            <Button primary title="Download Social Backgrounds">
+            <Button $primary title="Download Social Backgrounds">
               <FiDownloadCloud size={21} className="icon-left" />
             </Button>
           </a>


### PR DESCRIPTION
**Description**

- The "Download Social Backgrounds" button on the [Brand page](https://layer5.io/company/brand#social-backgrounds) was using a different color than other buttons.

- Updated it to the Saffron Yellow to maintain consistent styling.

**Before:**
<img width="964" height="353" alt="Screenshot from 2025-12-11 13-53-08" src="https://github.com/user-attachments/assets/e08b81ac-5882-4ea0-bb4a-e7795b7fa047" />

**After:**
<img width="955" height="567" alt="image" src="https://github.com/user-attachments/assets/3780de6f-ab7f-4698-affe-c3bb79996588" />



**Notes for Reviewers**
view the preview [here](https://693ad8cbbe4ac93a386332d0--layer5.netlify.app/company/brand#social-backgrounds)

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
