### PR TITLE
[UI] Fix article card image alignment on Resources page

### DIFF
--- a/src/components/Card/Card.style.js
+++ b/src/components/Card/Card.style.js
@@ -121,6 +121,15 @@ export const CardWrapper = styled.div`
   ${(props) =>
     !props.$listView &&
     `
+    .post-thumb-block .old-gatsby-image-wrapper {
+      height: 100% !important;
+    }
+    .post-thumb-block .old-gatsby-image-wrapper img {
+      width: 100% !important;
+      height: 100% !important;
+      object-fit: cover !important;
+    }
+
     @media screen and (max-width: 1200px) and (min-width: 992px) {
       .post-thumb-block {
         height: auto;


### PR DESCRIPTION
## Description

Fixes #7912.

On the Resources page, thumbnails of article cards are not aligned consistently. Cards using SVG thumbnails render at their natural height (the old-gatsby-image-wrapper carries an inline height: auto), so images sit at different vertical positions inside the fixed thumb block. Raster thumbnails, which go through GatsbyImage, already fill the block.

### Changes
- In grid view, force the old-gatsby-image-wrapper and its img to fill the thumb block (height: 100%, object-fit: cover), matching the behavior of GatsbyImage thumbnails.

### Screenshots
Not available, issue screenshot referenced in #7912.

I have raised this PR for the fix and would appreciate being assigned to the issue #7912 as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved legacy image thumbnails outside list view so images fill their designated areas consistently.
  * Updated image fitting to use a cover layout, reducing empty space and improving visual presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->