### PR TITLE
Fixed broken links in learning-paths

### DIFF
--- a/src/sections/Learn-Layer5/Course-Overview/index.js
+++ b/src/sections/Learn-Layer5/Course-Overview/index.js
@@ -63,7 +63,7 @@ const CourseOverview = ({ course, chapters, serviceMeshesList, children }) => {
   return (
     <CourseOverviewWrapper>
       <div className="course-back-btn">
-        <Link to={"/learn/learning-paths/${course.fields.learnpath}"}>
+        <Link to={`/learn/learning-paths/${course.fields.learnpath}`}>
           <IoChevronBackOutline /> <h4>Learning Paths/Courses</h4>
         </Link>
       </div>
@@ -87,7 +87,7 @@ const CourseOverview = ({ course, chapters, serviceMeshesList, children }) => {
           </div>
           <Button
             title={hasBookmark ? "Start Again" : "Get Started"}
-            $url={getChapterTitle(course.frontmatter.toc[0], chapters) ? "/${getChapterTitle(course.frontmatter.toc[0], chapters).fields.slug}" : "#"}
+            $url={getChapterTitle(course.frontmatter.toc[0], chapters) ? `/${getChapterTitle(course.frontmatter.toc[0], chapters).fields.slug}` : "#"}
           />
           {hasBookmark && (
             <Button

--- a/src/sections/Learn-Layer5/index.js
+++ b/src/sections/Learn-Layer5/index.js
@@ -104,7 +104,7 @@ const LearnPathsPage = () => {
         <Row className="learning-path-cards">
           {data.learnPaths.nodes.map((tutorial) => (
             <Col $sm={6} key={tutorial.id} style={{ marginTop: "2rem" }}>
-              <CardComponent tutorial={tutorial} path={tutorial.fields.learnpath} courseCount={getCoursesOfaLearningPath(tutorial.fields.learnpath).length} />
+              <CardComponent tutorial={tutorial} path={`/${tutorial.fields.slug}`} courseCount={getCoursesOfaLearningPath(tutorial.fields.learnpath).length} />
             </Col>
           ))}
         </Row>

--- a/src/sections/Learn/LearnPage-Sections/learning-path.js
+++ b/src/sections/Learn/LearnPage-Sections/learning-path.js
@@ -90,7 +90,7 @@ const LearningPaths = () => {
         <Row className="learning-path-cards">
           {data.learnPaths.nodes.map((tutorial) => (
             <Col $sm={6} key={tutorial.id}>
-              <CardComponent tutorial={tutorial} path={`learning-paths/${tutorial.fields.learnpath}`} courseCount={getCoursesOfaLearningPath(tutorial.fields.learnpath).length} />
+              <CardComponent tutorial={tutorial} path={`/learn/learning-paths/${tutorial.fields.learnpath}`} courseCount={getCoursesOfaLearningPath(tutorial.fields.learnpath).length} />
             </Col>
           ))}
         </Row>


### PR DESCRIPTION
**Description**
This PR fixes broken links and navigation issues in the learning paths section by correcting path generation and template literal syntax.

- Fixed 404 errors when course links are opened in a new tab or accessed directly.

- Corrected “Start Again” to restart the course from the first chapter.

- https://github.com/layer5io/layer5/issues/7269 Ensured "Learning Paths/Courses" navigation correctly routes back to the parent page.

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
