### PR TITLE
Update Kanvas hyperlinks to point to new landing page

### DIFF
--- a/src/assets/data/faq/index.js
+++ b/src/assets/data/faq/index.js
@@ -237,7 +237,7 @@ const data = {
       question: "How can I try out Kanvas?",
       category: "Kanvas",
       subcategory: "Getting Started",
-      link: "https://kanvas.new",
+      link: "https://www.kanvas.new",
       linktext: "Open kanvas.new",
       answer: [
        "Kanvas is available in beta today. Visit https://kanvas.new to use it.",

--- a/src/sections/Home/Banner-4/index.js
+++ b/src/sections/Home/Banner-4/index.js
@@ -80,7 +80,7 @@ const Banner1 = (props) => {
                   <Button $primary className="banner-btn one" title="Learn about Kanvas" $url="/cloud-native-management/kanvas">
                     <FaMapMarkedAlt size={21} className="icon-left" />
                   </Button>
-                  <Button $secondary className="banner-btn two" title="Open in Playground" $url="https://kanvas.new/" $external={true}>
+                  <Button $secondary className="banner-btn two" title="Open in Playground" $url="https://www.kanvas.new/" $external={true}>
                     <BsArrowUpRight size={21} className="icon-left" />
                   </Button>
                 </VintageBox>


### PR DESCRIPTION
**Description**

This PR updates hyperlinks that previously pointed to https://kanvas.new so that they now point to https://www.kanvas.new.

This PR fixes #7385

**Notes for Reviewers**

1. Updated all occurrences of https://kanvas.new to https://www.kanvas.new

2. Verified changes across Kanvas buttons and related sections

3. No unrelated files were modified

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
