### PR TITLE
[CI] Fix invalid reusable workflow call in feature-list.yml

### DIFF
--- a/.github/workflows/feature-list.yml
+++ b/.github/workflows/feature-list.yml
@@ -50,9 +50,3 @@ jobs:
           commit_user_email: ci@layer5.io
           commit_author: 'l5io <l5io@users.noreply.github.com>'
 
-  call-build-and-deploy--workflow:
-    needs:
-      - trigger-feature-list
-    name: Build and Deploy Site
-    uses: layer5io/layer5/.github/workflows/build-and-deploy-site.yml@master
-    secrets: inherit

--- a/src/sections/Pricing/feature_data.json
+++ b/src/sections/Pricing/feature_data.json
@@ -709,7 +709,7 @@
     "category": "Identity & Access Management",
     "functionOrder": "508",
     "function": "Cloud as an IDP",
-    "feature": "Own and control the user accounts of your enterprise members with Cloud your identity provider (IdP).",
+    "feature": "Own and control the user accounts of your enterprise members with Layer5 Cloud your identity provider (IdP).",
     "subscription_tier": "",
     "comparison_tiers": {
       "free": "",
@@ -1093,7 +1093,7 @@
     "category": "Support and Deployment",
     "functionOrder": "1002",
     "function": "Standard Support",
-    "feature": "Support can help you troubleshoot issues you run into. Get support via email.",
+    "feature": "Layer5 Support can help you troubleshoot issues you run into. Get support via email.",
     "subscription_tier": "TeamDesigner|TeamOperator",
     "comparison_tiers": {
       "free": "",
@@ -1109,7 +1109,7 @@
     "category": "Support and Deployment",
     "functionOrder": "1003",
     "function": "Managed Service Provider",
-    "feature": "White Label: Customize the appearance and branding of your engineering platform powered by Cloud. \n<br /><br />Multi-tenancy: Hierarchical organizations, teams, users and customizable permissioning.",
+    "feature": "White Label: Customize the appearance and branding of your engineering platform powered by Layer5 Cloud. \n<br /><br />Multi-tenancy: Hierarchical organizations, teams, users and customizable permissioning.",
     "subscription_tier": "Enterprise",
     "comparison_tiers": {
       "free": "",

--- a/src/sections/Pricing/feature_data.json
+++ b/src/sections/Pricing/feature_data.json
@@ -709,7 +709,7 @@
     "category": "Identity & Access Management",
     "functionOrder": "508",
     "function": "Cloud as an IDP",
-    "feature": "Own and control the user accounts of your enterprise members with Layer5 Cloud your identity provider (IdP).",
+    "feature": "Own and control the user accounts of your enterprise members with Cloud your identity provider (IdP).",
     "subscription_tier": "",
     "comparison_tiers": {
       "free": "",
@@ -1093,7 +1093,7 @@
     "category": "Support and Deployment",
     "functionOrder": "1002",
     "function": "Standard Support",
-    "feature": "Layer5 Support can help you troubleshoot issues you run into. Get support via email.",
+    "feature": "Support can help you troubleshoot issues you run into. Get support via email.",
     "subscription_tier": "TeamDesigner|TeamOperator",
     "comparison_tiers": {
       "free": "",
@@ -1109,7 +1109,7 @@
     "category": "Support and Deployment",
     "functionOrder": "1003",
     "function": "Managed Service Provider",
-    "feature": "White Label: Customize the appearance and branding of your engineering platform powered by Layer5 Cloud. \n<br /><br />Multi-tenancy: Hierarchical organizations, teams, users and customizable permissioning.",
+    "feature": "White Label: Customize the appearance and branding of your engineering platform powered by Cloud. \n<br /><br />Multi-tenancy: Hierarchical organizations, teams, users and customizable permissioning.",
     "subscription_tier": "Enterprise",
     "comparison_tiers": {
       "free": "",


### PR DESCRIPTION
## Description

Fixes the failing `feature-list.yml` workflow by removing the invalid `call-build-and-deploy--workflow` job.

**Error:**
Invalid workflow file: .github/workflows/feature-list.yml#L57 workflow is not reusable as it is missing a on.workflow_call trigger

**Root cause:**
 The `call-build-and-deploy--workflow` job was calling `build-and-deploy-site.yml` as a reusable workflow via `uses:`, but `build-and-deploy-site.yml` only has `on: push` and `on: workflow_dispatch` triggers; it is missing the required `on.workflow_call` trigger.

**Fix:**
 Removed the unnecessary job. The `stefanzweifel/git-auto-commit-action` step already pushes a commit to `master`, which automatically triggers `build-and-deploy-site.yml` via its existing `on: push: branches: [master]` trigger. 



**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
