### PR TITLE
perf(seo): lazy-load offscreen SVGs and icons

### DIFF
--- a/src/components/SocialLinks-Color/index.js
+++ b/src/components/SocialLinks-Color/index.js
@@ -20,25 +20,36 @@ const tooltipProps = {
 const SocialLinksColor = () => {
   return (
     <SocialLinksWrapper>
-      <Col $xs={12}>  
+      <Col $xs={12}>
         <Row className="social_icons">
           <CustomTooltip title="Layer5 Discussion Forum" {...tooltipProps}>
-            <a href="https://discuss.layer5.io" target="_blank" rel="noreferrer">
-              <img height="30px" src={forum_icon} alt="forum" />
+            <a
+              href="https://discuss.layer5.io"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <img height="30px" src={forum_icon} alt="forum" loading="lazy" />
             </a>
           </CustomTooltip>
           <CustomTooltip title="Email Layer5 Community" {...tooltipProps}>
-            <a className="mail_icon"
+            <a
+              className="mail_icon"
               href="mailto:community@layer5.io"
               target="_blank"
               rel="noreferrer"
             >
-              <img height="30px" src={mail_icon} alt="mail" />
+              <img height="30px" src={mail_icon} alt="mail" loading="lazy" />
             </a>
           </CustomTooltip>
           <CustomTooltip title="Join Layer5 on Slack" {...tooltipProps}>
             <a href="https://slack.layer5.io/" target="_blank" rel="noreferrer">
-              <img className="slack" height="30px" src={slack_icon} alt="slack" />
+              <img
+                className="slack"
+                height="30px"
+                src={slack_icon}
+                alt="slack"
+                loading="lazy"
+              />
             </a>
           </CustomTooltip>
           <CustomTooltip title="Follow Layer5 on X (Twitter)" {...tooltipProps}>
@@ -63,6 +74,7 @@ const SocialLinksColor = () => {
                 height="30px"
                 src={bluesky_icon}
                 alt="bluesky"
+                loading="lazy"
               />
             </a>
           </CustomTooltip>
@@ -73,7 +85,12 @@ const SocialLinksColor = () => {
               rel="noreferrer"
               className="github"
             >
-              <img height="30px" src={github_icon} alt="github" />
+              <img
+                height="30px"
+                src={github_icon}
+                alt="github"
+                loading="lazy"
+              />
             </a>
           </CustomTooltip>
           <CustomTooltip title="Layer5 on LinkedIn" {...tooltipProps}>
@@ -87,6 +104,7 @@ const SocialLinksColor = () => {
                 height="30px"
                 src={linkedin_icon}
                 alt="linkedin"
+                loading="lazy"
               />
             </a>
           </CustomTooltip>
@@ -102,6 +120,7 @@ const SocialLinksColor = () => {
                 height="30px"
                 src={youtube_icon}
                 alt="youtube"
+                loading="lazy"
               />
             </a>
           </CustomTooltip>
@@ -117,6 +136,7 @@ const SocialLinksColor = () => {
                 height="30px"
                 src={docker_icon}
                 alt="docker"
+                loading="lazy"
               />
             </a>
           </CustomTooltip>

--- a/src/components/SocialLinks/index.js
+++ b/src/components/SocialLinks/index.js
@@ -20,20 +20,25 @@ const SocialLinks = () => {
             target="_blank"
             rel="noreferrer"
           >
-            <img height="40 px" src={mail_icon} alt="mail" />
+            <img height="40 px" src={mail_icon} alt="mail" loading="lazy" />
           </a>
-          <a
-            href="https://slack.layer5.io/"
-            target="_blank" rel="noreferrer"
-          >
-            <img className="slack" height="40 px" src={slack_icon} alt="slack" />
+          <a href="https://slack.layer5.io/" target="_blank" rel="noreferrer">
+            <img
+              className="slack"
+              height="40 px"
+              src={slack_icon}
+              alt="slack"
+              loading="lazy"
+            />
           </a>
-          <a
-            href="https://x.com/layer5"
-            target="_blank"
-            rel="noreferrer"
-          >
-            <img className="twitter" height="40 px" src={twitter_icon} alt="twitter" />
+          <a href="https://x.com/layer5" target="_blank" rel="noreferrer">
+            <img
+              className="twitter"
+              height="40 px"
+              src={twitter_icon}
+              alt="twitter"
+              loading="lazy"
+            />
           </a>
           <a
             className="bluesky_icon"
@@ -41,14 +46,26 @@ const SocialLinks = () => {
             target="_blank"
             rel="noreferrer"
           >
-            <img className="bluesky" height="40 px" src={bluesky_icon} alt="bluesky" />
+            <img
+              className="bluesky"
+              height="40 px"
+              src={bluesky_icon}
+              alt="bluesky"
+              loading="lazy"
+            />
           </a>
           <a
             href="https://github.com/layer5io"
             target="_blank"
             rel="noreferrer"
           >
-            <img className="github" height="40 px" src={github_icon} alt="github" />
+            <img
+              className="github"
+              height="40 px"
+              src={github_icon}
+              alt="github"
+              loading="lazy"
+            />
           </a>
           <a
             className="youtube_icon"
@@ -56,7 +73,13 @@ const SocialLinks = () => {
             target="_blank"
             rel="noreferrer"
           >
-            <img className="youtube" height="40 px" src={youtube_icon} alt="youtube" />
+            <img
+              className="youtube"
+              height="40 px"
+              src={youtube_icon}
+              alt="youtube"
+              loading="lazy"
+            />
           </a>
           <a
             className="docker_icon"
@@ -64,7 +87,13 @@ const SocialLinks = () => {
             target="_blank"
             rel="noreferrer"
           >
-            <img className="docker" height="40 px" src={docker_icon} alt="docker" />
+            <img
+              className="docker"
+              height="40 px"
+              src={docker_icon}
+              alt="docker"
+              loading="lazy"
+            />
           </a>
         </Row>
       </Col>

--- a/src/components/specs/data-card.js
+++ b/src/components/specs/data-card.js
@@ -4,60 +4,57 @@ import { Col, Row } from "../../reusecore/Layout";
 import List_Icon from "../../assets/images/app/tick.svg";
 
 const DataCardWrapper = styled.div`
-  background: ${props => props.theme.grey222222ToWhite};
+  background: ${(props) => props.theme.grey222222ToWhite};
   border-radius: 10px;
-  color: ${props => props.theme.text};
+  color: ${(props) => props.theme.text};
   padding: 2rem;
   transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
-  
-  ul{
+
+  ul {
     list-style: none;
     padding: 0;
   }
-    .col-1 li{
-      display: flex;
-      align-items: center;
-      vertical-align: center;
-      margin-bottom: 1.5rem;
-      img{
-        margin-right: 1rem;
-      }
-      h5{
-        font-weight: 600;
-        transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
-      }
-     }
-     
-    .col-2 li {
-      h3{
-        color: ${props => props.theme.secondaryColor};
-        font-weight: 700;
-      }
-      p {
-        font-size: 16px;
-      }
-    } 
-     
-    
+  .col-1 li {
+    display: flex;
+    align-items: center;
+    vertical-align: center;
+    margin-bottom: 1.5rem;
+    img {
+      margin-right: 1rem;
+    }
+    h5 {
+      font-weight: 600;
+      transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
+    }
+  }
+
+  .col-2 li {
+    h3 {
+      color: ${(props) => props.theme.secondaryColor};
+      font-weight: 700;
+    }
+    p {
+      font-size: 16px;
+    }
+  }
 `;
 
 const DataCard = () => {
-
   return (
     <DataCardWrapper>
       <Row $Vcenter>
         <Col className="col-1" sm={6} lg={6}>
           <ul>
             <li>
-              <img src={List_Icon} alt="Performance Icon" />
+              <img src={List_Icon} alt="" aria-hidden="true" loading="lazy" />
               <h5>Extensive library of integrations</h5>
             </li>
             <li>
-              <img src={List_Icon} alt="Configuration Icon" />
+              <img src={List_Icon} alt="" aria-hidden="true" loading="lazy" />
               <h5>Infrastructure orchestration</h5>
             </li>
             <li>
-              <img src={List_Icon} alt="Performance Icon" />
+              <img src={List_Icon} alt="" aria-hidden="true" loading="lazy" />
               <h5>Multi-player editing</h5>
             </li>
           </ul>
@@ -65,15 +62,15 @@ const DataCard = () => {
         <Col className="col-1" sm={6} lg={6}>
           <ul>
             <li>
-              <img src={List_Icon} alt="Performance Icon" />
+              <img src={List_Icon} alt="" aria-hidden="true" loading="lazy" />
               <h5>Ready-to-use templates</h5>
             </li>
             <li>
-              <img src={List_Icon} alt="Configuration Icon" />
+              <img src={List_Icon} alt="" aria-hidden="true" loading="lazy" />
               <h5>Visual drag & drop</h5>
             </li>
             <li>
-              <img src={List_Icon} alt="Performance Icon" />
+              <img src={List_Icon} alt="" aria-hidden="true" loading="lazy" />
               <h5>Operate with No Code</h5>
             </li>
           </ul>


### PR DESCRIPTION
## Description

Fixes #6452

This PR improves page performance by deferring the loading of non-critical offscreen SVG icons.

### What Changed

* Added `loading="lazy"` to offscreen social icons in:

  * `src/components/SocialLinks/index.js`
  * `src/components/SocialLinks-Color/index.js`

* Added `loading="lazy"` to decorative checkmark icons in:

  * `src/components/specs/data-card.js`

* Improved accessibility for decorative icons by:

  * Setting `alt=""`
  * Adding `aria-hidden="true"`

### Why

The goal of this change is to reduce unnecessary image loading during the initial page render by deferring icons that are not immediately visible to users. This aligns with the recommendations in Issue #6452 and helps improve page performance without affecting above-the-fold content.

### Validation

* Investigated image usage before implementation.
* Kept the scope limited to clearly offscreen icons.
* Excluded ProfileCard badge images after confirming they may be visible on initial page load.
* Linting and formatting checks passed successfully.

### Impact

* Defers loading of non-critical SVG assets.
* Reduces initial network requests.
* Improves accessibility for decorative icons.
* Keeps the change small, focused, and low risk.
