### PR TITLE
fix: prevent news template from rendering on news page

### DIFF
--- a/src/collections/news/news-template/0000-00-00-news-title/index.mdx
+++ b/src/collections/news/news-template/0000-00-00-news-title/index.mdx
@@ -11,7 +11,7 @@ category: Coverage # Must be either "Coverage" or "Release". This is used to det
 tags: [] # Mandatory. An array of tags for the news item, such as ["Meshery", "KubeCon", "CNCF"].  
 presskit: "" # Optional. A URL to a press kit or additional resources related to the news item.
 resource: false # Mandatory. A boolean indicating whether this news item is a resource that should be listed in the resources section of the website. If true, it will be included in the resources section; if false or omitted, it will not be included in the resources section but will still appear in the news listing.
-published: true # Mandatory A boolean indicating whether the news item is published. If true, it will be visible on the website; if false, it will be hidden until ready for publication.
+published: false # Mandatory A boolean indicating whether the news item is published. If true, it will be visible on the website; if false, it will be hidden until ready for publication.
 source_url: "" # Mandatory. URL to the original article for "Originally published at" attribution.
 
 ---


### PR DESCRIPTION
**Description**

This PR fixes the news template publishing from true to false. 

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
