### PR TITLE
fix: card clickable issue for Integrations

### DIFF
--- a/src/sections/Meshery/Meshery-integrations/Individual-Integrations/CatalogGrid.js
+++ b/src/sections/Meshery/Meshery-integrations/Individual-Integrations/CatalogGrid.js
@@ -64,7 +64,6 @@ const CatalogGrid = ({ frontmatter }) => {
                 pattern={item}
                 type="Catalog"
                 patternType={item?.catalog_data?.type}
-                onCardClick={() => window.open(`https://cloud.layer5.io/catalog/content/catalog/${item?.id}`, "_blank")}
               />
             );
           })}


### PR DESCRIPTION
**Description**

The component cards in ComponentsGrid.js were rendered as plain `<div> `elements without any hyperlink or click handler. They were purely display elements with no interactive functionality.

Wrapped the component card in an `<a>` tag that links to Layer5 Cloud 

In CatalogGrid.js, there is a prop mismatch: cardLink is used, but the correct prop is onCardClick.

This PR fixes #7397 

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
