### PR TITLE
fix(rss): include all events in meshery-community-feed.xml

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -287,11 +287,10 @@ module.exports = {
                 }
                 allMdx(
                   sort: {frontmatter: {date: DESC}}
-                  limit: 50
+                  limit: 100
                   filter: {
                     frontmatter: {
                       published: { eq: true }
-                      category: { in: ["Meshery", "Announcements", "Events"] }
                     }
                     fields: { collection: { in: ["blog", "resources", "news", "events"] } }
                   }
@@ -321,15 +320,27 @@ module.exports = {
             `,
                   serialize: ({ query: { site, allMdx } }) => {
                     const targetTags = ["Community", "Meshery", "mesheryctl"];
+                    const targetCategories = [
+                      "Meshery",
+                      "Announcements",
+                      "Events",
+                    ];
 
                     return allMdx.nodes
                       .filter((node) => {
+                        // Include every published event in the feed.
+                        if (node.fields.collection === "events") return true;
+                        // For blog/resources/news, keep the existing behavior:
+                        // a matching category AND one of the target tags.
+                        const hasCategory = targetCategories.includes(
+                          node.frontmatter.category,
+                        );
                         const hasTag =
                           node.frontmatter.tags &&
                           node.frontmatter.tags.some((t) =>
                             targetTags.includes(t),
                           );
-                        return hasTag;
+                        return hasCategory && hasTag;
                       })
                       .slice(0, 30)
                       .map((node) => {
@@ -349,8 +360,11 @@ module.exports = {
                           },
                           custom_elements: [
                             { "content:encoded": node.excerpt },
-                            { "content:type": node.frontmatter.type },
-                            { "content:category": node.frontmatter.category },
+                            { "content:type": node.frontmatter.type || "" },
+                            {
+                              "content:category":
+                                node.frontmatter.category || "",
+                            },
                             {
                               "content:tags":
                                 node.frontmatter.tags?.join(", ") || "",


### PR DESCRIPTION
**Description**
Enhances the `meshery-community-feed.xml` RSS feed (FEED 3 in `gatsby-config.js`) to
include **all published events** in addition to the tag-filtered blog/news/resources
posts it already surfaces.


This PR fixes #7809 

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
