### PR TITLE
fix(rss): prevent undefined in siteRootUrl generation

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -17,7 +17,7 @@ const rawPrefix = process.env.PATH_PREFIX;
 const pathPrefix =
   rawPrefix && String(rawPrefix).trim().length
     ? `/${String(rawPrefix).replace(/^\/+|\/+$/g, "")}`
-    : undefined;
+    : "";
 
 const siteRootUrl = `${siteOrigin}${pathPrefix}`.replace(/\/$/, "");
 const shouldBuildFullSite = isFullSiteBuild();


### PR DESCRIPTION
**Description**

Fixes a bug in gatsby-config.js where pathPrefix defaulted to undefined instead of an empty string. This fixes an issue where the RSS feed (meshery-community-feed.xml) was generating broken URLs like `https://layer5.ioundefined/static/..`

**Refer : https://layer5.io/meshery-community-feed.xml**

<img width="1920" height="904" alt="image" src="https://github.com/user-attachments/assets/015eba6c-6a43-4afd-a154-e28f68a59092" />

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
