### PR TITLE
Fix: ui- rendering issue on Pr-preview link

### DIFF
--- a/.github/workflows/build-and-preview-site.yml
+++ b/.github/workflows/build-and-preview-site.yml
@@ -29,19 +29,19 @@ jobs:
 
       - name: Checkout PR
         if: github.event.action != 'closed'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout gh-pages for cleanup
         if: github.event.action == 'closed'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
 
       - name: Setup Node
         if: github.event.action != 'closed'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -77,7 +77,7 @@ jobs:
 
       - name: Checkout gh-pages for preview retention
         if: github.event.action != 'closed'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
           fetch-depth: 0
@@ -131,7 +131,7 @@ jobs:
         with:
           header: pr-preview
           message: |
-            🚀 Preview deployment: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.pull_request.number }}/
+            🚀 Preview deployment: https://layer5.io/pr-preview/pr-${{ github.event.pull_request.number }}/
             > *Note: Preview may take a moment (GitHub Pages deployment in progress). Please wait and refresh. Track deployment [here](https://github.com/${{ github.repository }}/actions/workflows/pages/pages-build-deployment)*
 
       - name: Comment on pruned previews

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -13,10 +13,12 @@ const siteOrigin = (process.env.GATSBY_SITE_URL || "https://layer5.io").replace(
   /\/$/,
   "",
 );
-const rawPathPrefix = process.env.PATH_PREFIX || "";
-const pathPrefix = rawPathPrefix
-  ? `/${rawPathPrefix.replace(/^\/+|\/+$/g, "")}`
-  : "";
+const rawPrefix = process.env.PATH_PREFIX;
+const pathPrefix =
+  rawPrefix && String(rawPrefix).trim().length
+    ? `/${String(rawPrefix).replace(/^\/+|\/+$/g, "")}`
+    : undefined;
+
 const siteRootUrl = `${siteOrigin}${pathPrefix}`.replace(/\/$/, "");
 const shouldBuildFullSite = isFullSiteBuild();
 const isLiteDevBuild = isDevelopment && !shouldBuildFullSite;
@@ -28,17 +30,18 @@ const collectionIgnoreGlobs = excludedCollections.map(
 );
 const devFlags = isDevelopment
   ? {
-    PARALLEL_SOURCING: false,
-    PRESERVE_FILE_DOWNLOAD_CACHE: true,
-  }
+      PARALLEL_SOURCING: false,
+      PRESERVE_FILE_DOWNLOAD_CACHE: true,
+    }
   : {};
 console.info(`Build Environment: "${process.env.NODE_ENV}"`);
 collectionIgnoreGlobs.length > 0
   ? console.info(
       `Build Scope excludes (${process.env.LITE_BUILD_PROFILE || DEFAULT_LITE_BUILD_PROFILE}): ${excludedCollections.join(", ")}`,
-  )
+    )
   : console.info("Build Scope includes all collections");
 module.exports = {
+  ...(pathPrefix != null ? { pathPrefix } : {}),
   siteMetadata: {
     title: "Layer5 - Expect more from your infrastructure",
     description:
@@ -49,7 +52,6 @@ module.exports = {
     image: "/images/layer5-gradient.webp",
     twitterUsername: "@layer5",
   },
-  ...(pathPrefix ? { pathPrefix } : {}),
   flags: {
     FAST_DEV: false,
     DEV_SSR: false,
@@ -142,11 +144,11 @@ module.exports = {
     // Start of Production-only Plugins
     ...(isProduction
       ? [
-        {
-          resolve: "gatsby-plugin-feed",
-          options: {
-            // Lightweight global query - only site metadata
-            query: `
+          {
+            resolve: "gatsby-plugin-feed",
+            options: {
+              // Lightweight global query - only site metadata
+              query: `
           {
             site {
               siteMetadata {
@@ -158,12 +160,12 @@ module.exports = {
             }
           }
         `,
-            feeds: [
-              // FEED 1: News - individual query per feed
-              {
-                output: "/news/feed.xml",
-                title: "Layer5 News",
-                query: `
+              feeds: [
+                // FEED 1: News - individual query per feed
+                {
+                  output: "/news/feed.xml",
+                  title: "Layer5 News",
+                  query: `
               {
                 site {
                   siteMetadata {
@@ -197,85 +199,85 @@ module.exports = {
                 }
               }
             `,
-                serialize: ({ query: { site, allMdx } }) => {
-                  return allMdx.nodes.map((node) => {
-                    return Object.assign({}, node.frontmatter, {
-                      title: node.frontmatter.title,
-                      author: node.frontmatter.author,
-                      description: node.frontmatter.description,
-                      date: node.frontmatter.date,
-                      url: site.siteMetadata.siteUrl + node.fields.slug,
-                      guid: site.siteMetadata.siteUrl + node.fields.slug,
-                      enclosure: node.frontmatter.thumbnail && {
-                        url:
+                  serialize: ({ query: { site, allMdx } }) => {
+                    return allMdx.nodes.map((node) => {
+                      return Object.assign({}, node.frontmatter, {
+                        title: node.frontmatter.title,
+                        author: node.frontmatter.author,
+                        description: node.frontmatter.description,
+                        date: node.frontmatter.date,
+                        url: site.siteMetadata.siteUrl + node.fields.slug,
+                        guid: site.siteMetadata.siteUrl + node.fields.slug,
+                        enclosure: node.frontmatter.thumbnail && {
+                          url:
                             site.siteMetadata.siteUrl +
                             node.frontmatter.thumbnail.publicURL,
-                      },
-                      custom_elements: [{ "content:encoded": node.excerpt }],
+                        },
+                        custom_elements: [{ "content:encoded": node.excerpt }],
+                      });
                     });
-                  });
+                  },
                 },
-              },
-              // FEED 2: Resources - individual query
-              //   {
-              //     output: "/resources/feed.xml",
-              //     title: "Layer5 Resources",
-              //     query: `
-              //   {
-              //     site {
-              //       siteMetadata {
-              //         title
-              //         siteUrl
-              //       }
-              //     }
-              //     allMdx(
-              //       sort: {frontmatter: {date: DESC}}
-              //       limit: 20
-              //       filter: {
-              //         frontmatter: { published: { eq: true } }
-              //         fields: { collection: { eq: "resources" } }
-              //       }
-              //     ) {
-              //       nodes {
-              //         excerpt
-              //         frontmatter {
-              //           title
-              //           author
-              //           description
-              //           date
-              //           thumbnail {
-              //             publicURL
-              //           }
-              //         }
-              //         fields {
-              //           slug
-              //         }
-              //       }
-              //     }
-              //   }
-              // `,
-              //     serialize: ({ query: { site, allMdx } }) => {
-              //       return allMdx.nodes.map((node) => {
-              //         return Object.assign({}, node.frontmatter, {
-              //           title: node.frontmatter.title,
-              //           author: node.frontmatter.author,
-              //           description: node.frontmatter.description,
-              //           date: node.frontmatter.date,
-              //           url: site.siteMetadata.siteUrl + node.fields.slug,
-              //           guid: site.siteMetadata.siteUrl + node.fields.slug,
-              //           enclosure: node.frontmatter.thumbnail && {
-              //             url: site.siteMetadata.siteUrl + node.frontmatter.thumbnail.publicURL,
-              //           },
-              //           custom_elements: [{ "content:encoded": node.excerpt }],
-              //         });
-              //       });
-              //     },
-              //   },
-              // FEED 3: Meshery Community - targeted query with filters
-              {
-                output: "/meshery-community-feed.xml",
-                title: "Meshery RSSFeed",
-                query: `
+                // FEED 2: Resources - individual query
+                //   {
+                //     output: "/resources/feed.xml",
+                //     title: "Layer5 Resources",
+                //     query: `
+                //   {
+                //     site {
+                //       siteMetadata {
+                //         title
+                //         siteUrl
+                //       }
+                //     }
+                //     allMdx(
+                //       sort: {frontmatter: {date: DESC}}
+                //       limit: 20
+                //       filter: {
+                //         frontmatter: { published: { eq: true } }
+                //         fields: { collection: { eq: "resources" } }
+                //       }
+                //     ) {
+                //       nodes {
+                //         excerpt
+                //         frontmatter {
+                //           title
+                //           author
+                //           description
+                //           date
+                //           thumbnail {
+                //             publicURL
+                //           }
+                //         }
+                //         fields {
+                //           slug
+                //         }
+                //       }
+                //     }
+                //   }
+                // `,
+                //     serialize: ({ query: { site, allMdx } }) => {
+                //       return allMdx.nodes.map((node) => {
+                //         return Object.assign({}, node.frontmatter, {
+                //           title: node.frontmatter.title,
+                //           author: node.frontmatter.author,
+                //           description: node.frontmatter.description,
+                //           date: node.frontmatter.date,
+                //           url: site.siteMetadata.siteUrl + node.fields.slug,
+                //           guid: site.siteMetadata.siteUrl + node.fields.slug,
+                //           enclosure: node.frontmatter.thumbnail && {
+                //             url: site.siteMetadata.siteUrl + node.frontmatter.thumbnail.publicURL,
+                //           },
+                //           custom_elements: [{ "content:encoded": node.excerpt }],
+                //         });
+                //       });
+                //     },
+                //   },
+                // FEED 3: Meshery Community - targeted query with filters
+                {
+                  output: "/meshery-community-feed.xml",
+                  title: "Meshery RSSFeed",
+                  query: `
               {
                 site {
                   siteMetadata {
@@ -317,52 +319,52 @@ module.exports = {
                 }
               }
             `,
-                serialize: ({ query: { site, allMdx } }) => {
-                  const targetTags = ["Community", "Meshery", "mesheryctl"];
+                  serialize: ({ query: { site, allMdx } }) => {
+                    const targetTags = ["Community", "Meshery", "mesheryctl"];
 
-                  return allMdx.nodes
-                    .filter((node) => {
-                      const hasTag =
+                    return allMdx.nodes
+                      .filter((node) => {
+                        const hasTag =
                           node.frontmatter.tags &&
                           node.frontmatter.tags.some((t) =>
                             targetTags.includes(t),
                           );
-                      return hasTag;
-                    })
-                    .slice(0, 30)
-                    .map((node) => {
-                      return Object.assign({}, node.frontmatter, {
-                        title: node.frontmatter.title,
-                        author: node.frontmatter.author,
-                        description:
+                        return hasTag;
+                      })
+                      .slice(0, 30)
+                      .map((node) => {
+                        return Object.assign({}, node.frontmatter, {
+                          title: node.frontmatter.title,
+                          author: node.frontmatter.author,
+                          description:
                             node.frontmatter.description ||
                             node.frontmatter.subtitle,
-                        date: node.frontmatter.date,
-                        url: site.siteMetadata.siteUrl + node.fields.slug,
-                        guid: site.siteMetadata.siteUrl + node.fields.slug,
-                        enclosure: node.frontmatter.thumbnail && {
-                          url:
+                          date: node.frontmatter.date,
+                          url: site.siteMetadata.siteUrl + node.fields.slug,
+                          guid: site.siteMetadata.siteUrl + node.fields.slug,
+                          enclosure: node.frontmatter.thumbnail && {
+                            url:
                               site.siteMetadata.siteUrl +
                               node.frontmatter.thumbnail.publicURL,
-                        },
-                        custom_elements: [
-                          { "content:encoded": node.excerpt },
-                          { "content:type": node.frontmatter.type },
-                          { "content:category": node.frontmatter.category },
-                          {
-                            "content:tags":
-                                node.frontmatter.tags?.join(", ") || "",
                           },
-                        ],
+                          custom_elements: [
+                            { "content:encoded": node.excerpt },
+                            { "content:type": node.frontmatter.type },
+                            { "content:category": node.frontmatter.category },
+                            {
+                              "content:tags":
+                                node.frontmatter.tags?.join(", ") || "",
+                            },
+                          ],
+                        });
                       });
-                    });
+                  },
                 },
-              },
-              // FEED 4: Blog - individual query
-              {
-                output: "/blog/feed.xml",
-                title: "Layer5 Blog",
-                query: `
+                // FEED 4: Blog - individual query
+                {
+                  output: "/blog/feed.xml",
+                  title: "Layer5 Blog",
+                  query: `
               {
                 site {
                   siteMetadata {
@@ -396,30 +398,30 @@ module.exports = {
                 }
               }
             `,
-                serialize: ({ query: { site, allMdx } }) => {
-                  return allMdx.nodes.map((node) => {
-                    return Object.assign({}, node.frontmatter, {
-                      title: node.frontmatter.title,
-                      author: node.frontmatter.author,
-                      description: node.frontmatter.description,
-                      date: node.frontmatter.date,
-                      url: site.siteMetadata.siteUrl + node.fields.slug,
-                      guid: site.siteMetadata.siteUrl + node.fields.slug,
-                      enclosure: node.frontmatter.thumbnail && {
-                        url:
+                  serialize: ({ query: { site, allMdx } }) => {
+                    return allMdx.nodes.map((node) => {
+                      return Object.assign({}, node.frontmatter, {
+                        title: node.frontmatter.title,
+                        author: node.frontmatter.author,
+                        description: node.frontmatter.description,
+                        date: node.frontmatter.date,
+                        url: site.siteMetadata.siteUrl + node.fields.slug,
+                        guid: site.siteMetadata.siteUrl + node.fields.slug,
+                        enclosure: node.frontmatter.thumbnail && {
+                          url:
                             site.siteMetadata.siteUrl +
                             node.frontmatter.thumbnail.publicURL,
-                      },
-                      custom_elements: [{ "content:encoded": node.excerpt }],
+                        },
+                        custom_elements: [{ "content:encoded": node.excerpt }],
+                      });
                     });
-                  });
+                  },
                 },
-              },
-              // FEED 5: Events - individual query
-              {
-                output: "/events/feed.xml",
-                title: "Layer5 Events",
-                query: `
+                // FEED 5: Events - individual query
+                {
+                  output: "/events/feed.xml",
+                  title: "Layer5 Events",
+                  query: `
               {
                 site {
                   siteMetadata {
@@ -453,35 +455,35 @@ module.exports = {
                 }
               }
             `,
-                serialize: ({ query: { site, allMdx } }) => {
-                  return allMdx.nodes.map((node) => {
-                    return Object.assign({}, node.frontmatter, {
-                      title: node.frontmatter.title,
-                      author: node.frontmatter.author,
-                      description: node.frontmatter.description,
-                      date: node.frontmatter.date,
-                      url: site.siteMetadata.siteUrl + node.fields.slug,
-                      guid: site.siteMetadata.siteUrl + node.fields.slug,
-                      enclosure: node.frontmatter.thumbnail && {
-                        url:
+                  serialize: ({ query: { site, allMdx } }) => {
+                    return allMdx.nodes.map((node) => {
+                      return Object.assign({}, node.frontmatter, {
+                        title: node.frontmatter.title,
+                        author: node.frontmatter.author,
+                        description: node.frontmatter.description,
+                        date: node.frontmatter.date,
+                        url: site.siteMetadata.siteUrl + node.fields.slug,
+                        guid: site.siteMetadata.siteUrl + node.fields.slug,
+                        enclosure: node.frontmatter.thumbnail && {
+                          url:
                             site.siteMetadata.siteUrl +
                             node.frontmatter.thumbnail.publicURL,
-                      },
-                      custom_elements: [{ "content:encoded": node.excerpt }],
+                        },
+                        custom_elements: [{ "content:encoded": node.excerpt }],
+                      });
                     });
-                  });
+                  },
                 },
-              },
-            ],
+              ],
+            },
           },
-        },
-        {
-          resolve: "gatsby-plugin-purgecss",
-          options: {
-            printRejected: true,
+          {
+            resolve: "gatsby-plugin-purgecss",
+            options: {
+              printRejected: true,
+            },
           },
-        },
-      ]
+        ]
       : []),
     // End of Production-only Plugins
     {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -30,15 +30,15 @@ const collectionIgnoreGlobs = excludedCollections.map(
 );
 const devFlags = isDevelopment
   ? {
-      PARALLEL_SOURCING: false,
-      PRESERVE_FILE_DOWNLOAD_CACHE: true,
-    }
+    PARALLEL_SOURCING: false,
+    PRESERVE_FILE_DOWNLOAD_CACHE: true,
+  }
   : {};
 console.info(`Build Environment: "${process.env.NODE_ENV}"`);
 collectionIgnoreGlobs.length > 0
   ? console.info(
       `Build Scope excludes (${process.env.LITE_BUILD_PROFILE || DEFAULT_LITE_BUILD_PROFILE}): ${excludedCollections.join(", ")}`,
-    )
+  )
   : console.info("Build Scope includes all collections");
 module.exports = {
   ...(pathPrefix != null ? { pathPrefix } : {}),
@@ -144,11 +144,11 @@ module.exports = {
     // Start of Production-only Plugins
     ...(isProduction
       ? [
-          {
-            resolve: "gatsby-plugin-feed",
-            options: {
-              // Lightweight global query - only site metadata
-              query: `
+        {
+          resolve: "gatsby-plugin-feed",
+          options: {
+            // Lightweight global query - only site metadata
+            query: `
           {
             site {
               siteMetadata {
@@ -160,12 +160,12 @@ module.exports = {
             }
           }
         `,
-              feeds: [
-                // FEED 1: News - individual query per feed
-                {
-                  output: "/news/feed.xml",
-                  title: "Layer5 News",
-                  query: `
+            feeds: [
+              // FEED 1: News - individual query per feed
+              {
+                output: "/news/feed.xml",
+                title: "Layer5 News",
+                query: `
               {
                 site {
                   siteMetadata {
@@ -199,85 +199,85 @@ module.exports = {
                 }
               }
             `,
-                  serialize: ({ query: { site, allMdx } }) => {
-                    return allMdx.nodes.map((node) => {
-                      return Object.assign({}, node.frontmatter, {
-                        title: node.frontmatter.title,
-                        author: node.frontmatter.author,
-                        description: node.frontmatter.description,
-                        date: node.frontmatter.date,
-                        url: site.siteMetadata.siteUrl + node.fields.slug,
-                        guid: site.siteMetadata.siteUrl + node.fields.slug,
-                        enclosure: node.frontmatter.thumbnail && {
-                          url:
+                serialize: ({ query: { site, allMdx } }) => {
+                  return allMdx.nodes.map((node) => {
+                    return Object.assign({}, node.frontmatter, {
+                      title: node.frontmatter.title,
+                      author: node.frontmatter.author,
+                      description: node.frontmatter.description,
+                      date: node.frontmatter.date,
+                      url: site.siteMetadata.siteUrl + node.fields.slug,
+                      guid: site.siteMetadata.siteUrl + node.fields.slug,
+                      enclosure: node.frontmatter.thumbnail && {
+                        url:
                             site.siteMetadata.siteUrl +
                             node.frontmatter.thumbnail.publicURL,
-                        },
-                        custom_elements: [{ "content:encoded": node.excerpt }],
-                      });
+                      },
+                      custom_elements: [{ "content:encoded": node.excerpt }],
                     });
-                  },
+                  });
                 },
-                // FEED 2: Resources - individual query
-                //   {
-                //     output: "/resources/feed.xml",
-                //     title: "Layer5 Resources",
-                //     query: `
-                //   {
-                //     site {
-                //       siteMetadata {
-                //         title
-                //         siteUrl
-                //       }
-                //     }
-                //     allMdx(
-                //       sort: {frontmatter: {date: DESC}}
-                //       limit: 20
-                //       filter: {
-                //         frontmatter: { published: { eq: true } }
-                //         fields: { collection: { eq: "resources" } }
-                //       }
-                //     ) {
-                //       nodes {
-                //         excerpt
-                //         frontmatter {
-                //           title
-                //           author
-                //           description
-                //           date
-                //           thumbnail {
-                //             publicURL
-                //           }
-                //         }
-                //         fields {
-                //           slug
-                //         }
-                //       }
-                //     }
-                //   }
-                // `,
-                //     serialize: ({ query: { site, allMdx } }) => {
-                //       return allMdx.nodes.map((node) => {
-                //         return Object.assign({}, node.frontmatter, {
-                //           title: node.frontmatter.title,
-                //           author: node.frontmatter.author,
-                //           description: node.frontmatter.description,
-                //           date: node.frontmatter.date,
-                //           url: site.siteMetadata.siteUrl + node.fields.slug,
-                //           guid: site.siteMetadata.siteUrl + node.fields.slug,
-                //           enclosure: node.frontmatter.thumbnail && {
-                //             url: site.siteMetadata.siteUrl + node.frontmatter.thumbnail.publicURL,
-                //           },
-                //           custom_elements: [{ "content:encoded": node.excerpt }],
-                //         });
-                //       });
-                //     },
-                //   },
-                // FEED 3: Meshery Community - targeted query with filters
-                {
-                  output: "/meshery-community-feed.xml",
-                  title: "Meshery RSSFeed",
-                  query: `
+              },
+              // FEED 2: Resources - individual query
+              //   {
+              //     output: "/resources/feed.xml",
+              //     title: "Layer5 Resources",
+              //     query: `
+              //   {
+              //     site {
+              //       siteMetadata {
+              //         title
+              //         siteUrl
+              //       }
+              //     }
+              //     allMdx(
+              //       sort: {frontmatter: {date: DESC}}
+              //       limit: 20
+              //       filter: {
+              //         frontmatter: { published: { eq: true } }
+              //         fields: { collection: { eq: "resources" } }
+              //       }
+              //     ) {
+              //       nodes {
+              //         excerpt
+              //         frontmatter {
+              //           title
+              //           author
+              //           description
+              //           date
+              //           thumbnail {
+              //             publicURL
+              //           }
+              //         }
+              //         fields {
+              //           slug
+              //         }
+              //       }
+              //     }
+              //   }
+              // `,
+              //     serialize: ({ query: { site, allMdx } }) => {
+              //       return allMdx.nodes.map((node) => {
+              //         return Object.assign({}, node.frontmatter, {
+              //           title: node.frontmatter.title,
+              //           author: node.frontmatter.author,
+              //           description: node.frontmatter.description,
+              //           date: node.frontmatter.date,
+              //           url: site.siteMetadata.siteUrl + node.fields.slug,
+              //           guid: site.siteMetadata.siteUrl + node.fields.slug,
+              //           enclosure: node.frontmatter.thumbnail && {
+              //             url: site.siteMetadata.siteUrl + node.frontmatter.thumbnail.publicURL,
+              //           },
+              //           custom_elements: [{ "content:encoded": node.excerpt }],
+              //         });
+              //       });
+              //     },
+              //   },
+              // FEED 3: Meshery Community - targeted query with filters
+              {
+                output: "/meshery-community-feed.xml",
+                title: "Meshery RSSFeed",
+                query: `
               {
                 site {
                   siteMetadata {
@@ -319,52 +319,52 @@ module.exports = {
                 }
               }
             `,
-                  serialize: ({ query: { site, allMdx } }) => {
-                    const targetTags = ["Community", "Meshery", "mesheryctl"];
+                serialize: ({ query: { site, allMdx } }) => {
+                  const targetTags = ["Community", "Meshery", "mesheryctl"];
 
-                    return allMdx.nodes
-                      .filter((node) => {
-                        const hasTag =
+                  return allMdx.nodes
+                    .filter((node) => {
+                      const hasTag =
                           node.frontmatter.tags &&
                           node.frontmatter.tags.some((t) =>
                             targetTags.includes(t),
                           );
-                        return hasTag;
-                      })
-                      .slice(0, 30)
-                      .map((node) => {
-                        return Object.assign({}, node.frontmatter, {
-                          title: node.frontmatter.title,
-                          author: node.frontmatter.author,
-                          description:
+                      return hasTag;
+                    })
+                    .slice(0, 30)
+                    .map((node) => {
+                      return Object.assign({}, node.frontmatter, {
+                        title: node.frontmatter.title,
+                        author: node.frontmatter.author,
+                        description:
                             node.frontmatter.description ||
                             node.frontmatter.subtitle,
-                          date: node.frontmatter.date,
-                          url: site.siteMetadata.siteUrl + node.fields.slug,
-                          guid: site.siteMetadata.siteUrl + node.fields.slug,
-                          enclosure: node.frontmatter.thumbnail && {
-                            url:
+                        date: node.frontmatter.date,
+                        url: site.siteMetadata.siteUrl + node.fields.slug,
+                        guid: site.siteMetadata.siteUrl + node.fields.slug,
+                        enclosure: node.frontmatter.thumbnail && {
+                          url:
                               site.siteMetadata.siteUrl +
                               node.frontmatter.thumbnail.publicURL,
-                          },
-                          custom_elements: [
-                            { "content:encoded": node.excerpt },
-                            { "content:type": node.frontmatter.type },
-                            { "content:category": node.frontmatter.category },
-                            {
-                              "content:tags":
+                        },
+                        custom_elements: [
+                          { "content:encoded": node.excerpt },
+                          { "content:type": node.frontmatter.type },
+                          { "content:category": node.frontmatter.category },
+                          {
+                            "content:tags":
                                 node.frontmatter.tags?.join(", ") || "",
-                            },
-                          ],
-                        });
+                          },
+                        ],
                       });
-                  },
+                    });
                 },
-                // FEED 4: Blog - individual query
-                {
-                  output: "/blog/feed.xml",
-                  title: "Layer5 Blog",
-                  query: `
+              },
+              // FEED 4: Blog - individual query
+              {
+                output: "/blog/feed.xml",
+                title: "Layer5 Blog",
+                query: `
               {
                 site {
                   siteMetadata {
@@ -398,30 +398,30 @@ module.exports = {
                 }
               }
             `,
-                  serialize: ({ query: { site, allMdx } }) => {
-                    return allMdx.nodes.map((node) => {
-                      return Object.assign({}, node.frontmatter, {
-                        title: node.frontmatter.title,
-                        author: node.frontmatter.author,
-                        description: node.frontmatter.description,
-                        date: node.frontmatter.date,
-                        url: site.siteMetadata.siteUrl + node.fields.slug,
-                        guid: site.siteMetadata.siteUrl + node.fields.slug,
-                        enclosure: node.frontmatter.thumbnail && {
-                          url:
+                serialize: ({ query: { site, allMdx } }) => {
+                  return allMdx.nodes.map((node) => {
+                    return Object.assign({}, node.frontmatter, {
+                      title: node.frontmatter.title,
+                      author: node.frontmatter.author,
+                      description: node.frontmatter.description,
+                      date: node.frontmatter.date,
+                      url: site.siteMetadata.siteUrl + node.fields.slug,
+                      guid: site.siteMetadata.siteUrl + node.fields.slug,
+                      enclosure: node.frontmatter.thumbnail && {
+                        url:
                             site.siteMetadata.siteUrl +
                             node.frontmatter.thumbnail.publicURL,
-                        },
-                        custom_elements: [{ "content:encoded": node.excerpt }],
-                      });
+                      },
+                      custom_elements: [{ "content:encoded": node.excerpt }],
                     });
-                  },
+                  });
                 },
-                // FEED 5: Events - individual query
-                {
-                  output: "/events/feed.xml",
-                  title: "Layer5 Events",
-                  query: `
+              },
+              // FEED 5: Events - individual query
+              {
+                output: "/events/feed.xml",
+                title: "Layer5 Events",
+                query: `
               {
                 site {
                   siteMetadata {
@@ -455,35 +455,35 @@ module.exports = {
                 }
               }
             `,
-                  serialize: ({ query: { site, allMdx } }) => {
-                    return allMdx.nodes.map((node) => {
-                      return Object.assign({}, node.frontmatter, {
-                        title: node.frontmatter.title,
-                        author: node.frontmatter.author,
-                        description: node.frontmatter.description,
-                        date: node.frontmatter.date,
-                        url: site.siteMetadata.siteUrl + node.fields.slug,
-                        guid: site.siteMetadata.siteUrl + node.fields.slug,
-                        enclosure: node.frontmatter.thumbnail && {
-                          url:
+                serialize: ({ query: { site, allMdx } }) => {
+                  return allMdx.nodes.map((node) => {
+                    return Object.assign({}, node.frontmatter, {
+                      title: node.frontmatter.title,
+                      author: node.frontmatter.author,
+                      description: node.frontmatter.description,
+                      date: node.frontmatter.date,
+                      url: site.siteMetadata.siteUrl + node.fields.slug,
+                      guid: site.siteMetadata.siteUrl + node.fields.slug,
+                      enclosure: node.frontmatter.thumbnail && {
+                        url:
                             site.siteMetadata.siteUrl +
                             node.frontmatter.thumbnail.publicURL,
-                        },
-                        custom_elements: [{ "content:encoded": node.excerpt }],
-                      });
+                      },
+                      custom_elements: [{ "content:encoded": node.excerpt }],
                     });
-                  },
+                  });
                 },
-              ],
-            },
+              },
+            ],
           },
-          {
-            resolve: "gatsby-plugin-purgecss",
-            options: {
-              printRejected: true,
-            },
+        },
+        {
+          resolve: "gatsby-plugin-purgecss",
+          options: {
+            printRejected: true,
           },
-        ]
+        },
+      ]
       : []),
     // End of Production-only Plugins
     {


### PR DESCRIPTION
**Description**

### gatsby-config.js
- In CI, the workflow sets PATH_PREFIX to the folder segment where the preview will live (e.g. pr-preview/pr-5).
- Gatsby reads pathPrefix: the leading / turns that into a path such as /pr-preview/pr-5.
- With npm run build:preview (gatsby build --prefix-paths), Gatsby rewrites asset and page links so they start with that prefix (e.g. /pr-preview/pr-5/app-….js).
- pathPrefix is only set when PATH_PREFIX is set, so a normal production build (no env var) stays a root deploy and is unchanged.

the workflow make the build which subpath the preview uses; gatsby-config.js applies that as pathPrefix so every script and style loads from the right place and the page can run as a full interactive app.


This PR fixes #

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
