### PR TITLE
fix: align INR formatPrice multiplier with declared rate

### DIFF
--- a/src/utils/currencies.js
+++ b/src/utils/currencies.js
@@ -33,7 +33,7 @@ export const Currencies = {
                 currency: "INR",
                 minimumFractionDigits: roundForDisplay ? 0 : 2,
                 maximumFractionDigits: roundForDisplay ? 0 : 2,
-            }).format(price * 88),
+            }).format(price * 88.32),
     },
 };
 


### PR DESCRIPTION
Description:
Fixes #7824

The `INR` currency entry declares `rate: 88.32` but `formatPrice()` hardcoded
`price * 88`, causing all INR prices to display ~0.36% lower than they should.

`formatSliderPrice()` already used `price * rate` correctly. This brings
`formatPrice()` into the same pattern, consistent with how EUR handles it.

Change:
`src/utils/currencies.js` line 36: `price * 88` - `price * 88.32`