### PR TITLE
Add redirect for broken istio conclusion training link

### DIFF
--- a/src/utils/redirects.yaml
+++ b/src/utils/redirects.yaml
@@ -227,3 +227,7 @@ redirects:
     toPath: "/cloud-native-management/kanvas/collaborate/peer-reviews"
     redirectInBrowser: true
     isPermanent: true
+  - fromPath: "/learn/learning-paths/mastering-service-meshes-for-developers/introduction-to-service-meshes/istio/conclusion.html"
+    toPath: "/learn/learning-paths/mastering-service-meshes-for-developers/introduction-to-service-meshes/istio/conclusion"
+    redirectInBrowser: true
+    isPermanent: true


### PR DESCRIPTION
**Description**

This PR fixes #7772

Added a permanent redirect in `src/utils/redirects.yaml` from the broken `.html`-suffixed URL to the correct clean URL for the Istio conclusion chapter in the "Introduction to Service Meshes" learning path.

## Notes for Reviewers

- The redirect is handled server-side via `gatsby-plugin-netlify`, so users hitting the broken URL receive a proper HTTP 301 before Gatsby loads a 404.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.