### PR TITLE
docs: add Meshery Relationships tutorial to newcomers tutorials table (#7696)

### DIFF
--- a/src/assets/data/tutorials/index.js
+++ b/src/assets/data/tutorials/index.js
@@ -202,6 +202,19 @@ const data = [
             },
         ],
     },
+    {
+        date: "2026-05-01",
+        topic: "Meshery Relationships",
+        resources: {
+            recording: "https://www.youtube.com/live/IJ0wtrQWxhw"
+        },
+        presenters: [
+            {
+                link: "/community/members/yash-vilas-mahakal",
+                name: "Yash Vilas Mahakal"
+            },
+        ],
+    },
 ];
 
 export default data;


### PR DESCRIPTION
Adds the 2026-05-01 Meshery Relationships tutorial to the newcomers tutorials table.

Closes #7696.

### Entry

- Date: 2026-05-01
- Topic: Meshery Relationships
- Recording: https://www.youtube.com/live/IJ0wtrQWxhw
- Presenter: [Yash Vilas Mahakal](/community/members/yash-vilas-mahakal)

The issue's slides field was left blank, so the `slides` key is omitted from the resources block; the 2020-10-01 entry (Vijay Cherukuri, "An Introduction to Contributing to Meshery") already uses the same recording-only shape, so the existing `TutorialsTable` renderer handles it.

### Change Type

- [x] Documentation