### PR TITLE
docs: replace internal handbook links with Gatsby Link

### DIFF
--- a/src/collections/handbook/community/index.mdx
+++ b/src/collections/handbook/community/index.mdx
@@ -32,8 +32,8 @@ Welcome to the Layer5 community! We're happy to have you here and handhold you f
 <div id="Resources">
   <h3> Resources </h3>
   <p><img className="logo" src={Point} alt="Point" />Be sure to access the resources <a href="https://drive.google.com/drive/u/0/folders/0ABH8aabN4WAKUk9PVA">community drive.</a></p>
-  <p><img className="logo" src={Point} alt="Point" />Sign-up on the <a href="https://layer5.io/subscribe">community mailer</a>.</p>
-  <p><img className="logo" src={Point} alt="Point" />Ask for a copy of <a href="https://layer5.io/books/the-enterprise-path-to-service-mesh-architectures">The Enterprise Path to Service Mesh Architectures.</a></p>
+  <p><img className="logo" src={Point} alt="Point" />Sign-up on the <Link to="/subscribe">community mailer</Link>.</p>
+  <p><img className="logo" src={Point} alt="Point" />Ask for a copy of <Link to="/books/the-enterprise-path-to-service-mesh-architectures">The Enterprise Path to Service Mesh Architectures.</Link></p>
 </div>
 
 Please refer to the <Link to="/community/handbook/code-of-conduct">Code of Conduct</Link> for more details.


### PR DESCRIPTION
### Description

This PR replaces internal absolute Layer5 URLs with Gatsby's `Link` component and relative paths in `src/collections/handbook/community/index.mdx`, following the repository's internal navigation guidelines.

Fixes https://github.com/layer5io/layer5/issues/7837

### Notes for Reviewers

* Replaced internal `https://layer5.io` links with Gatsby `Link` components.
* Updated links to use relative paths (`/subscribe` and `/books/the-enterprise-path-to-service-mesh-architectures`).
* No UI or functional changes.

### Signed commits

* [x] Yes, I signed my commits.
