### PR TITLE
Disallow search engine indexing of PR preview deployments

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -582,7 +582,9 @@ module.exports = {
             options: {
               host: siteRootUrl,
               sitemap: `${siteRootUrl}/sitemap-index.xml`,
-              policy: [{ userAgent: "*", allow: "/" }],
+              policy: [
+                { userAgent: "*", allow: "/", disallow: ["/pr-preview/"] },
+              ],
             },
           },
         ]


### PR DESCRIPTION
**Description**

This PR fixes #7773

**Notes for Reviewers**
  - Generated robots.txt will include:
  User-agent: *
  Allow: /
  Disallow: /pr-preview/

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.