### PR TITLE
change framework of docs.meshery.io to Hugo

### DIFF
--- a/src/collections/handbook/repository-overview/repo-data.js
+++ b/src/collections/handbook/repository-overview/repo-data.js
@@ -48,7 +48,7 @@ export const repo_data = [
         project: "Meshery Documentation",
         image: meshery,
         site: "http://docs.meshery.io",
-        language: "Jekyll",
+        language: "Hugo",
         maintainers_name: ["Vacant"],
         link: [""],
         repository: "https://github.com/meshery/meshery/tree/master/docs",


### PR DESCRIPTION
**Description**
This PR fixes #7517

Changes the framework of Meshery Documentation (docs.meshery.io) 
from Jekyll to Hugo in the repository overview.

**Notes for Reviewers**
Updated the framework field for the Meshery Documentation entry 
in `src/collections/handbook/repository-overview/repo-data.js` 
from Jekyll to Hugo.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
