### PR TITLE
fix(sistent): preserve sidebar scroll position across navigation

### DIFF
--- a/src/components/SistentNavigation/index.js
+++ b/src/components/SistentNavigation/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { HiOutlineChevronLeft } from "@react-icons/all-files/hi/HiOutlineChevronLeft";
 import { Link, graphql, useStaticQuery } from "gatsby";
 import { IoIosArrowForward } from "@react-icons/all-files/io/IoIosArrowForward";
@@ -20,6 +20,19 @@ const TOC = () => {
   const [expandComponent, setExpandComponent] = useState(
     location.pathname.includes("/components")
   );
+
+  const tocListRef = useRef(null);
+
+  useEffect(() => {
+    try {
+      const saved = sessionStorage.getItem("sistent-toc-scroll");
+      if (saved && tocListRef.current) {
+        tocListRef.current.scrollTop = Number(saved) || 0;
+      }
+    } catch (e) {
+      console.warn("Could not restore Sistent TOC scroll position:", e);
+    }
+  }, []);
 
   // Fetch component data dynamically from GraphQL
   const data = useStaticQuery(graphql`
@@ -71,7 +84,17 @@ const TOC = () => {
           )}
         </div>
       </div>
-      <div className="toc-list">
+      <div
+        className="toc-list"
+        ref={tocListRef}
+        onScroll={(e) => {
+          try {
+            sessionStorage.setItem("sistent-toc-scroll", e.target.scrollTop);
+          } catch {
+            // Ignore storage errors
+          }
+        }}
+      >
         <ul className={`toc-ul ${expand ? "toc-ul-open" : ""}`}>
           <li>
             <div>


### PR DESCRIPTION
**Description**

This PR fixes #7911 
 Preserves the scroll position of the Sistent TOC sidebar across page navigations by storing the scroll offset in sessionStorage on scroll and restoring it on component mount.
 
 ## Screen recording


https://github.com/user-attachments/assets/3e3a1e71-a7cc-46b7-95e7-9ed6af84fde1





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the table of contents scroll position when navigating away and returning to a page.
  * Restored the previous scroll position automatically for a smoother navigation experience.
  * Saved the latest table of contents position while scrolling for more reliable restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->