### PR TITLE
fix: correct 'Unbuntu' typo to 'Ubuntu' on Nighthawk page

### DIFF
--- a/src/sections/Projects/Nighthawk/index.js
+++ b/src/sections/Projects/Nighthawk/index.js
@@ -127,7 +127,7 @@ const Projects = () => {
                   <ul>
                     <li>Debian</li>
                     <li>CentOS</li>
-                    <li>Unbuntu</li>
+                    <li>Ubuntu</li>
                     <li>macOS</li>
                     <li>Docker</li>
                   </ul>


### PR DESCRIPTION
Fixes #7651.

The Nighthawk Distribution list on `layer5.io/projects/nighthawk` listed `Unbuntu` instead of `Ubuntu`. Fix in `src/sections/Projects/Nighthawk/index.js`.

## Signed commits

- [x] Yes, I signed my commits.