### PR TITLE
WorkshopPageWrapper - Card content overflow on workshops page

### DIFF
--- a/src/sections/Learn/Workshop-grid/WorkshopsGrid.style.js
+++ b/src/sections/Learn/Workshop-grid/WorkshopsGrid.style.js
@@ -6,9 +6,14 @@ export const WorkshopPageWrapper = styled.div`
 	}
 	.btn-and-status {
 		display: flex;
-		width: 97%;
+		width: 100%;
 		position: absolute;
-		top: 92%;
+		bottom: 0;
+		left: 0;
+		padding: 0.75rem 1rem;
+		align-items: center;
+		box-sizing: border-box;
+		gap: 0.5rem;
 
 		p {
 			color: ${props => props.theme.primaryLightColor};
@@ -54,13 +59,17 @@ export const WorkshopPageWrapper = styled.div`
 		outline: none;
 	}
 
-	.linkAndReadBtns {
+	.left-icons {
 		display: flex;
-		width: 95%;
-		flex-direction: row-reverse;
-		justify-content: space-between;
-		position: absolute;
-		bottom: 0rem;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	a.readmeBtn {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+		margin-left: auto;
 	}
 
 	.linkAndReadBtns-open {
@@ -106,12 +115,6 @@ export const WorkshopPageWrapper = styled.div`
 		}
 	}
 
-	.externalLink {
-		position: relative;
-		left: 1rem;
-		margin-top: 0.25rem;
-	}
-
 	.text-contents {
 		display: none;
 		width: 100%;
@@ -124,10 +127,6 @@ export const WorkshopPageWrapper = styled.div`
 		width: 100%;
 		height: 100%;
 		padding: 1.5rem;
-	}
-
-	.social-icons {
-		display: flex;
 	}
 
 	.links {
@@ -170,6 +169,7 @@ export const WorkshopPageWrapper = styled.div`
 		width: 100%;
 		display: block;
 		height: auto;
+		position: relative;
 		border-radius: 0.3125rem;
 		margin-bottom: 1.25rem;
 		box-shadow: 0rem 0.0625rem 0.3125rem rgba(0, 0, 0, 0.2);

--- a/src/sections/Learn/Workshop-grid/index.js
+++ b/src/sections/Learn/Workshop-grid/index.js
@@ -116,22 +116,19 @@ const WorkshopsPage = () => {
                       </div>
                     </div>
                     <div className={content && ID === id ? "btn-and-status-open" : "btn-and-status"}>
-                      <div className="social-icons">
+                      <div className="left-icons">
                         {frontmatter.slack && frontmatter.status === "delivered" ?
-                          <a href={frontmatter.slack} target = "_blank" rel="noreferrer" className="links">
+                          <a href={frontmatter.slack} target="_blank" rel="noreferrer" className="links">
                             <img src={Slack} alt="Slack"/>
-                                                        Slack
+                            Slack
                           </a> : ""}
+                        <Link to={fields.slug} className="siteLink">
+                          <FaRegWindowMaximize style={{ height: "25px", width: "auto" }} />
+                        </Link>
                       </div>
-                      <div className="linkAndReadBtns">
-                        <div className="expand">
-                          <Link to={fields.slug} className="readmeBtn readmreBtn"> Read More <BsArrowRight className="icon" size={30} /></Link>
-                        </div>
-
-                        <div className="externalLink">
-                          <Link to={fields.slug} className="siteLink"><FaRegWindowMaximize style={{ height: "25px", width: "auto" }} /></Link>
-                        </div>
-                      </div>
+                      <Link to={fields.slug} className="readmeBtn">
+                        Read More <BsArrowRight className="icon" size={30} />
+                      </Link>
                     </div>
                   </div>
                 </Col>


### PR DESCRIPTION
**Description**
Summary
Fixes the visual layout issue where card content (Slack icon, expansion icon, and "Read More" button) was overflowing beyond the card boundaries on the /learn/workshops page.

This PR fixes #7278 

**Notes for Reviewers**

**CSS Changes (WorkshopsGrid.style.js):**

- Added position: relative to .workshop-grid-card to establish positioning context
- Changed .btn-and-status from top: 92% to bottom: 0 for reliable bottom positioning
- Replaced nested absolute positioning with simple flexbox layout
- Added proper alignment with align-items: center and spacing with gap

**HTML Restructure (index.js):**
- Grouped left-side icons (Slack + expansion) into .left-icons container
- Simplified markup by removing unnecessary wrapper divs (.linkAndReadBtns, .expand, .externalLink)
- HTML order now matches visual order for better accessibility

**Screenshots:** 

<img width="2918" height="986" alt="card_layout" src="https://github.com/user-attachments/assets/9e3a42c9-5c4a-4436-9ea3-6ee18eb8dc1e" />


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [✅] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
