### PR TITLE
Fix double-slash redirect paths in CI builds

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -39,8 +39,8 @@ if (process.env.CI === "true") {
       createPage(page);
 
       createRedirect({
-        fromPath: `/${page.matchPath}/`,
-        toPath: `/${page.matchPath}`,
+        fromPath: `${page.matchPath}/`,
+        toPath: page.matchPath,
         redirectInBrowser: true,
         isPermanent: true,
       });
@@ -63,8 +63,8 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       const { path, matchPath, ...rest } = props;
       const isHandbookPage = path.startsWith("/community/handbook/");
       createRedirect({
-        fromPath: `/${path}/`,
-        toPath: `/${path}`,
+        fromPath: `${path}/`,
+        toPath: path,
         redirectInBrowser: true,
         isPermanent: true,
       });


### PR DESCRIPTION
# Fix: Double-Slash Redirect Paths on GitHub Pages Deployments

## Summary

This PR fixes a critical redirect bug in **`gatsby-node.js`** that generates malformed double-slash (`//`) paths during **GitHub Pages (CI=true)** builds. These malformed redirects break trailing-slash navigation across the site and negatively impact SEO.

The issue affects **all dynamically created pages** and only manifests in production GitHub Pages deployments, making it difficult to detect during local development.

---

## Problem Description

When `CI=true`, Gatsby creates redirects intended to normalize trailing-slash URLs. However, the current logic incorrectly prepends `/` to paths that **already start with `/`**, producing invalid redirect paths.

### Example

Given a valid slug:

```txt
/blog/meshery/my-post
```

The current redirect logic generates:

```txt
fromPath: //blog/meshery/my-post/
toPath:   //blog/meshery/my-post
```

This results in broken redirects for URLs with trailing slashes.

---

## Affected Areas

* **File:** `gatsby-node.js`
* **Lines:**

  * 42–46 (`onCreatePage`)
  * 65–70 (`envCreatePage`)
* **Deployment Target:** GitHub Pages (`CI=true`)
* **Pages Impacted:**

  * Blog posts
  * News articles
  * Events
  * Programs
  * Careers
  * Member profiles
  * Integrations
  * Workshops
  * Labs
  * Handbook pages
  * Learning content
    *(1000+ pages total)*

---

## Root Cause

* All slugs generated in `onCreateNode` are explicitly prefixed with `/`:

  ```js
  slug = `/${collection}/${slugify(node.frontmatter.title)}`;
  ```
* Redirect creation logic incorrectly assumes `path` and `matchPath` do **not** start with `/`.
* This mismatch causes double-slash paths (`//`) in redirect rules.

---

## Reproduction Steps

### Production Preview

1. Open any PR in the `layer5` repository
2. Wait for the GitHub Pages preview build
3. Open any dynamic page (blog, event, etc.)
4. Manually add a trailing slash to the URL
   Example:

   ```txt
   /blog/meshery/my-post/
   ```
5. Observe broken or incorrect redirect behavior

### Local

```bash
CI=true npm run build
```

Inspect generated redirect HTML files in `public/` and note double-slash paths in meta refresh tags.

---

## Fix Implemented

Removed the extra leading `/` when constructing redirect paths.

### `envCreatePage` (lines 65–70)

```js
createRedirect({
  fromPath: `${path}/`,
  toPath: path,
  redirectInBrowser: true,
  isPermanent: true,
});
```

### `onCreatePage` (lines 42–46)

```js
createRedirect({
  fromPath: `${page.matchPath}/`,
  toPath: page.matchPath,
  redirectInBrowser: true,
  isPermanent: true,
});
```

---

## Impact After Fix

* ✅ Trailing-slash URLs redirect correctly
* ✅ Canonical URLs restored for SEO
* ✅ No more silent redirect failures
* ✅ GitHub Pages deployment behaves correctly
* ✅ Shared links and documentation URLs remain reliable

---

## Why This Matters

This fix prevents widespread broken navigation and SEO degradation across the site’s primary production deployment. It ensures consistent, predictable URL behavior for users, contributors, and search engines alike.

---

## Checklist

* [x] Fix double-slash redirect paths
* [x] Preserve existing URL structure
* [x] No breaking changes to local development
* [x] Verified behavior in CI=true builds

---

Please review and merge to restore correct redirect behavior on GitHub Pages.
