### PR TITLE
fix: centre align brand kit download button

### DIFF
--- a/src/sections/Company/Brand/brandPage.style.js
+++ b/src/sections/Company/Brand/brandPage.style.js
@@ -152,7 +152,7 @@ const BrandPageWrapper = styled.section`
 	}
 
 	.download-button {
-		text-align: end;
+		text-align: center;
 		margin: 0 0 1rem 0;
 	}
 	.ImgDiv, .color-code-wrapper {


### PR DESCRIPTION
## Summary
Change `.download-button` `text-align` from `end` to `center` in `brandPage.style.js`.

## Test plan
- [ ] Navigate to /company/brand page
- [ ] Verify download buttons are centered on desktop
- [ ] Verify buttons remain left-aligned on mobile (< 575px)

Closes #7568

Signed-off-by: Tran Hoang Tu <tranhoangtu.it@gmail.com>