### PR TITLE
fix: correct grammar in LFX Fall 2026 announcement

### DIFF
--- a/src/collections/programs/lfx-2026/lfx-2026.mdx
+++ b/src/collections/programs/lfx-2026/lfx-2026.mdx
@@ -274,7 +274,7 @@ CNCF - Meshery: Meshery Models Support for OCI Registries (2026 Term 2)
 ### Meshery
 <br />
 
-> Fall 2026 projects will be announce. Check back soon!
+> Fall 2026 projects will be announced. Check back soon!
 
 
 <h2 id="additional-info">Additional information</h2>


### PR DESCRIPTION
**Description**

This PR fixes a grammatical typo in the LFX Fall 2026 section.

Before:
"Fall 2026 projects will be announce. Check back soon!"

After:
"Fall 2026 projects will be announced. Check back soon!"

**Notes for Reviewers**

* Corrected a grammar mistake in the LFX Fall 2026 announcement text.
* No functional changes.
* Documentation/content-only update.

**Signed commits**

* [x] Yes, I signed my commits.
