### PR TITLE
[Meshery] Redesign GitHub star call-to-action button

### DIFF
--- a/src/components/GitHubStarButtonBanner/GitHubStarButtonBanner.js
+++ b/src/components/GitHubStarButtonBanner/GitHubStarButtonBanner.js
@@ -105,7 +105,13 @@ const GitHubStarButtonBanner = ({
 
   useEffect(() => {
     const cacheKey = `gh_stars_${repo.replace("/", "_")}`;
-    const cached = localStorage.getItem(cacheKey);
+    let cached = null;
+
+    try {
+      cached = localStorage.getItem(cacheKey);
+    } catch {
+      cached = null;
+    }
 
     if (cached) {
       try {
@@ -116,9 +122,14 @@ const GitHubStarButtonBanner = ({
           return;
         }
       } catch {
-        localStorage.removeItem(cacheKey);
+        try {
+          localStorage.removeItem(cacheKey);
+        } catch {
+          // Ignore storage errors
+        }
       }
     }
+    localStorage.setItem;
 
     fetch(`https://api.github.com/repos/${repo}`)
       .then((res) => {
@@ -128,10 +139,14 @@ const GitHubStarButtonBanner = ({
       .then((data) => {
         if (data.stargazers_count !== undefined) {
           const count = data.stargazers_count;
-          localStorage.setItem(
-            cacheKey,
-            JSON.stringify({ count, timestamp: Date.now() }),
-          );
+          try {
+            localStorage.setItem(
+              cacheKey,
+              JSON.stringify({ count, timestamp: Date.now() }),
+            );
+          } catch {
+            // Ignore storage errors
+          }
           setStars(count);
         }
       })

--- a/src/components/GitHubStarButtonBanner/GitHubStarButtonBanner.js
+++ b/src/components/GitHubStarButtonBanner/GitHubStarButtonBanner.js
@@ -56,7 +56,8 @@ const BannerButton = styled.a`
   }
 
   &:focus-visible {
-    outline: 2px solid ${({ theme }) => theme.activeColor};
+  outline: 2px solid ${({ theme }) =>
+  theme.activeColor || theme.bannerAccent || "#2bb77c"};
     outline-offset: 3px;
   }
 

--- a/src/components/GitHubStarButtonBanner/GithubButton.js
+++ b/src/components/GitHubStarButtonBanner/GithubButton.js
@@ -1,0 +1,170 @@
+import React, { useState, useEffect } from "react";
+import { FaGithub } from "@react-icons/all-files/fa/FaGithub";
+import { FaStar } from "@react-icons/all-files/fa/FaStar";
+import styled from "styled-components";
+
+const BannerButton = styled.a`
+  box-sizing: border-box;
+  position: relative;
+  isolation: isolate;
+
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  min-width: 200px;
+  padding: 12px 30px;
+
+  color: ${({ theme }) => theme.bannerText || "#f0f6fc"};
+
+  font-family: inherit;
+  font-size: 15px;
+  font-weight: 500;
+  line-height: 1.2;
+
+  text-decoration: none;
+  text-transform: none;
+
+  transition: 250ms ease;
+
+  /* --- Hexagonal banner shape lives on a pseudo-element so clip-path never clips the focus ring --- */
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+
+    background: ${({ theme }) => theme.bannerBg || "#0d1117"};
+    border: 1px solid ${({ theme }) => theme.bannerAccent || "#2bb77c"};
+    clip-path: polygon(4% 0%, 96% 0%, 100% 50%, 96% 100%, 4% 100%, 0% 50%);
+
+    transition: inherit;
+  }
+
+  &:hover::before {
+    border-color: ${({ theme }) => theme.bannerAccentHover || "#3fd9a0"};
+    background: ${({ theme }) => theme.bannerBgHover || "#131a22"};
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.activeColor};
+    outline-offset: 3px;
+  }
+
+  &:visited {
+    color: ${({ theme }) => theme.bannerText || "#f0f6fc"};
+  }
+
+  .banner-action,
+  .banner-count {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .banner-count {
+    padding-left: 16px;
+    margin-left: 16px;
+    border-left: 1px dashed ${({ theme }) => theme.bannerAccent || "#2bb77c"};
+  }
+
+  .banner-icon {
+    flex-shrink: 0;
+    color: ${({ theme }) => theme.bannerAccent || "#2bb77c"};
+  }
+
+  @media (max-width: 768px) {
+    min-width: 180px;
+    padding: 12px 24px;
+    font-size: 14px;
+
+    .banner-count {
+      padding-left: 12px;
+      margin-left: 12px;
+    }
+  }
+`;
+
+const GitHubStarButtonBanner = ({
+  repo = "meshery/meshery",
+  url = "https://github.com/meshery/meshery",
+  className,
+  ...props
+}) => {
+  const [stars, setStars] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const cacheKey = `gh_stars_${repo.replace("/", "_")}`;
+    const cached = localStorage.getItem(cacheKey);
+
+    if (cached) {
+      try {
+        const { count, timestamp } = JSON.parse(cached);
+        if (Date.now() - timestamp < 3600000) {
+          setStars(count);
+          setLoading(false);
+          return;
+        }
+      } catch {
+        localStorage.removeItem(cacheKey);
+      }
+    }
+
+    fetch(`https://api.github.com/repos/${repo}`)
+      .then((res) => {
+        if (!res.ok) throw new Error("GitHub API error");
+        return res.json();
+      })
+      .then((data) => {
+        if (data.stargazers_count !== undefined) {
+          const count = data.stargazers_count;
+          localStorage.setItem(
+            cacheKey,
+            JSON.stringify({ count, timestamp: Date.now() }),
+          );
+          setStars(count);
+        }
+      })
+      .catch(() => {
+        // silent fail
+      })
+      .finally(() => setLoading(false));
+  }, [repo]);
+
+  const formatCount = (num) => {
+    if (num >= 1000) return (num / 1000).toFixed(1) + "k";
+    return num;
+  };
+
+  return (
+    <BannerButton
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={`Star ${repo} on GitHub`}
+      className={className}
+      {...props}
+    >
+      <span className="banner-action">
+        <FaGithub className="banner-icon" size={18} />
+        Star on GitHub
+      </span>
+      <span className="banner-count">
+        <FaStar className="banner-icon" size={14} />
+        {loading ? "…" : stars !== null ? formatCount(stars) : "Star"}
+      </span>
+    </BannerButton>
+  );
+};
+
+export default GitHubStarButtonBanner;

--- a/src/sections/Meshery/index.js
+++ b/src/sections/Meshery/index.js
@@ -15,7 +15,7 @@ import Features from "./Meshery-features";
 import InlineQuotes from "../../components/Inline-quotes";
 import Maximiliano from "../../collections/members/maximiliano-churichi/Maximiliano-Churichi.webp";
 import Nic from "../../collections/members/nicholas-jackson/nic-jackson.webp";
-import GitHubStarButtonBanner from "../../components/GitHubStarButtonBanner/GithubButton";
+import GitHubStarButtonBanner from "../../components/GitHubStarButtonBanner/GitHubStarButtonBanner";
 
 const MesheryPage = () => {
   return (
@@ -26,7 +26,6 @@ const MesheryPage = () => {
             <Col className="desc-text" $lg={6} $md={6} $sm={10} $xs={8}>
               <h1 className="heading-1"> Wrangle your infrastructure</h1>
               <h1 className="heading-2">
-                {" "}
                 <span className="heading-2"> collaboratively</span>
               </h1>
               <p className="desc-p">

--- a/src/sections/Meshery/index.js
+++ b/src/sections/Meshery/index.js
@@ -4,7 +4,6 @@ import Button from "../../reusecore/Button";
 import { FiDownloadCloud } from "@react-icons/all-files/fi/FiDownloadCloud";
 import { GiClockwork } from "@react-icons/all-files/gi/GiClockwork";
 
-import { FaGithub } from "@react-icons/all-files/fa/FaGithub";
 import FeaturesTable from "./Features-Col";
 
 import mesheryDemo from "../../../static/video/meshery/dashboard.webm";
@@ -16,6 +15,7 @@ import Features from "./Meshery-features";
 import InlineQuotes from "../../components/Inline-quotes";
 import Maximiliano from "../../collections/members/maximiliano-churichi/Maximiliano-Churichi.webp";
 import Nic from "../../collections/members/nicholas-jackson/nic-jackson.webp";
+import GitHubStarButtonBanner from "../../components/GitHubStarButtonBanner/GithubButton";
 
 const MesheryPage = () => {
   return (
@@ -25,32 +25,39 @@ const MesheryPage = () => {
           <Row className="description">
             <Col className="desc-text" $lg={6} $md={6} $sm={10} $xs={8}>
               <h1 className="heading-1"> Wrangle your infrastructure</h1>
-              <h1 className="heading-2"> <span className="heading-2"> collaboratively</span></h1>
+              <h1 className="heading-2">
+                {" "}
+                <span className="heading-2"> collaboratively</span>
+              </h1>
               <p className="desc-p">
                 {/* Meshery is the cloud native manager. <br /> */}
-                Confidently design, deploy, and operate your infrastructure and workloads with Meshery.
+                Confidently design, deploy, and operate your infrastructure and
+                workloads with Meshery.
               </p>
-              <Button $primary className="banner-btn" title="Schedule a Demo" $external={true}
+              <Button
+                $primary
+                className="banner-btn"
+                title="Schedule a Demo"
+                $external={true}
                 $url="https://calendar.google.com/calendar/appointments/schedules/AcZssZ3pmcApaDP4xd8hvG5fy8ylxuFxD3akIRc5vpWJ60q-HemQi80SFFAVftbiIsq9pgiA2o8yvU56?gv=true"
               >
                 <GiClockwork size={21} className="button-icon" />
               </Button>
-              <Button $secondary className="banner-btn" title="Run Meshery"
+              <Button
+                $secondary
+                className="banner-btn"
+                title="Run Meshery"
                 $url="/cloud-native-management/meshery/getting-started"
               >
                 <FiDownloadCloud size={21} className="button-icon" />
               </Button>
             </Col>
             <Col $lg={6} $md={6} className="meshery-hero-img desc-text">
-              <video autoPlay muted loop controls className="meshery-video" >
+              <video autoPlay muted loop controls className="meshery-video">
                 <source src={mesheryDemo} type="video/webm" />
               </video>
               {/* <img className="meshery-sup-img" src={mesheryFullStack} alt="Meshery the multi-mesh manager" /> */}
-              <Button $primary className="banner-btn align-btn"
-                title="Star the Repository" $url="https://github.com/meshery/meshery" $external={ true }
-              >
-                <FaGithub size={21} className="button-icon" />
-              </Button>
+              <GitHubStarButtonBanner />
             </Col>
           </Row>
         </div>
@@ -65,7 +72,10 @@ const MesheryPage = () => {
           image={Nic}
         />
         <div className="callout">
-          <h1> Manage your clusters with features you won't find anywhere else.</h1>
+          <h1>
+            {" "}
+            Manage your clusters with features you won't find anywhere else.
+          </h1>
         </div>
       </Container>
       <Features />
@@ -79,7 +89,6 @@ const MesheryPage = () => {
         />
       </Container>
     </MesheryWrapper>
-
   );
 };
 


### PR DESCRIPTION
**Description**

This PR fixes #7859.

### Changes Made

* Replaced the existing yellow rounded "Star the Repository" button with a unique banner-style GitHub call-to-action.
* Added GitHub and star icons for improved visual recognition.
* Displayed the live GitHub star count using the GitHub API.
* Created a reusable `GitHubStarButtonBanner` component for future use.
* Preserved accessibility with appropriate ARIA labels and keyboard focus styles.

**Notes for Reviewers**

Before 
<img width="1141" height="238" alt="Screenshot 2026-07-26 at 1 47 52 AM" src="https://github.com/user-attachments/assets/7569f1cc-e002-4471-9b5b-ebabc8ec2ad9" />
**After**
<img width="1141" height="238" alt="Screenshot 2026-07-26 at 1 48 48 AM" src="https://github.com/user-attachments/assets/bed62fd1-cc31-4095-9cdf-576db4ea7f6e" />


* The new design intentionally differentiates the GitHub CTA from the existing primary action buttons ("Schedule A Demo" and "Run Meshery"), as requested in the issue.
* The star count is cached client-side to reduce unnecessary GitHub API requests.
* The component is reusable and can be adopted on other repository pages if desired.

**[[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

* [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a GitHub star count banner to the Meshery page, replacing the previous inline GitHub button.
  - Shows a loading state, then updates with the repository’s star count (including compact “k” formatting) and refreshes via a short-lived cache.
  - External link behavior is safer and includes improved accessibility labeling.

- **Style**
  - Refreshed the Meshery banner layout/typography for the main headline and callout while keeping the same CTAs and content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->