### PR TITLE
fix(programs): fix Layer5 logo rendering on initial load

### DIFF
--- a/src/sections/Careers/Careers-Programs-grid/index.js
+++ b/src/sections/Careers/Careers-Programs-grid/index.js
@@ -62,7 +62,7 @@ const ProgramsGrid = ({ hide_path, sub_section }) => {
 
   let path = hide_path ? "" : "Programs";
   let programsArray = [];
-  const { isDark } = useStyledDarkMode();
+  const { isDark, didLoad } = useStyledDarkMode();
 
   const programs = data.allMdx.nodes.filter((item) => {
     if (programsArray.indexOf(item.frontmatter.program) >= 0) {
@@ -134,6 +134,7 @@ const ProgramsGrid = ({ hide_path, sub_section }) => {
                             {...((frontmatter.darkthumbnail ||
                               frontmatter.darkthumbnail_svg) &&
                             isDark &&
+                            didLoad &&
                             (frontmatter.darkthumbnail?.publicURL ||
                               frontmatter.darkthumbnail_svg?.publicURL) !==
                               (frontmatter.thumbnail?.publicURL ||


### PR DESCRIPTION
### Summary

This PR fixes #7929 

Fixes an intermittent issue on the `/careers/programs` page where the Layer5 logo sometimes incorrectly displays its light-theme variant on initial load when the site is actually in dark mode. 

### Root Cause
The `ProgramsGrid` component conditionally renders the dark theme thumbnail based on `isDark` 
During Server-Side Rendering , `isBrowser` evaluates to false, causing `isDark` to default to `false` and outputting the light-theme logo image source. During the initial client render, `useStyledDarkMode()` immediately sets `isDark=true` by reading `window.__theme`. Because the initial client render differs from the server render, leaving the image stuck on the light-theme asset until a subsequent state change (like toggling themes) forces a clean re-render.

### Solution
Added the `didLoad` variable from `useStyledDarkMode()` to the `Image` component's conditional rendering logic.
By verifying `isDark && didLoad`, we ensure that during the initial hydration pass (`didLoad = false`), the condition evaluates to `false`, matching the server's render. Immediately after hydration, `ThemeManagerContext` flips `didLoad` to `true` in a `useEffect`, causing a clean React update that safely swaps the image source to the dark theme asset without any mismatches.

This brings the component in line with existing theme-aware patterns used elsewhere in the repository (e.g., `sections/Home/Projects-home/index.js` and `sections/General/Faq/index.js`).

### Screen Recording 
**Before:**

https://github.com/user-attachments/assets/62b3a43d-26b0-4a2b-a1c6-462636331b61

**After:**

https://github.com/user-attachments/assets/74741d05-46f7-449d-8208-d06f8ed30904

---

# Testing
- [x] Verified direct load in dark mode (Logo renders dark)
- [x] Verified direct load in light mode (Logo renders light)
- [x] Verified repeated refreshes (No intermittent mismatch caching)
- [x] Verified theme toggling (Dark → Light → Dark works flawlessly)
- [x] Verified no console warnings (Hydration warnings resolved)
- [x] Verified no regressions (Layout and styling preserved perfectly)


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dark-mode career program thumbnails by ensuring the correct dark images appear only after theme settings finish loading.
  * Prevented dark thumbnails from displaying prematurely or when a dedicated dark image is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->