### PR TITLE
Fix typo in recognition handbook: Bages→Badges

### DIFF
--- a/src/collections/handbook/recognition/index.mdx
+++ b/src/collections/handbook/recognition/index.mdx
@@ -4,8 +4,8 @@ description: "Layer5 readily recognizes and publicly appreciates its community m
 type: Handbook
 contents:
   - id: 0
-    link: "#Profile Bages"
-    text: "Profile Bages"
+    link: "#Profile Badges"
+    text: "Profile Badges"
   - id: 1
     link: "#Membership"
     text: "Membership to GitHub"


### PR DESCRIPTION
## Description
Corrects a spelling mistake in `src/collections/handbook/recognition/index.mdx` by updating both the link anchor and display text from **"Profile Bages"** to **"Profile Badges"**.

This ensures the internal link and label use the correct spelling and improves consistency in the UI.

This PR fixes  #7685

---

## Notes for Reviewers
- Updated both:
  - `link: "#Profile Badges"`
  - `text: "Profile Badges"`
- No functional changes, only a text correction.
- Verified that the anchor and navigation remain consistent.

---

## Screenshots (if applicable)
<img width="206" height="305" alt="Screenshot 2026-05-02 at 2 53 41 AM" src="https://github.com/user-attachments/assets/40e6ea3e-4ef5-4c9b-9878-db8dc1c023ec" />

---

## [Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)
- [ ] Yes, I signed my commits.

---

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->