### PR TITLE
fix(ci): always use full production build in CI workflows

### DIFF
--- a/.github/workflows/build-and-deploy-site.yml
+++ b/.github/workflows/build-and-deploy-site.yml
@@ -28,10 +28,18 @@ jobs:
       #     restore-keys: |
       #       ${{ runner.os }}-gatsby-
 
-      - name: Install and Build 🔧
-        run: |
-          make setup
-          make clean
+      - name: Install 🔧
+        run: make setup
+
+      - name: Build 🏗️
+        # Always run the full production build explicitly.
+        # Do NOT use `make clean` here — that target is a developer convenience
+        # command whose recipe has changed multiple times, causing blog posts and
+        # other collections to be silently excluded from the deployed site when
+        # it ran a lite/dev build instead of the full production build.
+        # `npm run build` is the canonical, stable production build command:
+        #   cross-env BUILD_FULL_SITE=true gatsby build
+        run: npm run build
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/build-and-preview-site.yml
+++ b/.github/workflows/build-and-preview-site.yml
@@ -14,10 +14,18 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Install and Build 🔧
-        run: |
-          make setup
-          make clean
+      - name: Install 🔧
+        run: make setup
+
+      - name: Build 🏗️
+        # Always run the full production build explicitly.
+        # Do NOT use `make clean` here — that target is a developer convenience
+        # command whose recipe has changed multiple times, causing blog posts and
+        # other collections to be silently excluded from the deployed site when
+        # it ran a lite/dev build instead of the full production build.
+        # `npm run build` is the canonical, stable production build command:
+        #   cross-env BUILD_FULL_SITE=true gatsby build
+        run: npm run build
 
       - name: Broken Link Check 🔗
         uses: technote-space/broken-link-checker-action@v2

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,8 @@ site-fast:
 build:
 	npm run build
 
-## Empty build cache and run layer5.io on your local machine.
-clean: 
+## Empty build cache and rebuild layer5.io on your local machine (developer use only; CI uses `npm run build` directly).
+clean:
 	npm run clean && make build
 
 ## Run Eslint on your local machine.


### PR DESCRIPTION
## Root Cause

The `build-and-deploy-site.yml` and `build-and-preview-site.yml` workflows were calling `make clean`. The `clean` Makefile target is a **developer convenience command** whose recipe has changed multiple times, each time breaking production:

| Period | `make clean` ran | Result |
|--------|-----------------|--------|
| Before PR #7508 | `gatsby clean && make site` → `gatsby develop:lite` | Lite build **excludes blog, news, events, resources** — all posts disappeared from deployed site |
| Same period (after commit `22c47cf3a`) | `gatsby clean` failed with `/bin/sh: gatsby: not found` | CI error — no build, no deploy |
| After PR #7508 | `npm run clean && make build` | Full build — works, but still depends on fragile Makefile chain |

Every time `make clean` was changed for local dev ergonomics, it silently broke CI.

## Fix

Call **`npm run build` directly** in both workflow files. This script is defined in `package.json` as:

```
cross-env BUILD_FULL_SITE=true gatsby build
```

It is the canonical, stable production build command that:
- Always sets `BUILD_FULL_SITE=true` so **all collections are included** (blog, news, events, resources, members, integrations)
- Never runs a development server that hangs CI
- Is not subject to Makefile target refactoring

Also adds a comment to the Makefile `clean` target to mark it as developer-only, preventing future confusion about using it in CI.

## Test plan

- [ ] Verify that the next push to `master` triggers a full production build (1298 pages, 108+ blog pages) rather than a lite build
- [ ] Confirm `/blog` shows all published posts including 2024 and 2025 entries after deployment
- [ ] Confirm `/resources` still works as expected