### PR TITLE
Fix: resolve broken Join Now button in Events section

### DIFF
--- a/src/components/UpcomingEventCard/index.js
+++ b/src/components/UpcomingEventCard/index.js
@@ -8,43 +8,59 @@ import "swiper/css/bundle";
 import Button from "../../reusecore/Button";
 import slugify from "../../utils/slugify";
 
-
 const UpcomingEvents = ({ data }) => {
   return (
     <UpcomingEventsWrapper>
       <div className="blog-slider swiper">
-        <div style={{
-          display: "block"
-        }} className="blog-slider__wrp swiper-wrapper"
+        <div
+          style={{
+            display: "block",
+          }}
+          className="blog-slider__wrp swiper-wrapper"
         >
-
           <Swiper
             spaceBetween={50}
             slidesPerView={1}
             modules={[Mousewheel, Pagination]}
             pagination={{ clickable: true }}
           >
-            {data.nodes.map(item => {
+            {data.nodes.map((item) => {
               return (
                 <SwiperSlide key={item.id}>
                   <div className="blog-slider_item swiper-slide">
                     <div className="blog-slider_img">
-                      <Link to={`/community/events/${slugify(item.frontmatter.title)}`}>
-                        <Image {...item.frontmatter.thumbnail}  alt={item.frontmatter.title} />
+                      <Link
+                        to={`/community/events/${slugify(item.frontmatter.title)}`}
+                      >
+                        <Image
+                          {...item.frontmatter.thumbnail}
+                          alt={item.frontmatter.title}
+                        />
                       </Link>
                     </div>
                     <div className="blog-slider_content">
-                      <h3 className="blog-slider_title">{item.frontmatter.title}</h3>
-                      <p className="blog-slider_date">{item.frontmatter.date}</p>
-                      <p className="blog-slider_description">{item.frontmatter.abstract}</p>
-                      <Button $secondary className="blog-slider_button" $url={item.frontmatter.eurl} title="Join Now" $external={true} />
+                      <h3 className="blog-slider_title">
+                        {item.frontmatter.title}
+                      </h3>
+                      <p className="blog-slider_date">
+                        {item.frontmatter.date}
+                      </p>
+                      <p className="blog-slider_description">
+                        {item.frontmatter.abstract}
+                      </p>
+                      <Button
+                        $secondary
+                        className="blog-slider_button"
+                        url={item.frontmatter.eurl}
+                        title="Join Now"
+                        $external={true}
+                      />
                     </div>
                   </div>
                 </SwiperSlide>
               );
             })}
           </Swiper>
-
         </div>
       </div>
     </UpcomingEventsWrapper>


### PR DESCRIPTION
**Description**
Removed the transient prop `$` from the `$url` prop in the Button component to ensure the link actually registers on the HTML element. 

This PR fixes #7623

**Notes for Reviewers**
The button link logic is fixed. *(Note: My local Windows environment was failing to build the `sharp` image module, so I will be using the automated Deploy Preview to verify if my CSS layout changes successfully fixed the desktop image misalignment!).*

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.