### PR TITLE
Fix LFX 2026 build failure

### DIFF
--- a/src/collections/programs/lfx-2026/LfxPageNav.js
+++ b/src/collections/programs/lfx-2026/LfxPageNav.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { ArrowUpwardIcon } from "@sistent/sistent";
+// import { ArrowUpwardIcon } from "@sistent/sistent";
 import styled from "styled-components";
 
 const NavCard = styled.nav`
@@ -11,7 +11,7 @@ const NavCard = styled.nav`
   background: ${(props) => props.theme.grey1D1D1DToGreyFAFAFA};
   border: 1px solid ${(props) => props.theme.grey1D1817ToGreyE6E6E6};
   border-radius: 7px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.10);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   padding: 1rem;
   z-index: 99;
   @media (max-width: 900px) {
@@ -102,7 +102,12 @@ const LfxPageNav = ({ items }) => {
         <NavList>
           {items.map((item) => (
             <li key={item.href}>
-              <a href={item.href} className={activeHref === item.href ? "active" : ""}>{item.label}</a>
+              <a
+                href={item.href}
+                className={activeHref === item.href ? "active" : ""}
+              >
+                {item.label}
+              </a>
             </li>
           ))}
         </NavList>
@@ -112,7 +117,10 @@ const LfxPageNav = ({ items }) => {
         onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
         aria-label="Back to top"
       >
-        <ArrowUpwardIcon style={{ fontSize: "1.2rem", fill: "white" }} />
+        {/* <ArrowUpwardIcon style={{ fontSize: "1.2rem", fill: "white" }} /> */}
+        <span aria-hidden="true" style={{ fontSize: "1.2rem", lineHeight: 1 }}>
+          ↑
+        </span>
       </BackToTopBtn>
     </>
   );


### PR DESCRIPTION
**Description**

This PR fixes #7783 

This PR fixes the production build failure on `/programs/lfx/2026`.

The build was failing during Gatsby static HTML generation with the following error:

```txt
WebpackError: Element type is invalid: expected a string (for built-in components)
or a class/function (for composite components) but got: undefined.
```

The issue was caused by `ArrowUpwardIcon` being imported from `@sistent/sistent`, but that icon export appears to be unavailable/undefined. As a result, Gatsby attempted to render an undefined component during the production build.

This PR removes the invalid icon import and replaces it with a simple arrow inside the existing back-to-top button, keeping the same functionality while avoiding the undefined component error.

**Notes for Reviewers**

Tested with:

```bash
npm run build
```

The production build now completes successfully:

```txt
success Building static HTML for pages - 1330/1330
info Done building
```

There are still existing `[gatsby-plugin-image] Missing image prop` warnings during the build, but they do not block the build and appear unrelated to this specific failure.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
