### PR TITLE
Add Employee badge and member filter option

### DIFF
--- a/src/collections/handbook/recognition/badges-data.js
+++ b/src/collections/handbook/recognition/badges-data.js
@@ -32,6 +32,7 @@ import uiuxrLogo from "../../../assets/images/uiuxr/uiuxr.svg";
 import MesheryCatalogLogo from "../../../assets/images/meshery/meshery-catalog.svg";
 import DockerExtension from "../../../assets/images/docker-extension/docker-extension-meshery-logo.svg";
 import DocsLogo from "../../../assets/images/docs/docs.svg";
+import Layer5Logo from "../../../assets/images/layer5/5 icon/svg/light/5-light-no-trim.svg";
 
 export const activityBadges = [
   { name: "Design Pioneer", title: "Design Pioneer", badgeKey: "first-design", image: DesignPioneerLogo, description: "Awarded to the Layer5 cloud users when they create their first design." },
@@ -76,6 +77,7 @@ export const projectBadges = [
   { name: "Meshery Catalog", title: "Meshery Catalog", badgeKey: "meshery-catalog", image: MesheryCatalogLogo, description: <>Awarded to the community members who make consistent and impactful contributions to the <a href="https://meshery.io/catalog">Meshery Catalog</a> of Meshery project in recognition and appreciation of their efforts.</> },
   { name: "Docker Extension", title: "Docker Extension", badgeKey: "docker-extension", image: DockerExtension, description: "Awarded to the community members who make consistent and impactful contributions to the Docker Extension of meshery project in recognition and appreciation of their efforts." },
   { name: "Docs", title: "Docs", badgeKey: "docs", image: DocsLogo, description: <>Awarded to the community members who make consistent and impactful contributions to the <a href="https://docs.meshery.io/">Meshery docs</a> in recognition and appreciation of their efforts.</> },
+  { name: "Employee", title: "Employee", badgeKey: "employee", image: Layer5Logo, description: "Awarded to Layer5 employees in recognition of their contributions and role within the organization." },
 ];
 
 export const specialBadges = [

--- a/src/pages/community/members.js
+++ b/src/pages/community/members.js
@@ -162,6 +162,14 @@ const options = [
     className: "allOptions",
   },
   {
+    label: "Employee",
+    value: "employee",
+    color: lighttheme.linkColor,
+    isFixed: true,
+    icon: icon5,
+    className: "allOptions",
+  },
+  {
     label: "STATUS",
     value: "",
     color: lighttheme.linkColor,
@@ -223,14 +231,6 @@ const options = [
     color: lighttheme.linkColor,
     isFixed: true,
     icon: communityIcon,
-    className: "allOptions",
-  },
-  {
-    label: "Employee",
-    value: "employee",
-    color: lighttheme.linkColor,
-    isFixed: true,
-    icon: icon5,
     className: "allOptions",
   },
 ].map((obj) => ({

--- a/src/pages/community/members.js
+++ b/src/pages/community/members.js
@@ -225,6 +225,14 @@ const options = [
     icon: communityIcon,
     className: "allOptions",
   },
+  {
+    label: "Employee",
+    value: "employee",
+    color: lighttheme.linkColor,
+    isFixed: true,
+    icon: icon5,
+    className: "allOptions",
+  },
 ].map((obj) => ({
   ...obj,
   label: (


### PR DESCRIPTION
## Add Employee Badge and Filter Option

### Description

This PR implements an "Employee" badge to recognize Layer5 employees on the community members page.

### Changes:
- Imported the Layer5 logo and created a new **Employee** badge under the **Project Badges** section in `badges-data.js`.
- Added a new filter option in `pages/community/members.js`:
  - **value:** `"employee"`
  - **color:** `lighttheme.linkColor`
  - **icon:** `icon5`
- Ensured employees can be filtered on the members page using this new category.

This follows the discussion in the issue where it was clarified to add the badge under **Project Badges**.

Fixes #6277
---

### Notes for Reviewers
- The badge uses the Layer5 icon as requested.
- Placement confirmed under **Project Badges** (not Activity or Special Recognition).
- Filter integration tested on the members page.
- Let me know if naming, description, or icon styling needs adjustment.

---

### [Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)
- [ ] Yes, I signed my commits.