### PR TITLE
fix: prevent currency label overlap on initial render

### DIFF
--- a/src/sections/Pricing/index.js
+++ b/src/sections/Pricing/index.js
@@ -76,7 +76,9 @@ export const CurrencySelect = ({ currency, setCurrency }) => {
         },
       }}
     >
-      <InputLabel id="currency-selector-label">Currency</InputLabel>
+      <InputLabel id="currency-selector-label" shrink>
+        Currency
+      </InputLabel>
       <Select
         labelId="currency-selector-label"
         value={currency}
@@ -84,6 +86,7 @@ export const CurrencySelect = ({ currency, setCurrency }) => {
           setCurrency(e.target.value);
         }}
         label="Currency"
+        notched
         MenuProps={{
           disableScrollLock: true,
           marginThreshold: null,


### PR DESCRIPTION

Fixes the currency label overlapping with the selected value (e.g., $ USD) on initial page load in the CurrencySelect component on the Pricing page.

This PR fixes #7822

https://github.com/user-attachments/assets/7e0738e2-467f-49ad-b7d1-cb0376115466



The bug only occurs on the live/production site and not in local dev mode because it is an SSR hydration timing issue. MUI does not shrink the label fast enough when a default value is already set.

Fix: Added `shrink` prop to `InputLabel` and `notched` prop to `Select`.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.