### PR TITLE
blog: Discover Meshery Components with mesheryctl

### DIFF
--- a/src/collections/blog/2026/05-01-discover-meshery-components-mesheryctl/hero-image.svg
+++ b/src/collections/blog/2026/05-01-discover-meshery-components-mesheryctl/hero-image.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%"   stop-color="#1E2117"/>
+      <stop offset="14%"  stop-color="#3C494F"/>
+      <stop offset="28%"  stop-color="#375154"/>
+      <stop offset="42%"  stop-color="#305D5D"/>
+      <stop offset="55%"  stop-color="#266E6A"/>
+      <stop offset="68%"  stop-color="#1A847B"/>
+      <stop offset="80%"  stop-color="#0B9E8F"/>
+      <stop offset="92%"  stop-color="#00B39F"/>
+      <stop offset="100%" stop-color="#00D3A9"/>
+    </linearGradient>
+
+    <radialGradient id="clearing" cx="78%" cy="48%" r="42%">
+      <stop offset="0%"   stop-color="#FFFFFF" stop-opacity="0.85"/>
+      <stop offset="22%"  stop-color="#F7FCFC" stop-opacity="0.55"/>
+      <stop offset="46%"  stop-color="#BFEBE7" stop-opacity="0.28"/>
+      <stop offset="72%"  stop-color="#52CBBE" stop-opacity="0.10"/>
+      <stop offset="100%" stop-color="#00B39F" stop-opacity="0"/>
+    </radialGradient>
+
+    <radialGradient id="saffronGlow" cx="14%" cy="18%" r="32%">
+      <stop offset="0%"   stop-color="#FFF3C5" stop-opacity="0.55"/>
+      <stop offset="40%"  stop-color="#EBC017" stop-opacity="0.22"/>
+      <stop offset="100%" stop-color="#EBC017" stop-opacity="0"/>
+    </radialGradient>
+
+    <linearGradient id="textScrim" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%"   stop-color="#1E2117" stop-opacity="0.55"/>
+      <stop offset="55%"  stop-color="#1E2117" stop-opacity="0.22"/>
+      <stop offset="100%" stop-color="#1E2117" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="630" fill="url(#bgGrad)"/>
+  <rect width="1200" height="630" fill="url(#saffronGlow)"/>
+  <rect width="1200" height="630" fill="url(#clearing)"/>
+
+  <!-- Orbital rings -->
+  <ellipse cx="1130" cy="-50" rx="310" ry="310"
+           fill="none" stroke="#00B39F" stroke-opacity="0.10" stroke-width="1"/>
+  <ellipse cx="1130" cy="-50" rx="380" ry="380"
+           fill="none" stroke="#00B39F" stroke-opacity="0.06" stroke-width="1"/>
+
+  <!-- Stylized terminal block, evoking mesheryctl -->
+  <g transform="translate(820,210)">
+    <rect x="0" y="0" width="320" height="200" rx="10"
+          fill="#1E2117" fill-opacity="0.92" stroke="#00B39F" stroke-opacity="0.55" stroke-width="1.5"/>
+    <circle cx="22" cy="22" r="6" fill="#EBC017" fill-opacity="0.85"/>
+    <circle cx="42" cy="22" r="6" fill="#00D3A9" fill-opacity="0.85"/>
+    <circle cx="62" cy="22" r="6" fill="#477E96" fill-opacity="0.85"/>
+    <text x="22" y="78" font-family="'Courier New', monospace" font-size="15" fill="#FFF3C5">$ mesheryctl</text>
+    <text x="22" y="106" font-family="'Courier New', monospace" font-size="15" fill="#FFFFFF">  component list</text>
+    <text x="22" y="138" font-family="'Courier New', monospace" font-size="15" fill="#FFF3C5">$ mesheryctl</text>
+    <text x="22" y="166" font-family="'Courier New', monospace" font-size="15" fill="#FFFFFF">  component search istio</text>
+  </g>
+
+  <!-- Text-side scrim -->
+  <rect x="0" y="0" width="640" height="630" fill="url(#textScrim)"/>
+
+  <!-- Left teal accent bar -->
+  <rect x="0" y="0" width="8" height="630" fill="#00B39F" opacity="0.95"/>
+
+  <!-- Category pill -->
+  <rect x="60" y="178" width="140" height="28" rx="4" fill="#00B39F"/>
+  <text x="76" y="197" font-family="'Helvetica Neue', Arial, sans-serif"
+        font-size="12" font-weight="bold" letter-spacing="2" fill="#FFFFFF">MESHERY</text>
+
+  <!-- Pill-aligned separator -->
+  <rect x="60" y="218" width="140" height="1" fill="#00B39F" opacity="0.55"/>
+
+  <!-- Title -->
+  <text x="60" y="280" font-family="'Helvetica Neue', Arial, sans-serif"
+        font-size="48" font-weight="bold" fill="#FFFFFF">Discover Meshery</text>
+  <text x="60" y="334" font-family="'Helvetica Neue', Arial, sans-serif"
+        font-size="48" font-weight="bold" fill="#FFFFFF">Components with</text>
+  <text x="60" y="388" font-family="'Helvetica Neue', Arial, sans-serif"
+        font-size="48" font-weight="bold" fill="#00D3A9">mesheryctl</text>
+
+  <!-- Subtitle -->
+  <text x="60" y="438" font-family="'Helvetica Neue', Arial, sans-serif"
+        font-size="21" fill="#BFEBE7">A quick tip for new Meshery operators</text>
+
+  <!-- Bottom bar -->
+  <rect x="0" y="580" width="1200" height="50" fill="#1E2117" opacity="0.88"/>
+  <rect x="0" y="580" width="1200" height="4" fill="#00B39F" opacity="0.90"/>
+  <text x="60" y="615" font-family="'Helvetica Neue', Arial, sans-serif"
+        font-size="13" fill="#BFEBE7" opacity="0.75">layer5.io  -  Making Engineers Expect More from Their Infrastructure</text>
+</svg>

--- a/src/collections/blog/2026/05-01-discover-meshery-components-mesheryctl/index.mdx
+++ b/src/collections/blog/2026/05-01-discover-meshery-components-mesheryctl/index.mdx
@@ -1,0 +1,94 @@
+---
+title: "Discover Meshery Components with mesheryctl"
+subtitle: "A quick tip for finding what you can deploy, right after install"
+date: 2026-05-01 10:00:00 -0500
+author: Layer5 Team
+thumbnail: ./hero-image.svg
+darkthumbnail: ./hero-image.svg
+description: "Use mesheryctl component list and search to inventory every model registered in your Meshery server, then find the same components in Kanvas."
+type: Blog
+category: Meshery
+tags:
+  - Meshery
+  - mesheryctl
+  - Kanvas
+  - Platform Engineering
+featured: false
+published: true
+resource: true
+product: Meshery
+---
+
+import { BlogWrapper } from "../../Blog.style.js";
+import { Link } from "gatsby";
+import Blockquote from "../../../../reusecore/Blockquote";
+import Callout from "../../../../reusecore/Callout";
+import CTA_FullWidth from "../../../../components/Call-To-Actions/CTA_FullWidth";
+import CTAImg from "../../../../assets/images/meshery/icon-only/meshery-logo-shadow.webp";
+import heroImage from "./hero-image.svg";
+
+<BlogWrapper>
+
+<div className="intro">
+  <p>
+    You just finished <code>mesheryctl system start</code> and the server is up. Before you draft a design, you need to know what you can actually drop on the canvas - which models are registered, which versions are available, and whether that obscure CRD you care about is one of them. The fastest path is two commands and the Kanvas component browser, and it takes about a minute.
+  </p>
+</div>
+
+<img
+  src={heroImage}
+  className="image-center-shadow"
+  alt="A terminal showing mesheryctl component list and search commands against a Layer5 cosmic backdrop"
+/>
+
+## Inventory everything with `mesheryctl component list`
+
+Run <code>mesheryctl component list</code> and Meshery prints a paginated table of every component its registry knows about - Name, Model, Category, and Version. By default you get ten rows per page; pass <code>--page</code> to walk through the rest, or <code>--pagesize</code> to widen the view, or just <code>--count</code> to get the headline number for a slide.
+
+```bash
+mesheryctl component list
+mesheryctl component list --page 3 --pagesize 50
+mesheryctl component list --count
+```
+
+That count is the truth on your specific server. It reflects every model you've imported, every integration that ships out of the box, and any custom component packages your team has registered. If a component isn't in this list, Kanvas can't draw it and Meshery can't deploy it - which makes <code>component list</code> the canonical "what's installed" check.
+
+<Blockquote quote="If it isn't in mesheryctl component list, Kanvas can't draw it and Meshery can't deploy it." />
+
+## Filter by topic with `mesheryctl component search`
+
+Once the catalog gets big, scrolling stops being useful. <code>mesheryctl component search &lt;query&gt;</code> hits the same registry but filters by name, so <code>mesheryctl component search istio</code> returns only Istio-related components, and <code>mesheryctl component search prometheus</code> narrows it to Prometheus and its operands.
+
+```bash
+mesheryctl component search istio
+mesheryctl component search prometheus
+mesheryctl component search "aws s3"
+```
+
+The search is the fastest way to confirm a model is actually registered before you commit to a design. If <code>search</code> returns nothing, the integration probably isn't imported yet - check the <a href="https://docs.meshery.io/concepts/logical/components" target="_blank" rel="noopener noreferrer">Meshery components documentation</a> for the import flow, or browse <Link to="/cloud-native-management/meshery/integrations">Meshery's integrations</Link> to see what's available upstream.
+
+## Browse the same registry visually in Kanvas
+
+Open <Link to="/kanvas">Kanvas</Link> and the left sidebar's component browser is reading from exactly the same registry your CLI just queried. Type the same search term into the browser's filter and you'll see the components you found in the terminal, grouped by model and category, ready to drag onto the canvas. The CLI is faster for inventory and scripting; the browser is faster for actually building.
+
+<Callout type="tip" title="Two views, one source of truth">
+  <p>The CLI and the Kanvas component browser hit the same Meshery registry. If you imported a model with <code>mesheryctl model import</code>, it shows up in both immediately - no restart, no re-login.</p>
+</Callout>
+
+<CTA_FullWidth
+  image={CTAImg}
+  heading="Get Started with Meshery"
+  alt="Meshery - Cloud Native Manager"
+  content="Meshery is the open source, cloud native management plane for Kubernetes and cloud native infrastructure."
+  button_text="Get Meshery"
+  url="/cloud-native-management/meshery"
+  external_link={false}
+/>
+
+<div className="outro">
+  <p>
+    Pin this post next to your terminal. When you're ready to go deeper, head to the <Link to="/cloud-native-management/meshery/meshery-playground">Meshery Playground</Link> or join the conversation in the <a href="https://slack.layer5.io" target="_blank" rel="noopener noreferrer">Layer5 Slack</a>.
+  </p>
+</div>
+
+</BlogWrapper>


### PR DESCRIPTION
Adds the `discover-meshery-components-mesheryctl` blog post under `src/collections/blog/2026/` - a 3-paragraph quick tip walking through `mesheryctl component list`, `mesheryctl component search`, and the matching Kanvas component browser view.