### PR TITLE
[DOCS] Fix: added scroll-padding-top to prevent headers hiding under navbar

### DIFF
--- a/src/sections/app.style.js
+++ b/src/sections/app.style.js
@@ -49,6 +49,7 @@ html{
     overflow-x: hidden;
     box-sizing: border-box;
     -ms-overflow-style: scrollbar;
+    scroll-padding-top: 5rem;
 }
 
 body,html {


### PR DESCRIPTION
**Description**

This PR fixes #7646
Added `scroll-padding-top: 5rem` to the global `html` styles in 
`app.style.js` to prevent anchor link targets from being hidden 
under the sticky navbar when navigating via on-page links.

**Notes for Reviewers**
Single line CSS change in `src/sections/app.style.js`
Value `5rem` matches the approximate navbar height

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
