### PR TITLE
fix(nav): shorten hover dropdown linger

### DIFF
--- a/src/sections/General/Navigation/navigation.style.js
+++ b/src/sections/General/Navigation/navigation.style.js
@@ -156,9 +156,11 @@ const NavigationWrap = styled.header`
     width: 120%;
     display: block;
     box-shadow: 0px 5px 10px 1px rgba(0, 179, 159, 0.5);
-    animation: bobbleout ease 0.18s forwards;
+    animation: bobbleout ease 0.12s forwards;
     pointer-events: none;
-    transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
+    transition:
+      opacity 0.12s ease-out,
+      transform 0.12s ease-out;
   }
   .wrap {
     display: block;
@@ -367,7 +369,7 @@ const NavigationWrap = styled.header`
     }
   }
   ul:hover > ul {
-    animation: bobble ease 0.3s forwards;
+    animation: bobble ease 0.18s forwards;
     pointer-events: auto;
     visibility: visible;
   }
@@ -655,8 +657,8 @@ const NavigationWrap = styled.header`
       padding-top: 0.4rem;
     }
     .mobile-nested-menu {
-       font-size: 1.1rem;
-       margin-left: 1rem;
+      font-size: 1.1rem;
+      margin-left: 1rem;
     }
   }
 
@@ -771,7 +773,7 @@ const NavigationWrap = styled.header`
   .dark-theme-toggle {
     /* margin-left: 2rem; */
     visibility: ${(props) =>
-  typeof props.theme.DarkTheme === "boolean" ? "visible" : "hidden"};
+      typeof props.theme.DarkTheme === "boolean" ? "visible" : "hidden"};
   }
 
   .toggle {
@@ -794,7 +796,8 @@ const NavigationWrap = styled.header`
     --offset-diagonal: calc(var(--size) * 0.45);
     transform: scale(0.75);
     color: #3c494f;
-    box-shadow: inset 0 0 0 var(--size),
+    box-shadow:
+      inset 0 0 0 var(--size),
       calc(var(--offset-orthogonal) * -1) 0 0 var(--ray-size),
       var(--offset-orthogonal) 0 0 var(--ray-size),
       0 calc(var(--offset-orthogonal) * -1) 0 var(--ray-size),


### PR DESCRIPTION
## Description
- shorten the desktop nav dropdown hover animation used around the MeshMap playground entry
- limit the dropdown transition to quick opacity/transform timing instead of the longer generic nav transition

## Related Issues
- Fixes #7644

## Changes Made
- reduced the dropdown exit animation from `0.18s` to `0.12s`
- reduced the dropdown open animation from `0.3s` to `0.18s`
- replaced the dropdown's long `0.8s` transition with a short dropdown-specific opacity/transform transition

## Checklist
- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Validation
- `npx --yes prettier --check src/sections/General/Navigation/navigation.style.js`
- verified the updated dropdown timing values in `navigation.style.js`