### PR TITLE
ci: use GH_ACCESS_TOKEN for repository checkout in feature-list workflow

### DIFF
--- a/.github/workflows/feature-list.yml
+++ b/.github/workflows/feature-list.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout current repository
         uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Install Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Description

This PR updates the `feature-list.yml` GitHub Actions workflow to check out the repository using the `GH_ACCESS_TOKEN` secret instead of the default `GITHUB_TOKEN`. 

## Rationale
Using a custom GitHub Access Token (`GH_ACCESS_TOKEN`) ensures that commits pushed by the automated workflow step trigger any down-stream GitHub Actions (such as builds or deployments), which are otherwise restricted when using the default repository-scoped `GITHUB_TOKEN`.

## Changes
- Modified [.github/workflows/feature-list.yml](file:///Users/rishiraj/Desktop/layer5/.github/workflows/feature-list.yml) to add the `token: ${{ secrets.GH_ACCESS_TOKEN }}` parameter to the checkout action step.


<img width="972" height="486" alt="Screenshot 2026-07-10 at 4 16 51 AM" src="https://github.com/user-attachments/assets/c6dd48e6-9d04-4391-af06-cbd413e0de05" />



**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
