### PR TITLE
fix: improve careers page layout

### DIFF
--- a/src/sections/Careers/careers.style.js
+++ b/src/sections/Careers/careers.style.js
@@ -1,79 +1,81 @@
 import styled from "styled-components";
 
 const CareersSectionWrapper = styled.div`
-p {
-    color: ${props => props.theme.whiteEightToBlack};
+  p {
+    color: ${(props) => props.theme.whiteEightToBlack};
     transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
-}
-    h1{
-        color: ${props => props.theme.text};
-        transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
-    }
-    .page-header{
-        margin:4rem auto;
-    }
-    .centerTexts{
-        margin-top: -3rem;
-        text-align: center;
-    }
-    .center{
-        text-align: center;
-    }
+  }
+  h1 {
+    color: ${(props) => props.theme.text};
+    transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
+  }
+  .page-header {
+    margin: 4rem auto;
+  }
+  .centerTexts {
+    margin-top: -3rem;
+    text-align: center;
+  }
+  .center {
+    text-align: center;
+  }
 
+  .videoText {
+    flex-wrap: nowrap;
+    margin: auto;
+    margin-top: 3rem;
+    display: flex;
+    align-items: flex-start;
+    gap: 2rem;
+  }
+  .introText,
+  .introImage {
+    flex: 1;
+  }
+  .introText {
+    margin-top: 0;
+  }
+  .introText h1 {
+    margin-bottom: 1rem;
+  }
+  .introText p {
+    text-align: justify;
+    color: ${(props) => props.theme.whiteEightToBlack};
+    transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
+  }
+  .introImage {
+    margin: auto;
+    text-align: center;
+
+    img {
+      width: 100%;
+      max-width: 100%;
+    }
+  }
+  @media only screen and (max-width: 996px) {
     .videoText {
-        flex-wrap: nowrap;
-        margin: auto;
-        margin-top: 1rem;
-        display: flex;
-        align-items: center;
-        gap: 2rem;
+      flex-wrap: wrap;
     }
-    .introText{
-        margin-top: 10rem;
+    .introText {
+      width: 100%;
     }
-    .introText h1{
-        margin-bottom: 1rem;
+    .introImage {
+      width: 100%;
+      margin: auto;
+      text-align: center;
     }
-    .introText p {
-        text-align: justify;
-        color: ${props => props.theme.whiteEightToBlack};
-        transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
-    }
-    .introVideo{
-        width: 50%;
-        margin: auto;
-        text-align: center;
+  }
 
-        iframe{
-            width: 26rem;
-        }
+  @media only screen and (max-width: 420px) {
+    .introImage {
+      img {
+        width: 20rem;
+      }
     }
-    @media only screen and (max-width:996px){
-        .videoText{
-            flex-wrap: wrap;
-        }
-        .introText{
-            width: 100%;
-        }
-        .introVideo{
-            width: 100%;
-            margin: auto;
-            text-align: center;
-        }
-    }
+  }
 
-    @media only screen and (max-width:420px){
-        .introVideo{
-            iframe{
-                width: 20rem;
-            }
-        }
-    }
-
-    .opportunity-section {
- 
-    }
-    
+  .opportunity-section {
+  }
 `;
 
 export default CareersSectionWrapper;


### PR DESCRIPTION
This PR fixes the layout misalignment in the "Layer5 Culture" section on the Careers page. The culture text and illustration image were not vertically aligned, leaving an awkward gap above the text block.

###Changes

- Fixed vertical alignment of the culture text and image columns
- Removed excessive top offset on the intro text
- Limited changes to careers.style.js only

###Notes for Reviewers
- The diff shows 66 insertions / 64 deletions due to indentation normalization in the styled-component block. The actual logical change is few lines.

Screenshot before :
<img width="1920" height="969" alt="image" src="https://github.com/user-attachments/assets/5c06ced2-7d8a-425e-b939-ea27141d4953" />

Screenshot after correction:
<img width="1920" height="969" alt="image" src="https://github.com/user-attachments/assets/1efbb2e2-1833-4f37-b7e7-9179728f4628" />


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
