### PR TITLE
Fix Adventures callout width prop

### DIFF
--- a/src/sections/Adventures-Callout/discuss.style.js
+++ b/src/sections/Adventures-Callout/discuss.style.js
@@ -8,7 +8,7 @@ const AdventuresWrapper = styled.div`
         font-weight: 500;
     }
     h2 span{
-        color:${props => props.theme.secondaryColor};
+        color:${(props) => props.theme.secondaryColor};
     }
     .logo{
         width: 100%;
@@ -18,11 +18,11 @@ const AdventuresWrapper = styled.div`
         text-align: center;
         p { 
             text-align: center;
-            color: ${props => props.theme.white};
+            color: ${(props) => props.theme.white};
             padding: 0px 3.125rem;
         }
         h2 {
-            color: ${props => props.theme.white}; 
+            color: ${(props) => props.theme.white}; 
             line-height: 1.2;
         }
         h1 {
@@ -41,6 +41,7 @@ const AdventuresWrapper = styled.div`
                 padding: 1.25rem;
                 background-color: #1E2117; 
                 border-radius: 25px;
+                overflow: hidden;
                 p {
                     text-align: center;
                     padding: 0px 0px 1px 0px;
@@ -70,8 +71,8 @@ const AdventuresWrapper = styled.div`
 
     button{
         color: #1E2117;
-        padding: 0.2em 1em;
-        border: 2px solid;
+        padding: 0;
+        border: 0;
         background: none;
         transition: color 0.25s,border-color 0.25s,transform 0.25s,box-shadow 0.25s;
         cursor: pointer;

--- a/src/sections/Adventures-Callout/index.js
+++ b/src/sections/Adventures-Callout/index.js
@@ -6,22 +6,30 @@ import AdventuresWrapper from "./discuss.style";
 
 const Adventure = "../../assets/images/adventure-five/layer_five.webp";
 
-
 const AdventuresCallout = () => {
   return (
     <AdventuresWrapper>
       <div className="explain">
         <div className="cards">
           <Col lg={12} md={12} sm={12}>
-            <a target="_blank" href="/community/adventures-of-five-and-friends" rel="noreferrer">
+            <a
+              target="_blank"
+              href="/community/adventures-of-five-and-friends"
+              rel="noreferrer"
+            >
               <div className="card">
                 <div className="parentcard">
-                  <SectionTitle className="section-title" UniWidth="100%">
+                  <SectionTitle className="section-title" $UniWidth="100%">
                     <h2>Adventures of Five & Friends</h2>
                     {/*<p>Meet Five, our intergalatic Cloud Native Hero</p>*/}
 
-                    <button><StaticImage className="logo" alt="Adventures of Five & Friends" src={Adventure} /></button>
-
+                    <button>
+                      <StaticImage
+                        className="logo"
+                        alt="Adventures of Five & Friends"
+                        src={Adventure}
+                      />
+                    </button>
                   </SectionTitle>
                 </div>
               </div>


### PR DESCRIPTION
**Root cause:**

`SectionTitle` reads `$UniWidth`, but the callout passed `UniWidth`, so the width override was ignored and the content collapsed to the default 40%.
The image also appeared outside the card because the button added padding/border and the card didn’t clip overflow.

**Fix:**
- Use` $UniWidth`="100%" so SectionTitle gets the intended width.
- Keep the image inside the card by clipping overflow and removing button padding/border.

**Before:**

<img width="600" height="250" alt="image" src="https://github.com/user-attachments/assets/f322c97b-b425-441a-9c88-fdd8a3bdf215" />

**After:**

<img width="600" height="250" alt="image" src="https://github.com/user-attachments/assets/95d90f94-f593-4b96-be3b-94c08bd05a2b" />



**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
