### PR TITLE
fix: fixing the columns order on small devices

### DIFF
--- a/src/sections/Developer-Infrastructure/features.js
+++ b/src/sections/Developer-Infrastructure/features.js
@@ -29,11 +29,25 @@ const FeatureWrapper = styled.div`
       }
     }
   }
+  .catalog-container .catalog:nth-child(even) {
+    .catalog-image {
+      @media (max-width: 767px) {
+        order: 0;
+      }
+    }
+    .catalog-detail {
+      @media (max-width: 767px) {
+        order: 1;
+      }
+    }
+  }
   .catalog {
     display: flex;
     padding: 2rem 0;
-    @media (max-width: 767px) {
+    @media (max-width: 768px) {
       padding: 2rem 0;
+    }
+    @media (max-width: 468px) {
       flex-direction: column;
     }
     .catalog-detail {
@@ -54,7 +68,13 @@ const FeatureWrapper = styled.div`
           font-size: 2rem;
           line-height: 2.5rem;
           text-align: center;
+          padding-left: 100px;
+          padding-right: 100px;
           margin-bottom: 1rem;
+        }
+        @media (max-width: 467px) {
+          padding-left: 25px;
+          padding-right: 25px;
         }
       }
       .caption {
@@ -68,6 +88,12 @@ const FeatureWrapper = styled.div`
           font-size: 1rem;
           line-height: 1.5rem;
           text-align: center;
+          padding-left: 100px;
+          padding-right: 100px;
+        }
+        @media (max-width: 467px) {
+          padding-left: 25px;
+          padding-right: 25px;
         }
       }
     }
@@ -81,13 +107,14 @@ const FeatureWrapper = styled.div`
         align-items: center;
         @media (max-width: 767px) {
           justify-content: center;
+        }
+        .kubernetes-image {
+          @media (max-width: 767px) {
+            max-width: 90%;
+            margin-bottom: 2rem;
+          }
         } 
       }
-    }
-  }
-  .catalog:nth-child(1){
-    @media (max-width: 767px) {
-      flex-direction: column-reverse;
     }
   }
 `;


### PR DESCRIPTION
**Description**
On  https://layer5.io/solutions/developer-defined-infrastructure page, at Design Architecture Diagram section and Orchestration Management section, on small devices the columns order should be reverted. 
The image is first displayed following by the section's title and small description.
This PR aims to fix that.

This PR fixes ##7292

**Notes for Reviewers**

He are images before changes
<img width="462" height="683" alt="Screenshot 2025-12-27 at 14 11 37" src="https://github.com/user-attachments/assets/84193181-5282-4fcb-8d36-bc6d5ffb28df" />
<img width="459" height="390" alt="Screenshot 2025-12-27 at 14 12 52" src="https://github.com/user-attachments/assets/45725071-351d-421b-8fe9-12dfe2a0815b" />

- And here are images after making some changes
<img width="515" height="679" alt="Screenshot 2025-12-27 at 14 50 03" src="https://github.com/user-attachments/assets/b46c423f-f33c-466f-9e1e-2156d5df583c" />
<img width="525" height="396" alt="Screenshot 2025-12-27 at 14 50 17" src="https://github.com/user-attachments/assets/d9ba1bf0-eebc-44a9-ad37-35837b906c49" />


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
