### PR TITLE
fix: add margin-bottom to heading in Working on Your Issue section

### DIFF
--- a/src/sections/Community/Newcomers-guide/index.js
+++ b/src/sections/Community/Newcomers-guide/index.js
@@ -12,7 +12,8 @@ import longArrow from "./long-arrow.svg";
 import { StaticImage } from "gatsby-plugin-image";
 
 const CommunityImage2 = "../Community-pictures/five-finding-issue.webp";
-const CommunityImage3 = "../../../assets/images/newcomers-page-images/community-collage.webp";
+const CommunityImage3 =
+  "../../../assets/images/newcomers-page-images/community-collage.webp";
 const FiveWorking = "../Community-pictures/five-working.webp";
 const CommunityHandbook = "../Community-pictures/community-handbook.webp";
 
@@ -25,19 +26,25 @@ const NewcomersGuide = () => {
       <Container>
         <div className="newcomers-welcome">
           <p>
-            Whether you are a first time contributor or an open source
-            veteran, you are welcome to contribute to and actively engage in the
+            Whether you are a first time contributor or an open source veteran,
+            you are welcome to contribute to and actively engage in the
             development of projects at Layer5. Here are some instructions to get
             you started and if you haven’t joined yet, join the{" "}
             <a href="https://slack.layer5.io/" target="_blank" rel="noreferrer">
               Slack workspace
             </a>{" "}
-            to collaborate with the community and the <a href="https://discuss.layer5.io" target="">discussion forum</a> for questions. Also, you can check the
-            quick-links below for jumping straight into things.
+            to collaborate with the community and the{" "}
+            <a href="https://discuss.layer5.io" target="">
+              discussion forum
+            </a>{" "}
+            for questions. Also, you can check the quick-links below for jumping
+            straight into things.
           </p>
-          <Row style={{
-            flexWrap: "wrap"
-          }} className="newcomers-journey"
+          <Row
+            style={{
+              flexWrap: "wrap",
+            }}
+            className="newcomers-journey"
           >
             <Col
               className="heading"
@@ -61,34 +68,44 @@ const NewcomersGuide = () => {
           </Row>
           <Row className="how-to-contribute">
             <p>
-              These steps outline the process by which you can
-              openly engage, learn, and participate in the broad set of open
-              source projects at Layer5. If at any time you get stuck, please
-              seek help in the{" "}
+              These steps outline the process by which you can openly engage,
+              learn, and participate in the broad set of open source projects at
+              Layer5. If at any time you get stuck, please seek help in the{" "}
               <a
                 href="https://discuss.layer5.io"
                 target="_blank"
                 rel="noreferrer"
               >
                 community forum
-              </a>{""}.
-              Our{" "}
-              <Link to="/community/meshmates">MeshMates</Link> and community
-              members are here to help!
+              </a>
+              {""}. Our <Link to="/community/meshmates">MeshMates</Link> and
+              community members are here to help!
             </p>
           </Row>
         </div>
         <div className="instructions">
-          <Row style={{
-            flexWrap: "wrap"
-          }} className="step"
+          <Row
+            style={{
+              flexWrap: "wrap",
+            }}
+            className="step"
           >
             <Col $sm={12} $lg={6}>
               <h3>Fill in the Community Member Form</h3>
-              <p>Help us get to know you, so that we can highlight projects and initiatives that align with your interests. Fill-in a community member form. Gain access to community resources.</p>
+              <p>
+                Help us get to know you, so that we can highlight projects and
+                initiatives that align with your interests. Fill-in a community
+                member form. Gain access to community resources.
+              </p>
             </Col>
             <Col $sm={12} $lg={6} className="col-newcomers-form">
-              <Button $primary className="newcomers-form" title="Submit a Member Form" $url="/newcomer" $external={false} />
+              <Button
+                $primary
+                className="newcomers-form"
+                title="Submit a Member Form"
+                $url="/newcomer"
+                $external={false}
+              />
             </Col>
             <Col $sm={12} $lg={6} className="col-finding-an-issue">
               <div className="finding-an-issue">
@@ -97,7 +114,14 @@ const NewcomersGuide = () => {
             </Col>
             <Col $sm={12} $lg={6}>
               <h3>Finding an Issue to Work On</h3>
-              <p>Note that the Layer5 community spans six GitHub organizations. See all in the <Link to="/community/handbook/repository-overview">repository overview</Link>.</p>
+              <p>
+                Note that the Layer5 community spans six GitHub organizations.
+                See all in the{" "}
+                <Link to="/community/handbook/repository-overview">
+                  repository overview
+                </Link>
+                .
+              </p>
               <ol type="i">
                 <li>
                   Browse the list of{" "}
@@ -131,10 +155,12 @@ const NewcomersGuide = () => {
                   ” label.
                 </li>
                 <li>
-                  Find an area of interest by perusing the list of projects by repository and technology in the{" "}
+                  Find an area of interest by perusing the list of projects by
+                  repository and technology in the{" "}
                   <Link to="/community/handbook/repository-overview/">
                     Layer5 Repository Overview
-                  </Link>.
+                  </Link>
+                  .
                 </li>
                 <li>
                   After identifying the issue you wish to work on, check whether
@@ -145,12 +171,15 @@ const NewcomersGuide = () => {
               </ol>
             </Col>
           </Row>
-          <Row style={{
-            flexWrap: "wrap"
-          }} className="step"
+          <Row
+            style={{
+              flexWrap: "wrap",
+            }}
+            className="step"
           >
             <Col $sm={12} $lg={6}>
               <h3>Working on Your Issue</h3>
+              <p>Follow these steps once an issue has been assigned to you.</p>
               <ol type="i">
                 <li>
                   Once an issue has been assigned to you, it’s time to get
@@ -193,7 +222,8 @@ const NewcomersGuide = () => {
                   >
                     #newcomers
                   </a>{" "}
-                  channel in our Slack workspace. Introduce yourself and ask questions.
+                  channel in our Slack workspace. Introduce yourself and ask
+                  questions.
                 </li>
               </ol>
             </Col>
@@ -203,10 +233,16 @@ const NewcomersGuide = () => {
           </Row>
           <Row style={{ flexWrap: "wrap" }} className="step">
             <Col $sm={12} $lg={6} className="community-collage">
-              <a className="book-container" href="https://layer5.io/community/handbook/">
+              <a
+                className="book-container"
+                href="https://layer5.io/community/handbook/"
+              >
                 <div className="book">
                   <div>
-                    <StaticImage src={CommunityHandbook} alt="Community Image" />
+                    <StaticImage
+                      src={CommunityHandbook}
+                      alt="Community Image"
+                    />
                   </div>
                 </div>
               </a>
@@ -214,10 +250,11 @@ const NewcomersGuide = () => {
             <Col $sm={12} $lg={6}>
               <h3>Explore the Meshery Community</h3>
               <p>
-              The community is growing at a tremendous rate. We value our connections
-              and that is what makes us unique. Whether it is your first meeting or
-              your tenth contribution, we want to make sure that you are supported and
-              equipped to take advantage of all of that the community has to offer.
+                The community is growing at a tremendous rate. We value our
+                connections and that is what makes us unique. Whether it is your
+                first meeting or your tenth contribution, we want to make sure
+                that you are supported and equipped to take advantage of all of
+                that the community has to offer.
               </p>
             </Col>
           </Row>
@@ -229,22 +266,24 @@ const NewcomersGuide = () => {
                 Be patient. There are a large number of contributors and only a
                 small number of maintainers/reviewers. All contributors are
                 equally important to us, and we'll be sure to get to you as soon
-                as possible. In the meanwhile, you are welcome to engage in the Layer5{" "}
+                as possible. In the meanwhile, you are welcome to engage in the
+                Layer5{" "}
                 <a
                   href="https://discuss.layer5.io/"
                   target="_blank"
                   rel="noreferrer"
                 >
-        discussion forum
-                </a>, join our{" "}
+                  discussion forum
+                </a>
+                , join our{" "}
                 <a
                   href="https://slack.layer5.io/"
                   target="_blank"
                   rel="noreferrer"
                 >
-        Slack workspace
+                  Slack workspace
                 </a>{" "}
-      and take a look at all our <Link to="/projects">projects</Link>.
+                and take a look at all our <Link to="/projects">projects</Link>.
               </p>
             </Col>
             <Col $sm={12} $lg={6} className="community-collage">


### PR DESCRIPTION
## Description
Added `margin-bottom` to the "Working on Your Issue" heading on the 
community page to fix the spacing issue between the heading and the 
list items below it.

## Problem
The "Working on Your Issue" section heading had no `margin-bottom`, 
causing the first list item to sit immediately below the heading 
with no spacing, making it cramped and hard to read.

## Solution
Added `marginBottom: "10px"` to the heading in the 
`src/sections/Community/Newcomers-guide/index.js` file.

### **Fixes #issue-number** #7752