### PR TITLE
fix: update Join Now button to dynamically link to recent event page

### DIFF
--- a/src/components/UpcomingEventCard/index.js
+++ b/src/components/UpcomingEventCard/index.js
@@ -52,9 +52,12 @@ const UpcomingEvents = ({ data }) => {
                       <Button
                         $secondary
                         className="blog-slider_button"
-                        $url={item.frontmatter.eurl}
+                        $url={
+                          item.frontmatter.eurl ||
+                          `/community/events/${slugify(item.frontmatter.title)}`
+                        }
                         title="Join Now"
-                        $external={true}
+                        $external={!!item.frontmatter.eurl}
                       />
                     </div>
                   </div>


### PR DESCRIPTION
**Description**
This PR fixes #7649

The "Join Now" button on /community/events page was not working for recent events. 
When a new event did not have an `eurl` field in its frontmatter, the button had no 
fallback and would break.

**Changes Made**
- Added fallback URL so that if `eurl` is missing, button redirects to the event's own page
- Changed `$external={true}` to `$external={!!item.frontmatter.eurl}` so external link 
  only opens in new tab when eurl is present

**Notes for Reviewers**
The fix is in `src/components/UpcomingEventCard/index.js` in the Button component.
Button now dynamically handles both cases:
1. When `eurl` is present → opens external join link
2. When `eurl` is missing → redirects to event detail page

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

https://github.com/user-attachments/assets/bbc38fc9-b2ff-43a9-a50e-7e965e36601b

