### PR TITLE
fix: correct dark theme typography on Docker Extension page

### DIFF
--- a/src/sections/Docker-Meshery/dockerMeshery.style.js
+++ b/src/sections/Docker-Meshery/dockerMeshery.style.js
@@ -46,8 +46,6 @@ export const DockerMesheryWrapper = styled.div`
             }
           }
         }
-    }
-
     p.uppercase { 
         text-align: center;
         text-transform: uppercase; 
@@ -88,7 +86,7 @@ export const DockerMesheryWrapper = styled.div`
       align-items: center;
     }
     .dockerMesherySection {
-      margin: auto;
+      margin: 4rem auto;
     }
     div.feature-title {
       background-color: ${(props) => props.theme.saffronLightColor};
@@ -96,7 +94,7 @@ export const DockerMesheryWrapper = styled.div`
       font-weight: 500;
       margin-bottom: .3rem;
       line-height: 1.25rem;
-      color: black;
+      color: ${(props) => props.theme.text};
       padding: 5%;
       border-radius: 1rem;
     }


### PR DESCRIPTION
### Description

This PR fixes #7930 

Fixes the dark-theme typography issue on the Docker Extension for Meshery page while correcting an underlying styled-components CSS parsing issue.

### Root Cause

- An unmatched closing brace prematurely terminated the styled-components block.
- The CSS parser (`stylis`) consequently mis-scoped the selectors that followed.
- Several declarations unintentionally leaked onto the root wrapper, assigning properties meant for specific elements (like margins and padding) to the entire page wrapper.
- The production layout appeared "contained" only because those leaked declarations accidentally applied horizontal wrapper margins (`4rem 4rem`) and wrapper padding (`5%`).
- After restoring the intended CSS scope, the layout behaves correctly and the hero properly spans the full width as originally implemented.

### Solution

- Removes the unmatched closing brace.
- Restores proper selector scoping to the styling sheet.
- Replaces the hardcoded `color: black` with the theme-aware `props.theme.text`.
- Adds spacing to `.dockerMesherySection` so the first content section has appropriate vertical separation from the hero, while correctly keeping the hero full-width.
- Does not modify any unrelated styling or component behavior.

### Screen Recording



**Before:**
<img width="400" height="450" alt="image" src="https://github.com/user-attachments/assets/853348e1-d1c7-47d8-8979-807ccf7ea891" width="50%"/> <img width="400" height="450" alt="image" src="https://github.com/user-attachments/assets/bf301123-0099-4891-a584-0ed5625d695b" width="50%"/>


**After:**

https://github.com/user-attachments/assets/f104d6c7-ad20-4c39-809e-1459e81a04e6



### Testing

- [x] Verified light theme
- [x] Verified dark theme
- [x] Verified hero renders full width
- [x] Verified spacing between hero and first content section
- [x] Verified typography is readable in dark mode
- [x] Verified no regressions in light mode
- [x] Verified only the intended file was modified


### Notes

The implementation intentionally keeps the diff minimal by addressing only the root causes and preserving the existing design and component structure.


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Fixed layout styling in the Docker Meshery section.
  * Updated section spacing for improved visual alignment.
  * Adjusted feature title text to use the theme’s standard color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->