### PR TITLE
[root-wrapper] feat(ui): Add copy-to-clipboard button on hover for inline code snippets in blog posts

### DIFF
--- a/root-wrapper.js
+++ b/root-wrapper.js
@@ -28,11 +28,20 @@ const OptimizedImage = (props) => {
   );
 };
 
+// Returns true only for commands like `npm install`, `npx skill install`
+// Returns false for paths like `~/.claude/skills/`, flags like `-sfn`
+const isCommand = (text) => {
+  const str = String(text).trim();
+  return !/^[~/.]/.test(str);
+};
+
 // Inline code component with copy-on-hover button
 const InlineCode = ({ children }) => {
   const [copied, setCopied] = React.useState(false);
   const [hovered, setHovered] = React.useState(false);
   const codeRef = React.useRef(null);
+
+  const showCopyButton = isCommand(children);
 
   const handleCopy = () => {
     const text = codeRef.current?.textContent || children;
@@ -52,24 +61,38 @@ const InlineCode = ({ children }) => {
       onMouseLeave={() => setHovered(false)}
     >
       <code ref={codeRef}>{children}</code>
-      <button
-        onClick={handleCopy}
-        title="Copy to clipboard"
-        style={{
-          marginLeft: "4px",
-          background: "transparent",
-          border: "none",
-          cursor: "pointer",
-          padding: "2px 4px",
-          color: "inherit",
-          opacity: hovered ? 1 : 0,
-          transition: "opacity 0.2s ease",
-          borderRadius: "3px",
-        }}
-        aria-label="Copy to clipboard"
-      >
-        {copied ? <IoIosCheckmark size={16} /> : <IoIosCopy size={14} />}
-      </button>
+      {showCopyButton && (
+        <span
+          style={{
+            display: "inline-block",
+            width: hovered ? "22px" : "0px",
+            marginLeft: hovered ? "4px" : "0px",
+            overflow: "hidden",
+            transition: "width 0.2s ease, margin 0.2s ease",
+            verticalAlign: "middle",
+          }}
+        >
+          <button
+            onClick={handleCopy}
+            title="Copy to clipboard"
+            style={{
+              background: "transparent",
+              border: "none",
+              cursor: "pointer",
+              padding: "2px 2px",
+              color: "inherit",
+              opacity: hovered ? 1 : 0,
+              transition: "opacity 0.2s ease",
+              borderRadius: "3px",
+              display: "flex",
+              alignItems: "center",
+            }}
+            aria-label="Copy to clipboard"
+          >
+            {copied ? <IoIosCheckmark size={16} /> : <IoIosCopy size={14} />}
+          </button>
+        </span>
+      )}
     </span>
   );
 };

--- a/root-wrapper.js
+++ b/root-wrapper.js
@@ -5,6 +5,8 @@ import CTA_ImageOnly from "./src/components/Call-To-Actions/CTA_ImageOnly";
 import CTA_FullWidth from "./src/components/Call-To-Actions/CTA_FullWidth";
 import CTA_Bottom from "./src/components/Call-To-Actions/CTA_Bottom";
 import { ContextWrapper } from "./context-wrapper";
+import { IoIosCopy } from "@react-icons/all-files/io/IoIosCopy";
+import { IoIosCheckmark } from "@react-icons/all-files/io/IoIosCheckmark";
 
 // Custom image component for better CLS scores
 const OptimizedImage = (props) => {
@@ -30,9 +32,11 @@ const OptimizedImage = (props) => {
 const InlineCode = ({ children }) => {
   const [copied, setCopied] = React.useState(false);
   const [hovered, setHovered] = React.useState(false);
+  const codeRef = React.useRef(null);
 
   const handleCopy = () => {
-    navigator.clipboard.writeText(children);
+    const text = codeRef.current?.textContent || children;
+    navigator.clipboard.writeText(text);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
@@ -47,7 +51,7 @@ const InlineCode = ({ children }) => {
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
-      <code>{children}</code>
+      <code ref={codeRef}>{children}</code>
       <button
         onClick={handleCopy}
         title="Copy to clipboard"
@@ -57,7 +61,6 @@ const InlineCode = ({ children }) => {
           border: "none",
           cursor: "pointer",
           padding: "2px 4px",
-          fontSize: "12px",
           color: "inherit",
           opacity: hovered ? 1 : 0,
           transition: "opacity 0.2s ease",
@@ -65,7 +68,7 @@ const InlineCode = ({ children }) => {
         }}
         aria-label="Copy to clipboard"
       >
-        {copied ? "✅" : "📋"}
+        {copied ? <IoIosCheckmark size={16} /> : <IoIosCopy size={14} />}
       </button>
     </span>
   );

--- a/root-wrapper.js
+++ b/root-wrapper.js
@@ -7,7 +7,7 @@ import CTA_Bottom from "./src/components/Call-To-Actions/CTA_Bottom";
 import { ContextWrapper } from "./context-wrapper";
 
 // Custom image component for better CLS scores
-const OptimizedImage = props => {
+const OptimizedImage = (props) => {
   return (
     <div style={{ width: "100%", height: "auto" }}>
       <img
@@ -17,12 +17,57 @@ const OptimizedImage = props => {
         style={{
           objectFit: props.objectFit || "contain",
           margin: "20px 0px",
-          ...props.style
+          ...props.style,
         }}
         loading="lazy"
         alt={props.alt || "Blog content image"}
       />
     </div>
+  );
+};
+
+// Inline code component with copy-on-hover button
+const InlineCode = ({ children }) => {
+  const [copied, setCopied] = React.useState(false);
+  const [hovered, setHovered] = React.useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(children);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <span
+      style={{
+        position: "relative",
+        display: "inline-flex",
+        alignItems: "center",
+      }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <code>{children}</code>
+      <button
+        onClick={handleCopy}
+        title="Copy to clipboard"
+        style={{
+          marginLeft: "4px",
+          background: "transparent",
+          border: "none",
+          cursor: "pointer",
+          padding: "2px 4px",
+          fontSize: "12px",
+          color: "inherit",
+          opacity: hovered ? 1 : 0,
+          transition: "opacity 0.2s ease",
+          borderRadius: "3px",
+        }}
+        aria-label="Copy to clipboard"
+      >
+        {copied ? "✅" : "📋"}
+      </button>
+    </span>
   );
 };
 
@@ -32,24 +77,21 @@ const components = {
       return (
         <Code
           codeString={props.children.trim()}
-          language={
-            props.className && props.className.replace("language-", "")
-          }
+          language={props.className && props.className.replace("language-", "")}
           {...props}
         />
       );
     }
   },
   img: OptimizedImage,
+  code: InlineCode,
   CTA_ImageOnly,
   CTA_FullWidth,
-  CTA_Bottom
+  CTA_Bottom,
 };
 
 export const wrapRootElement = ({ element }) => (
   <ContextWrapper>
-    <MDXProvider components={components}>
-      {element}
-    </MDXProvider>
+    <MDXProvider components={components}>{element}</MDXProvider>
   </ContextWrapper>
 );


### PR DESCRIPTION
**Description**
This PR fixes #7790

Added a copy-to-clipboard button that appears on hover for inline code snippets in blog posts.

## Changes
- Added `InlineCode` component in `root-wrapper.js`
- Copy icon 📋 appears on hover using opacity transition
- Shows ✅ confirmation for 2 seconds after copying
- Uses `navigator.clipboard.writeText()` API
- No change to existing inline code styling

## Screenshots/Demo

https://github.com/user-attachments/assets/fc19fca6-7cd3-4af7-87d2-1523cabc9105

**Notes for Reviewers**
The InlineCode component is added to the MDXProvider components in root-wrapper.js. It wraps the existing `<code>` tag without modifying its styles, so all existing styling is preserved.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.