### PR TITLE
Update Cloud menu item 

### DIFF
--- a/src/sections/General/Navigation/utility/menu-items.js
+++ b/src/sections/General/Navigation/utility/menu-items.js
@@ -69,8 +69,9 @@ const Data = {
         },
         {
           name: "Cloud",
-          path: "/cloud-native-management/catalog",
+          path: "https://cloud.layer5.io/",
           sepLine: true,
+          externalLink: true,
         },
         {
           name: "Academy",


### PR DESCRIPTION
Fixes the Products → Cloud navbar link by updating it to the correct external Layer5 Cloud URL and ensuring proper external navigation behavior.
<img width="1920" height="1080" alt="Screenshot (1638)" src="https://github.com/user-attachments/assets/8b7a0dcc-ae71-49ee-ad48-64d73e242f86" />
Similarly Recogination I made changes for cloud link.
Fixes #7277 