### PR TITLE
fix: article thumbnails missing on /resources page

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -536,9 +536,7 @@ module.exports = {
         name: "images",
         path: `${__dirname}/src/assets/images`,
         ignore: [
-          "**/*.svg",
           "**/learning-path/**",
-          "**/service-mesh-icons/**",
           "**/app/**",
           "**/learn-layer5/**",
           "**/careers/**",

--- a/src/collections/events/2020/ccoss2020/index.mdx
+++ b/src/collections/events/2020/ccoss2020/index.mdx
@@ -2,8 +2,8 @@
 title: "CCOSS 2020"
 description: "Meshery is a tool that allows you to deploy, configure, measure, operate, and modify multiple service meshes (Istio, Linkerd, etc.). In this workshop, you will learn what a service mesh is and how Meshery can help you assess the landscape of service meshes available in the market."
 date: 2020-10-19
-thumbnail_svg: ./ccoss-logo.svg
-darkthumbnail_svg: ./ccoss-logo.svg
+thumbnail: ./ccoss-logo.svg
+darkthumbnail: ./ccoss-logo.svg
 eurl: https://ccoss.org/sessions/w-meshery/
 type: Workshop
 product: Meshery

--- a/src/collections/events/2020/istiocon2020/index.mdx
+++ b/src/collections/events/2020/istiocon2020/index.mdx
@@ -2,8 +2,8 @@
 title: "IstioCon 2021"
 description: "Kickstart your service mesh journey with Layer5's renowned workshop featuring Meshery, the service mesh manager. Learn the ins and outs of Istio, the popular service mesh, in this hands-on training. "
 date: 2021-02-22
-thumbnail_svg: ./istiocon-logo.svg
-darkthumbnail_svg: ./istiocon-logo.svg
+thumbnail: ./istiocon-logo.svg
+darkthumbnail: ./istiocon-logo.svg
 eurl: https://events.istio.io/istiocon-2021/workshops/using-istio/
 type: Event
 published: true

--- a/src/collections/resources/articles/api-gateways/index.mdx
+++ b/src/collections/resources/articles/api-gateways/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "API Gateways interplay with service meshes"
-thumbnail_svg: ../../service-mesh.svg
-darkthumbnail_svg: ../../service-mesh.svg
+thumbnail: ../../service-mesh.svg
+darkthumbnail: ../../service-mesh.svg
 category: Service Mesh
 date: 2021-08-27 10:30:05 -0530
 tags:

--- a/src/collections/resources/articles/choosing-the-perfect-proxy/index.mdx
+++ b/src/collections/resources/articles/choosing-the-perfect-proxy/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Choosing the Perfect Proxy"
-thumbnail_svg: ../../service-mesh.svg
-darkthumbnail_svg: ../../service-mesh.svg
+thumbnail: ../../service-mesh.svg
+darkthumbnail: ../../service-mesh.svg
 date: 2021-08-28 10:30:05 -0530
 category: Service Mesh
 tags:

--- a/src/collections/resources/articles/consul-service-mesh/index.mdx
+++ b/src/collections/resources/articles/consul-service-mesh/index.mdx
@@ -2,8 +2,8 @@
 title: "Service Mesh: Consul"
 date: 2022-08-05 10:30:05 -0530
 author: Deepesha Burse
-thumbnail_svg: ../../../../assets/images/service-mesh-icons/consul.svg
-darkthumbnail_svg: ../../../../assets/images/service-mesh-icons/consul.svg
+thumbnail: ../../../../assets/images/service-mesh-icons/consul.svg
+darkthumbnail: ../../../../assets/images/service-mesh-icons/consul.svg
 description: Explanation of Consul Connect
 type: Article
 published: true

--- a/src/collections/resources/articles/container-management/container-management.mdx
+++ b/src/collections/resources/articles/container-management/container-management.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Managing Containers"
-thumbnail_svg: ./docker.svg
-darkthumbnail_svg: ./docker.svg
+thumbnail: ./docker.svg
+darkthumbnail: ./docker.svg
 date: 2022-07-06 10:30:05 -0530
 category: Kubernetes
 type: Article

--- a/src/collections/resources/articles/deploying-istio/index.mdx
+++ b/src/collections/resources/articles/deploying-istio/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Deploying Istio"
-thumbnail_svg: ../../../../assets/images/service-mesh-icons/istio.svg
-darkthumbnail_svg: ../../../../assets/images/service-mesh-icons/istio.svg
+thumbnail: ../../../../assets/images/service-mesh-icons/istio.svg
+darkthumbnail: ../../../../assets/images/service-mesh-icons/istio.svg
 date: 2021-09-02 10:30:05 -0530
 type: Article
 category: Service Mesh

--- a/src/collections/resources/articles/gitops/what-is-gitops.mdx
+++ b/src/collections/resources/articles/gitops/what-is-gitops.mdx
@@ -1,7 +1,7 @@
 ---
 title: "What is GitOps?"
-thumbnail_svg: "../../../../assets/images/socialIcons/github-dark.svg"
-darkthumbnail_svg: "../../../../assets/images/socialIcons/github-light.svg"
+thumbnail: "../../../../assets/images/socialIcons/github-dark.svg"
+darkthumbnail: "../../../../assets/images/socialIcons/github-light.svg"
 date: 2022-08-16 10:30:05 -0530
 category: Cloud Native
 tags:

--- a/src/collections/resources/articles/istio-at-a-glance/istio-at-a-glance.mdx
+++ b/src/collections/resources/articles/istio-at-a-glance/istio-at-a-glance.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Istio v1.5 at a Glance"
-thumbnail_svg: ../../../../assets/images/service-mesh-icons/istio.svg
-darkthumbnail_svg: ../../../../assets/images/service-mesh-icons/istio.svg
+thumbnail: ../../../../assets/images/service-mesh-icons/istio.svg
+darkthumbnail: ../../../../assets/images/service-mesh-icons/istio.svg
 date: 2021-09-04 10:30:05 -0530
 category: Service Mesh
 tags:

--- a/src/collections/resources/articles/istio-authorization policy/index.mdx
+++ b/src/collections/resources/articles/istio-authorization policy/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Istio Authorization Policy"
-thumbnail_svg: ../../../../assets/images/service-mesh-icons/istio.svg
-darkthumbnail_svg: ../../../../assets/images/service-mesh-icons/istio.svg
+thumbnail: ../../../../assets/images/service-mesh-icons/istio.svg
+darkthumbnail: ../../../../assets/images/service-mesh-icons/istio.svg
 date: 2022-06-01 10:30:05 -0530
 type: Article
 category: Service Mesh

--- a/src/collections/resources/articles/istio-pilot/index.mdx
+++ b/src/collections/resources/articles/istio-pilot/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Istio Pilot"
-thumbnail_svg: ../../../../assets/images/service-mesh-icons/istio.svg
-darkthumbnail_svg: ../../../../assets/images/service-mesh-icons/istio.svg
+thumbnail: ../../../../assets/images/service-mesh-icons/istio.svg
+darkthumbnail: ../../../../assets/images/service-mesh-icons/istio.svg
 date: 2021-09-10 10:30:05 -0530
 type: Article
 category: Service Mesh

--- a/src/collections/resources/articles/istio-service-mesh/index.mdx
+++ b/src/collections/resources/articles/istio-service-mesh/index.mdx
@@ -2,8 +2,8 @@
 title: "Service Mesh: Istio"
 date: 2022-08-31 10:30:05 -0530
 author: Deepesha Burse
-thumbnail_svg: ../../../../assets/images/service-mesh-icons/istio.svg
-darkthumbnail_svg: ../../../../assets/images/service-mesh-icons/istio-white.svg
+thumbnail: ../../../../assets/images/service-mesh-icons/istio.svg
+darkthumbnail: ../../../../assets/images/service-mesh-icons/istio-white.svg
 description: Explanation of Istio
 type: Article
 published: true

--- a/src/collections/resources/articles/istio-service-proxy/index.mdx
+++ b/src/collections/resources/articles/istio-service-proxy/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Service Proxy"
-thumbnail_svg: ../../../../assets/images/service-mesh-icons/envoy/icon/color/envoy-icon-color.svg
-darkthumbnail_svg: ../../../../assets/images/service-mesh-icons/envoy/icon/color/envoy-icon-color.svg
+thumbnail: ../../../../assets/images/service-mesh-icons/envoy/icon/color/envoy-icon-color.svg
+darkthumbnail: ../../../../assets/images/service-mesh-icons/envoy/icon/color/envoy-icon-color.svg
 date: 2021-09-11 10:30:05 -0530
 type: Article
 category: Service Mesh

--- a/src/collections/resources/articles/istio-virtual-service/index.mdx
+++ b/src/collections/resources/articles/istio-virtual-service/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Istio Virtual Service"
-thumbnail_svg: ../../../../assets/images/service-mesh-icons/istio.svg
-darkthumbnail_svg: ../../../../assets/images/service-mesh-icons/istio.svg
+thumbnail: ../../../../assets/images/service-mesh-icons/istio.svg
+darkthumbnail: ../../../../assets/images/service-mesh-icons/istio.svg
 date: 2022-06-16 10:30:05 -0530
 type: Article
 category: Service Mesh

--- a/src/collections/resources/articles/kubernetes/archtiecture-101/k8s-architecture-101.mdx
+++ b/src/collections/resources/articles/kubernetes/archtiecture-101/k8s-architecture-101.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Kubernetes Architecture 101"
-thumbnail_svg: ../kubernetes.svg
-darkthumbnail_svg: ../kubernetes.svg
+thumbnail: ../kubernetes.svg
+darkthumbnail: ../kubernetes.svg
 date: 2022-07-05 10:30:05 -0530
 category: Kubernetes
 type: Article

--- a/src/collections/resources/articles/kubernetes/getting-started-with-kubernetes/index.mdx
+++ b/src/collections/resources/articles/kubernetes/getting-started-with-kubernetes/index.mdx
@@ -2,8 +2,8 @@
 title: "Getting Started with Kubernetes"
 date: 2022-11-02 10:30:05 -0530
 author: Tolulope Ola-David
-thumbnail_svg: ./kubernetes-logo.svg
-darkthumbnail_svg: ./kubernetes-logo.svg
+thumbnail: ./kubernetes-logo.svg
+darkthumbnail: ./kubernetes-logo.svg
 description: Introduction to Kubernetes
 type: Article
 published: true

--- a/src/collections/resources/articles/kubernetes/management-of-kubernetes/index.mdx
+++ b/src/collections/resources/articles/kubernetes/management-of-kubernetes/index.mdx
@@ -2,8 +2,8 @@
 title: "Management of Kubernetes"
 date: 2022-11-21 10:30:05 -0530
 author: Tolulope Ola-David
-thumbnail_svg: ./kubernetes-logo.svg
-darkthumbnail_svg: ./kubernetes-logo.svg
+thumbnail: ./kubernetes-logo.svg
+darkthumbnail: ./kubernetes-logo.svg
 description: Management of Kubernetes
 type: Article
 published: true

--- a/src/collections/resources/articles/kubernetes/multi-cluster/k8s-multi-cluster.mdx
+++ b/src/collections/resources/articles/kubernetes/multi-cluster/k8s-multi-cluster.mdx
@@ -1,7 +1,7 @@
 ---
 title: "What is Multi-Cluster Kubernetes?"
-thumbnail_svg: ./kubernetes.svg
-darkthumbnail_svg: ./kubernetes.svg
+thumbnail: ./kubernetes.svg
+darkthumbnail: ./kubernetes.svg
 date: 2022-07-05T10:30:05-05:30
 category: Kubernetes
 type: Article

--- a/src/collections/resources/articles/microservices-based-application-delivery/index.mdx
+++ b/src/collections/resources/articles/microservices-based-application-delivery/index.mdx
@@ -2,8 +2,8 @@
 title: "7 Key Considerations for Microservices-Based Application Delivery"
 subtitle: "Ensuring the Success of Your Cloud Native Journey"
 date: 2021-09-15 10:30:05 -0530
-thumbnail_svg: ./citrix-path-to-cloud-native.svg
-darkthumbnail_svg: ./citrix-path-to-cloud-native.svg
+thumbnail: ./citrix-path-to-cloud-native.svg
+darkthumbnail: ./citrix-path-to-cloud-native.svg
 category: Service Mesh
 type: Article
 tags:

--- a/src/collections/resources/articles/service-mesh-fundamentals/index.mdx
+++ b/src/collections/resources/articles/service-mesh-fundamentals/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Service Mesh Fundamentals"
-thumbnail_svg: ../../service-mesh.svg
-darkthumbnail_svg: ../../service-mesh.svg
+thumbnail: ../../service-mesh.svg
+darkthumbnail: ../../service-mesh.svg
 date: 2021-10-05 10:30:05 -0530
 category: Service Mesh
 type: Article

--- a/src/collections/resources/articles/terraform-with-meshery/index.mdx
+++ b/src/collections/resources/articles/terraform-with-meshery/index.mdx
@@ -3,8 +3,8 @@ title: Terraform with Meshery
 subtitle:
 date: 2022-12-22 08:00:00 -0530
 author: Gaurav Chadha
-thumbnail_svg: ./terraform-color.svg
-darkthumbnail_svg: ./terraform-color.svg
+thumbnail: ./terraform-color.svg
+darkthumbnail: ./terraform-color.svg
 description: "Terraform Infrastructure as Code with Meshery"
 type: Article
 category: Cloud Native

--- a/src/collections/resources/articles/value-of-a-service-mesh/index.mdx
+++ b/src/collections/resources/articles/value-of-a-service-mesh/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Value of a Service Mesh"
-thumbnail_svg: ./service-mesh.svg
-darkthumbnail_svg: ./service-mesh.svg
+thumbnail: ./service-mesh.svg
+darkthumbnail: ./service-mesh.svg
 date: 2021-10-20 10:30:05 -0530
 category: Service Mesh
 type: Article

--- a/src/collections/resources/articles/webassembly/comparing-lua-and-webassemby.mdx
+++ b/src/collections/resources/articles/webassembly/comparing-lua-and-webassemby.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Lua vs WebAssembly"
-thumbnail_svg: ./lua-wasm.svg
-darkthumbnail_svg: ./lua-wasm.svg
+thumbnail: ./lua-wasm.svg
+darkthumbnail: ./lua-wasm.svg
 date: 2021-10-28 10:30:05 -0530
 category: WebAssembly Filters
 type: Article

--- a/src/collections/resources/articles/webassembly/envoy-and-webassembly.mdx
+++ b/src/collections/resources/articles/webassembly/envoy-and-webassembly.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Envoy and WebAssembly"
-thumbnail_svg: ./wasm-envoy.svg
-darkthumbnail_svg: ./wasm-envoy.svg
+thumbnail: ./wasm-envoy.svg
+darkthumbnail: ./wasm-envoy.svg
 date: 2021-10-29 10:30:05 -0530
 category: WebAssembly Filters
 type: Article

--- a/src/collections/resources/case-study/hpes-adoption-of-meshery-and-kanvas/index.mdx
+++ b/src/collections/resources/case-study/hpes-adoption-of-meshery-and-kanvas/index.mdx
@@ -4,8 +4,8 @@ subtitle: HPE uses Meshery to manage SPIRE instances
 permalink: case-study/hpes-adoption-of-meshery-and-kanvas
 date: 2023-06-17 08:00:00 -0530
 author: Layer5 Team
-thumbnail_svg: ./meshery-and-hpe.svg
-darkthumbnail_svg: ./meshery-and-hpe.svg
+thumbnail: ./meshery-and-hpe.svg
+darkthumbnail: ./meshery-and-hpe.svg
 description: "HPE uses Meshery to manage SPIRE instances"
 type: Case Study
 category: Case Study

--- a/src/collections/resources/recorded-webinars/introduction-to-meshery.mdx
+++ b/src/collections/resources/recorded-webinars/introduction-to-meshery.mdx
@@ -1,7 +1,7 @@
 ---
 title: "An Introduction to Meshery (Webinar-on-Demand)"
-thumbnail_svg: ../../../assets/images/meshery/full-logo/meshery-logo-light-text.svg
-darkthumbnail_svg: ../../../assets/images/meshery/full-logo/meshery-logo-light-text.svg
+thumbnail: ../../../assets/images/meshery/full-logo/meshery-logo-light-text.svg
+darkthumbnail: ../../../assets/images/meshery/full-logo/meshery-logo-light-text.svg
 date: 2021-11-07 10:30:05 -0530
 category: Meshery
 type: Recorded Webinar

--- a/src/collections/resources/resources-template/index.mdx
+++ b/src/collections/resources/resources-template/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Template and Guide"
-thumbnail_svg: ../service-mesh.svg
-darkthumbnail_svg: ../service-mesh.svg
+thumbnail: ../service-mesh.svg
+darkthumbnail: ../service-mesh.svg
 date: 2021-11-07 10:30:05 -0530
 category: Lorem Ipsum
 tags:


### PR DESCRIPTION
**Description**
- Fixes missing thumbnails for articles on the[ /resources](https://layer5.io/resources) page.

**Root Cause**
1. MDX files used `thumbnail_svg` instead of `thumbnail` in their frontmatter.
2. `gatsby-config.js` was configured to ignore SVG files, preventing Gatsby from loading them.

**Fix**
1. Removed `**/*.svg` and `service-mesh-icons` from the ignore list in `gatsby-config.js`.
2. Renamed `thumbnail_svg` to `thumbnail` and `darkthumbnail_svg` to `darkthumbnail` in the article MDX files.

| Before | After |
|---------|--------|
| <img src="https://github.com/user-attachments/assets/4e76aaaa-eee8-40f1-976b-fdc90cabdcfd" width="100%"> | <img src="https://github.com/user-attachments/assets/ea4e4f5b-6521-4267-b066-33c51df451a7" width="100%"> |


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
