### PR TITLE
fix: correct docker extension icon hover effect

### DIFF
--- a/src/sections/Projects/Project-grid/projectGrid.style.js
+++ b/src/sections/Projects/Project-grid/projectGrid.style.js
@@ -68,6 +68,12 @@ export const ProjectWrapper = styled.div`
       transition: 0.4s;
       transform: scale(1.05);
     }
+    &.seven:hover {
+      img {
+        filter: saturate(0) brightness(3) contrast(5)
+          url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='teal'%3E%3CfeColorMatrix type='matrix' values='1 0 0 0 0 0 0.30196 0 0 0.698039 0 0 0.38039 0 0.619607 0 0 0 1 0'/%3E%3C/filter%3E%3C/svg%3E#teal");
+      }
+    }
   }
   .project__card-container {
     max-width: 100%;
@@ -199,7 +205,7 @@ export const ProjectWrapper = styled.div`
     h5 {
       align-self: center;
     }
-}
+  }
 
   // Service Mesh Performance
   .project__card.five {


### PR DESCRIPTION
**Description**

This PR fixes #7886

The Meshery Docker Extension icon in the Projects grid previously rendered incorrectly. The logo now recolors to white and teal on hover.

https://github.com/user-attachments/assets/882e5dfb-5e26-42a8-9d43-f441578fe043


**Notes for Reviewers**

- Removed the generic `invert(1)` filter on the Docker Extension card and applied a targeted SVG data URI filter in `projectGrid.style.js`.
- Verified locally that the layout remains responsive and the hover state cleanly matches the surrounding project icons.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the hover behavior for the seventh project card with a custom visual filter applied to its image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->