### PR TITLE
Fix Academy comparison table rendering

### DIFF
--- a/src/collections/resources/Resources.style.js
+++ b/src/collections/resources/Resources.style.js
@@ -10,6 +10,25 @@ export const ResourcesWrapper = styled.div`
     text-align: left;
     margin-top: 2rem;
   }
+
+  div.comparison table {
+    border-collapse: collapse;
+    margin: 1.5rem 0 2rem;
+    width: 100%;
+  }
+
+  div.comparison th,
+  div.comparison td {
+    border: 1px solid ${props => props.theme.borderColor || props.theme.primaryLightColor};
+    padding: 0.75rem;
+    text-align: left;
+    vertical-align: top;
+  }
+
+  div.comparison th {
+    background-color: ${props => props.theme.secondaryLightColorTwo};
+    font-weight: 600;
+  }
   
   .sub-heading {
     color: gray;

--- a/src/collections/resources/Resources.style.js
+++ b/src/collections/resources/Resources.style.js
@@ -29,6 +29,21 @@ export const ResourcesWrapper = styled.div`
     background-color: ${props => props.theme.secondaryLightColorTwo};
     font-weight: 600;
   }
+
+  div.comparison td[data-status="yes"] {
+    color: ${props => props.theme.secondaryColor};
+    font-weight: 600;
+  }
+
+  div.comparison td[data-status="partial"] {
+    color: ${props => props.theme.highlightColor};
+    font-weight: 600;
+  }
+
+  div.comparison td[data-status="no"] {
+    color: ${props => props.theme.errorColor};
+    font-weight: 600;
+  }
   
   .sub-heading {
     color: gray;

--- a/src/collections/resources/Resources.style.js
+++ b/src/collections/resources/Resources.style.js
@@ -17,6 +17,11 @@ export const ResourcesWrapper = styled.div`
     width: 100%;
   }
 
+  div.comparison__table-wrapper {
+    max-width: 100%;
+    overflow-x: auto;
+  }
+
   div.comparison th,
   div.comparison td {
     border: 1px solid ${props => props.theme.borderColor || props.theme.primaryLightColor};

--- a/src/collections/resources/comparison/layer5-academy-vs-moocit/index.mdx
+++ b/src/collections/resources/comparison/layer5-academy-vs-moocit/index.mdx
@@ -4,19 +4,18 @@ subtitle: Academy Comparison
 date: 2025-08-18 08:00:00 -0530
 thumbnail: ../../../../assets/images/academy/academy-layer5-light.png
 darkthumbnail: ../../../../assets/images/academy/academy-layer5.png
-description: "Layer5 Academy vs Moocit Comaprision"
+description: "Layer5 Academy vs Moocit Comparison"
 type: Comparison
 category: Academy
 tags:
   - Academy
-  - Moocit 
+  - Moocit
 featured: false
 published: true
 resource: true
 ---
 
 import { ResourcesWrapper } from "../../Resources.style.js";
-
 
 <ResourcesWrapper>
 <div className="comparison">
@@ -33,66 +32,265 @@ The following details highlight the key differences between Layer5 Academy and M
 
 It is the backbone of the platform, enabling instructors to easily design, structure, and deliver courses. This includes tools for creating multimedia lessons, managing modules, setting prerequisites, and organizing assessments to ensure a seamless teaching process.
 
-
-| Feature | Moocit | Layer5 | Notes |
-|---------|--------|--------|-------|
-| Content Variety | ✅ | ✅ | Both: Support text, images, videos, PDFs |
-| Interactive Learning | ✅ | ✅ | Both: Quizzes, tests, self-assessment |
-| Learning Paths/Tracks | ✅ | ✅ | Both: Support sequential paths and prerequisites |
-| Course Publishing | ✅ | ✅ | Moocit: Web-based approach to content creation and publishing with incremental instant and scheduled releases. Layer5: Gitflow based approach to content creation and publishing is gitflow based with version-controlled publishing.  |
-| Course Management | ✅ | ✅ | Both: Tools to organize, assign, and manage |
-| Course Tracking | ✅ | ✅ | Both: Track learner progress and completion |
-| Course Authoring | ⚠️ | ✅ | Moocit: uses the Open edX platform with XML-based authoring. Layer5: uses a modern Hugo static site generator with Markdown-based authoring. |
-| Public Catalog | ❌ | ✅ | Moocit: Lacks browsable, public catalog. Layer5: Provides comprehensive discoverability with browsable, public catalog. |
+<table>
+  <thead>
+    <tr>
+      <th>Feature</th>
+      <th>Moocit</th>
+      <th>Layer5</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Content Variety</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>Both: Support text, images, videos, PDFs</td>
+    </tr>
+    <tr>
+      <td>Interactive Learning</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>Both: Quizzes, tests, self-assessment</td>
+    </tr>
+    <tr>
+      <td>Learning Paths/Tracks</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>Both: Support sequential paths and prerequisites</td>
+    </tr>
+    <tr>
+      <td>Course Publishing</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>Moocit: Web-based approach to content creation and publishing with incremental instant and scheduled releases. Layer5: Gitflow based approach to content creation and publishing with version-controlled publishing.</td>
+    </tr>
+    <tr>
+      <td>Course Management</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>Both: Tools to organize, assign, and manage</td>
+    </tr>
+    <tr>
+      <td>Course Tracking</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>Both: Track learner progress and completion</td>
+    </tr>
+    <tr>
+      <td>Course Authoring</td>
+      <td>Partial</td>
+      <td>Yes</td>
+      <td>Moocit: uses the Open edX platform with XML-based authoring. Layer5: uses a modern Hugo static site generator with Markdown-based authoring.</td>
+    </tr>
+    <tr>
+      <td>Public Catalog</td>
+      <td>No</td>
+      <td>Yes</td>
+      <td>Moocit: Lacks browsable, public catalog. Layer5: Provides comprehensive discoverability with browsable, public catalog.</td>
+    </tr>
+  </tbody>
+</table>
 
 ### Learner Experience
 
 Learner experience emphasizes intuitive design, collaboration, and flexibility. Both platforms enable personalized learning, progress tracking, and interactive engagement, with Layer5 extending into real-time collaboration via [Kanvas](/cloud-native-management/kanvas).
 
-| Feature | Moocit | Layer5 | Notes |
-|---------|--------|--------|-------|
-| Learner Portal | ✅ | ✅ | |
-| Self-paced Learning | ✅ | ✅ | |
-| Instructor-led Learning | ✅ | ✅ | | 
-| Mobile Learning | ✅ | ✅ | |
-| Certificate Generation | ✅ | ✅ | Both: Shareable certifications |
-| Social Learning | ✅ | ✅ | Both: Forums, discussions. Layer5: Kanvas and Slack. |
-| Learner Profile | ⚠️ | ✅| Moocit: Limited support for interactive profiles. Layer5: Comprehensive learner profiles with progress tracking and social features. |
-| Group / Synchronous Learning | ❌ | ✅ | Layer5: Real-time, collaborative learning. |
-| Hands-on Labs | ❌ | ✅ | Layer5:  through Kanvas |
+<table>
+  <thead>
+    <tr>
+      <th>Feature</th>
+      <th>Moocit</th>
+      <th>Layer5</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Learner Portal</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Self-paced Learning</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Instructor-led Learning</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Mobile Learning</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Certificate Generation</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>Both: Shareable certifications</td>
+    </tr>
+    <tr>
+      <td>Social Learning</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>Both: Forums, discussions. Layer5: Kanvas and Slack.</td>
+    </tr>
+    <tr>
+      <td>Learner Profile</td>
+      <td>Partial</td>
+      <td>Yes</td>
+      <td>Moocit: Limited support for interactive profiles. Layer5: Comprehensive learner profiles with progress tracking and social features.</td>
+    </tr>
+    <tr>
+      <td>Group / Synchronous Learning</td>
+      <td>No</td>
+      <td>Yes</td>
+      <td>Layer5: Real-time, collaborative learning.</td>
+    </tr>
+    <tr>
+      <td>Hands-on Labs</td>
+      <td>No</td>
+      <td>Yes</td>
+      <td>Layer5: through Kanvas</td>
+    </tr>
+  </tbody>
+</table>
 
 ### Administration & Analytics
 
 Both platforms deliver robust administration capabilities with user management, analytics, and compliance tools. Layer5 extends customization through its cloud-native ecosystem integration.
 
-| Feature | Moocit | Layer5 | Notes |
-|---------|--------|--------|-------|
-| Assessment Management | ✅ | ✅ | Both: Build and evaluate assessments. |
-| Gradebook | ✅ | ✅ | Both: Track grades and scores. |
-| Reporting & Statistics | ✅ | ✅ | Both: Insights into learner engagement and performance. |
-| User Management | ⚠️ | ✅ | Moocit: Manage user accounts. Layer5: Manage user accounts with granular and customizable permissions and roles. |
-| Group Creation and Management |  ✅ | ✅ | Both: Allow instructors to organize students and content into different groups. |
-| Single Sign-On (SSO) | ❌ | ✅ | Layer5: Enhanced identity and granular access control. |
-| Branded Academy Invitations | ❌ | ✅ | Layer5: Approval queues, domain-based allowances. |
-| Branded Content Announcements | ❌ | ✅ | Layer5: New content announcements |
-| Public Clouds | ❌ | ✅ | Layer5: AWS, Azure, GCP, DigitalOcean, and an Kubernetes service |
-| Orchestration Support | ❌ | ✅ | Layer5: Hundreds of CNCF ecosystem integrations |
+<table>
+  <thead>
+    <tr>
+      <th>Feature</th>
+      <th>Moocit</th>
+      <th>Layer5</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Assessment Management</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>Both: Build and evaluate assessments.</td>
+    </tr>
+    <tr>
+      <td>Gradebook</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>Both: Track grades and scores.</td>
+    </tr>
+    <tr>
+      <td>Reporting &amp; Statistics</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>Both: Insights into learner engagement and performance.</td>
+    </tr>
+    <tr>
+      <td>User Management</td>
+      <td>Partial</td>
+      <td>Yes</td>
+      <td>Moocit: Manage user accounts. Layer5: Manage user accounts with granular and customizable permissions and roles.</td>
+    </tr>
+    <tr>
+      <td>Group Creation and Management</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>Both: Allow instructors to organize students and content into different groups.</td>
+    </tr>
+    <tr>
+      <td>Single Sign-On (SSO)</td>
+      <td>No</td>
+      <td>Yes</td>
+      <td>Layer5: Enhanced identity and granular access control.</td>
+    </tr>
+    <tr>
+      <td>Branded Academy Invitations</td>
+      <td>No</td>
+      <td>Yes</td>
+      <td>Layer5: Approval queues, domain-based allowances.</td>
+    </tr>
+    <tr>
+      <td>Branded Content Announcements</td>
+      <td>No</td>
+      <td>Yes</td>
+      <td>Layer5: New content announcements</td>
+    </tr>
+    <tr>
+      <td>Public Clouds</td>
+      <td>No</td>
+      <td>Yes</td>
+      <td>Layer5: AWS, Azure, GCP, DigitalOcean, and a Kubernetes service</td>
+    </tr>
+    <tr>
+      <td>Orchestration Support</td>
+      <td>No</td>
+      <td>Yes</td>
+      <td>Layer5: Hundreds of CNCF ecosystem integrations</td>
+    </tr>
+  </tbody>
+</table>
 
 ### Additional Features
 
 Extra functionalities make the platforms more engaging. While both cover gamification and eCommerce, Layer5 distinguishes itself with advanced white-labeling and community-driven Slack support.
 
-| Feature | Moocit | Layer5 | Notes |
-|---------|--------|--------|-------|
-| Gamification | ✅ | ✅ | Layer5: badges and learning leaderboards. |
-| eCommerce Management | ✅ | ✅ | Both: Support Stripe as a built-in integration. |
-| White-labeling | ✅ | ✅ | Layer5: Superior branding flexibility. |
-| Chatbot Support | ⚠️ | ✅ | Moocit: website chat. Layer5: community-centric Slack. |
-| Cloud Native Focused | ❌ | ✅  | Layer5 is a cloud native ecosystem stalwart, tightly aligned with the CNCF. |
+<table>
+  <thead>
+    <tr>
+      <th>Feature</th>
+      <th>Moocit</th>
+      <th>Layer5</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Gamification</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>Layer5: badges and learning leaderboards.</td>
+    </tr>
+    <tr>
+      <td>eCommerce Management</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>Both: Support Stripe as a built-in integration.</td>
+    </tr>
+    <tr>
+      <td>White-labeling</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>Layer5: Superior branding flexibility.</td>
+    </tr>
+    <tr>
+      <td>Chatbot Support</td>
+      <td>Partial</td>
+      <td>Yes</td>
+      <td>Moocit: website chat. Layer5: community-centric Slack.</td>
+    </tr>
+    <tr>
+      <td>Cloud Native Focused</td>
+      <td>No</td>
+      <td>Yes</td>
+      <td>Layer5 is a cloud native ecosystem stalwart, tightly aligned with the CNCF.</td>
+    </tr>
+  </tbody>
+</table>
 
 ## Summary
 
-While Moocit lacks content attribution and seamless orchestration with hands-on labs, Layer5 Academy stands out by enabling true learning through interactive, hands-on labs powered by Kanvas—where real learning happens. Layer5 Academy's labs drive students to utilize third-party public cloud providers' infrastructure, meaning more time spent on hands-on activities can increase costs for users paying for their chosen provider's resources. However, public cloud providers featuring Academy content and labs can incentivize adoption by offering credits and discount codes, presented to learners after enrolling in a Challenge, Learning Path, or Certification. Furthermore, Layer5 enhances administrative efficiency with support for bulk invitations for new learners and email announcements for new academy content, underscoring its superior strengths in content creation, learner experience, and administrative capabilities compared to Moocit.
+While Moocit lacks content attribution and seamless orchestration with hands-on labs, Layer5 Academy stands out by enabling true learning through interactive, hands-on labs powered by Kanvas, where real learning happens. Layer5 Academy's labs drive students to utilize third-party public cloud providers' infrastructure, meaning more time spent on hands-on activities can increase costs for users paying for their chosen provider's resources. However, public cloud providers featuring Academy content and labs can incentivize adoption by offering credits and discount codes, presented to learners after enrolling in a Challenge, Learning Path, or Certification. Furthermore, Layer5 enhances administrative efficiency with support for bulk invitations for new learners and email announcements for new academy content, underscoring its superior strengths in content creation, learner experience, and administrative capabilities compared to Moocit.
 
 </div>
 </ResourcesWrapper>

--- a/src/collections/resources/comparison/layer5-academy-vs-moocit/index.mdx
+++ b/src/collections/resources/comparison/layer5-academy-vs-moocit/index.mdx
@@ -44,50 +44,50 @@ It is the backbone of the platform, enabling instructors to easily design, struc
   <tbody>
     <tr>
       <td>Content Variety</td>
-      <td>Yes</td>
-      <td>Yes</td>
+      <td data-status="yes">Yes</td>
+      <td data-status="yes">Yes</td>
       <td>Both: Support text, images, videos, PDFs</td>
     </tr>
     <tr>
       <td>Interactive Learning</td>
-      <td>Yes</td>
-      <td>Yes</td>
+      <td data-status="yes">Yes</td>
+      <td data-status="yes">Yes</td>
       <td>Both: Quizzes, tests, self-assessment</td>
     </tr>
     <tr>
       <td>Learning Paths/Tracks</td>
-      <td>Yes</td>
-      <td>Yes</td>
+      <td data-status="yes">Yes</td>
+      <td data-status="yes">Yes</td>
       <td>Both: Support sequential paths and prerequisites</td>
     </tr>
     <tr>
       <td>Course Publishing</td>
-      <td>Yes</td>
-      <td>Yes</td>
+      <td data-status="yes">Yes</td>
+      <td data-status="yes">Yes</td>
       <td>Moocit: Web-based approach to content creation and publishing with incremental instant and scheduled releases. Layer5: Gitflow based approach to content creation and publishing with version-controlled publishing.</td>
     </tr>
     <tr>
       <td>Course Management</td>
-      <td>Yes</td>
-      <td>Yes</td>
+      <td data-status="yes">Yes</td>
+      <td data-status="yes">Yes</td>
       <td>Both: Tools to organize, assign, and manage</td>
     </tr>
     <tr>
       <td>Course Tracking</td>
-      <td>Yes</td>
-      <td>Yes</td>
+      <td data-status="yes">Yes</td>
+      <td data-status="yes">Yes</td>
       <td>Both: Track learner progress and completion</td>
     </tr>
     <tr>
       <td>Course Authoring</td>
-      <td>Partial</td>
-      <td>Yes</td>
+      <td data-status="partial">Partial</td>
+      <td data-status="yes">Yes</td>
       <td>Moocit: uses the Open edX platform with XML-based authoring. Layer5: uses a modern Hugo static site generator with Markdown-based authoring.</td>
     </tr>
     <tr>
       <td>Public Catalog</td>
-      <td>No</td>
-      <td>Yes</td>
+      <td data-status="no">No</td>
+      <td data-status="yes">Yes</td>
       <td>Moocit: Lacks browsable, public catalog. Layer5: Provides comprehensive discoverability with browsable, public catalog.</td>
     </tr>
   </tbody>
@@ -109,56 +109,56 @@ Learner experience emphasizes intuitive design, collaboration, and flexibility. 
   <tbody>
     <tr>
       <td>Learner Portal</td>
-      <td>Yes</td>
-      <td>Yes</td>
+      <td data-status="yes">Yes</td>
+      <td data-status="yes">Yes</td>
       <td></td>
     </tr>
     <tr>
       <td>Self-paced Learning</td>
-      <td>Yes</td>
-      <td>Yes</td>
+      <td data-status="yes">Yes</td>
+      <td data-status="yes">Yes</td>
       <td></td>
     </tr>
     <tr>
       <td>Instructor-led Learning</td>
-      <td>Yes</td>
-      <td>Yes</td>
+      <td data-status="yes">Yes</td>
+      <td data-status="yes">Yes</td>
       <td></td>
     </tr>
     <tr>
       <td>Mobile Learning</td>
-      <td>Yes</td>
-      <td>Yes</td>
+      <td data-status="yes">Yes</td>
+      <td data-status="yes">Yes</td>
       <td></td>
     </tr>
     <tr>
       <td>Certificate Generation</td>
-      <td>Yes</td>
-      <td>Yes</td>
+      <td data-status="yes">Yes</td>
+      <td data-status="yes">Yes</td>
       <td>Both: Shareable certifications</td>
     </tr>
     <tr>
       <td>Social Learning</td>
-      <td>Yes</td>
-      <td>Yes</td>
+      <td data-status="yes">Yes</td>
+      <td data-status="yes">Yes</td>
       <td>Both: Forums, discussions. Layer5: Kanvas and Slack.</td>
     </tr>
     <tr>
       <td>Learner Profile</td>
-      <td>Partial</td>
-      <td>Yes</td>
+      <td data-status="partial">Partial</td>
+      <td data-status="yes">Yes</td>
       <td>Moocit: Limited support for interactive profiles. Layer5: Comprehensive learner profiles with progress tracking and social features.</td>
     </tr>
     <tr>
       <td>Group / Synchronous Learning</td>
-      <td>No</td>
-      <td>Yes</td>
+      <td data-status="no">No</td>
+      <td data-status="yes">Yes</td>
       <td>Layer5: Real-time, collaborative learning.</td>
     </tr>
     <tr>
       <td>Hands-on Labs</td>
-      <td>No</td>
-      <td>Yes</td>
+      <td data-status="no">No</td>
+      <td data-status="yes">Yes</td>
       <td>Layer5: through Kanvas</td>
     </tr>
   </tbody>
@@ -180,62 +180,62 @@ Both platforms deliver robust administration capabilities with user management, 
   <tbody>
     <tr>
       <td>Assessment Management</td>
-      <td>Yes</td>
-      <td>Yes</td>
+      <td data-status="yes">Yes</td>
+      <td data-status="yes">Yes</td>
       <td>Both: Build and evaluate assessments.</td>
     </tr>
     <tr>
       <td>Gradebook</td>
-      <td>Yes</td>
-      <td>Yes</td>
+      <td data-status="yes">Yes</td>
+      <td data-status="yes">Yes</td>
       <td>Both: Track grades and scores.</td>
     </tr>
     <tr>
       <td>Reporting &amp; Statistics</td>
-      <td>Yes</td>
-      <td>Yes</td>
+      <td data-status="yes">Yes</td>
+      <td data-status="yes">Yes</td>
       <td>Both: Insights into learner engagement and performance.</td>
     </tr>
     <tr>
       <td>User Management</td>
-      <td>Partial</td>
-      <td>Yes</td>
+      <td data-status="partial">Partial</td>
+      <td data-status="yes">Yes</td>
       <td>Moocit: Manage user accounts. Layer5: Manage user accounts with granular and customizable permissions and roles.</td>
     </tr>
     <tr>
       <td>Group Creation and Management</td>
-      <td>Yes</td>
-      <td>Yes</td>
+      <td data-status="yes">Yes</td>
+      <td data-status="yes">Yes</td>
       <td>Both: Allow instructors to organize students and content into different groups.</td>
     </tr>
     <tr>
       <td>Single Sign-On (SSO)</td>
-      <td>No</td>
-      <td>Yes</td>
+      <td data-status="no">No</td>
+      <td data-status="yes">Yes</td>
       <td>Layer5: Enhanced identity and granular access control.</td>
     </tr>
     <tr>
       <td>Branded Academy Invitations</td>
-      <td>No</td>
-      <td>Yes</td>
+      <td data-status="no">No</td>
+      <td data-status="yes">Yes</td>
       <td>Layer5: Approval queues, domain-based allowances.</td>
     </tr>
     <tr>
       <td>Branded Content Announcements</td>
-      <td>No</td>
-      <td>Yes</td>
+      <td data-status="no">No</td>
+      <td data-status="yes">Yes</td>
       <td>Layer5: New content announcements</td>
     </tr>
     <tr>
       <td>Public Clouds</td>
-      <td>No</td>
-      <td>Yes</td>
+      <td data-status="no">No</td>
+      <td data-status="yes">Yes</td>
       <td>Layer5: AWS, Azure, GCP, DigitalOcean, and a Kubernetes service</td>
     </tr>
     <tr>
       <td>Orchestration Support</td>
-      <td>No</td>
-      <td>Yes</td>
+      <td data-status="no">No</td>
+      <td data-status="yes">Yes</td>
       <td>Layer5: Hundreds of CNCF ecosystem integrations</td>
     </tr>
   </tbody>
@@ -257,32 +257,32 @@ Extra functionalities make the platforms more engaging. While both cover gamific
   <tbody>
     <tr>
       <td>Gamification</td>
-      <td>Yes</td>
-      <td>Yes</td>
+      <td data-status="yes">Yes</td>
+      <td data-status="yes">Yes</td>
       <td>Layer5: badges and learning leaderboards.</td>
     </tr>
     <tr>
       <td>eCommerce Management</td>
-      <td>Yes</td>
-      <td>Yes</td>
+      <td data-status="yes">Yes</td>
+      <td data-status="yes">Yes</td>
       <td>Both: Support Stripe as a built-in integration.</td>
     </tr>
     <tr>
       <td>White-labeling</td>
-      <td>Yes</td>
-      <td>Yes</td>
+      <td data-status="yes">Yes</td>
+      <td data-status="yes">Yes</td>
       <td>Layer5: Superior branding flexibility.</td>
     </tr>
     <tr>
       <td>Chatbot Support</td>
-      <td>Partial</td>
-      <td>Yes</td>
+      <td data-status="partial">Partial</td>
+      <td data-status="yes">Yes</td>
       <td>Moocit: website chat. Layer5: community-centric Slack.</td>
     </tr>
     <tr>
       <td>Cloud Native Focused</td>
-      <td>No</td>
-      <td>Yes</td>
+      <td data-status="no">No</td>
+      <td data-status="yes">Yes</td>
       <td>Layer5 is a cloud native ecosystem stalwart, tightly aligned with the CNCF.</td>
     </tr>
   </tbody>

--- a/src/collections/resources/comparison/layer5-academy-vs-moocit/index.mdx
+++ b/src/collections/resources/comparison/layer5-academy-vs-moocit/index.mdx
@@ -32,13 +32,14 @@ The following details highlight the key differences between Layer5 Academy and M
 
 It is the backbone of the platform, enabling instructors to easily design, structure, and deliver courses. This includes tools for creating multimedia lessons, managing modules, setting prerequisites, and organizing assessments to ensure a seamless teaching process.
 
+<div className="comparison__table-wrapper">
 <table>
   <thead>
     <tr>
-      <th>Feature</th>
-      <th>Moocit</th>
-      <th>Layer5</th>
-      <th>Notes</th>
+      <th scope="col">Feature</th>
+      <th scope="col">Moocit</th>
+      <th scope="col">Layer5</th>
+      <th scope="col">Notes</th>
     </tr>
   </thead>
   <tbody>
@@ -92,18 +93,20 @@ It is the backbone of the platform, enabling instructors to easily design, struc
     </tr>
   </tbody>
 </table>
+</div>
 
 ### Learner Experience
 
 Learner experience emphasizes intuitive design, collaboration, and flexibility. Both platforms enable personalized learning, progress tracking, and interactive engagement, with Layer5 extending into real-time collaboration via [Kanvas](/cloud-native-management/kanvas).
 
+<div className="comparison__table-wrapper">
 <table>
   <thead>
     <tr>
-      <th>Feature</th>
-      <th>Moocit</th>
-      <th>Layer5</th>
-      <th>Notes</th>
+      <th scope="col">Feature</th>
+      <th scope="col">Moocit</th>
+      <th scope="col">Layer5</th>
+      <th scope="col">Notes</th>
     </tr>
   </thead>
   <tbody>
@@ -163,18 +166,20 @@ Learner experience emphasizes intuitive design, collaboration, and flexibility. 
     </tr>
   </tbody>
 </table>
+</div>
 
 ### Administration & Analytics
 
 Both platforms deliver robust administration capabilities with user management, analytics, and compliance tools. Layer5 extends customization through its cloud-native ecosystem integration.
 
+<div className="comparison__table-wrapper">
 <table>
   <thead>
     <tr>
-      <th>Feature</th>
-      <th>Moocit</th>
-      <th>Layer5</th>
-      <th>Notes</th>
+      <th scope="col">Feature</th>
+      <th scope="col">Moocit</th>
+      <th scope="col">Layer5</th>
+      <th scope="col">Notes</th>
     </tr>
   </thead>
   <tbody>
@@ -240,18 +245,20 @@ Both platforms deliver robust administration capabilities with user management, 
     </tr>
   </tbody>
 </table>
+</div>
 
 ### Additional Features
 
 Extra functionalities make the platforms more engaging. While both cover gamification and eCommerce, Layer5 distinguishes itself with advanced white-labeling and community-driven Slack support.
 
+<div className="comparison__table-wrapper">
 <table>
   <thead>
     <tr>
-      <th>Feature</th>
-      <th>Moocit</th>
-      <th>Layer5</th>
-      <th>Notes</th>
+      <th scope="col">Feature</th>
+      <th scope="col">Moocit</th>
+      <th scope="col">Layer5</th>
+      <th scope="col">Notes</th>
     </tr>
   </thead>
   <tbody>
@@ -287,6 +294,7 @@ Extra functionalities make the platforms more engaging. While both cover gamific
     </tr>
   </tbody>
 </table>
+</div>
 
 ## Summary
 

--- a/src/theme/app/themeStyles.js
+++ b/src/theme/app/themeStyles.js
@@ -300,7 +300,7 @@ export const darktheme = {
   saffronColor: "#EBC017",
 
   // error red
-  errorColor: "#D32F2F",
+  errorColor: "#FF6B6B",
 
   // flax (light yellow)
   highlightLightColor: "#EAD07D",

--- a/src/theme/app/themeStyles.js
+++ b/src/theme/app/themeStyles.js
@@ -62,6 +62,9 @@ const lighttheme = {
   highlightColor: "#EBC017",
   saffronColor: "#EBC017",
 
+  // error red
+  errorColor: "#D32F2F",
+
   // flax (light yellow)
   highlightLightColor: "#EAD07D",
   saffronLightColor: "#EAD07D",
@@ -295,6 +298,9 @@ export const darktheme = {
   // saffron (dark yellow)
   highlightColor: "#EBC017",
   saffronColor: "#EBC017",
+
+  // error red
+  errorColor: "#D32F2F",
 
   // flax (light yellow)
   highlightLightColor: "#EAD07D",


### PR DESCRIPTION
**## Description  Fixes the comparison tables on the Layer5 Academy vs Moocit page. Previously, the Markdown table syntax was displayed as raw text with `|` characters instead of rendered rows and columns.    

Fixes #7935    

 ## Changes  - Replaced four Markdown pipe tables with semantic MDX/HTML tables. - Added scoped styling for borders, spacing, alignment, and table headers. - Used clear `Yes`, `No`, and `Partial` labels for comparison states. - Corrected the `Comparison` spelling in the page frontmatter.  


## Expected behavior  The comparison content is now displayed as properly structured tables, making the features of Layer5 Academy and Moocit easier to read and compare. 


 ## Validation  - MDX compilation passed. - Confirmed four `<table>` elements are generated. - Confirmed no raw pipe-table rows remain. - ESLint passed for the modified stylesheet. - `git diff --check` passed.   

 ### Before  Comparison content appeared as raw pipe-delimited text.  <img width="1218" height="771" alt="Screenshot 2026-08-07 140444" src="https://github.com/user-attachments/assets/7cb3091b-4733-40f6-b0c0-d7a82f16ed09" />  

 ### After  Comparison content is rendered in structured rows and columns.  <img width="1142" height="729" alt="Screenshot 2026-08-07 140422" src="https://github.com/user-attachments/assets/70f59a84-e1c5-4d61-b968-be9a26bb5754" />   <!-- This is an auto-generated comment: release notes by coderabbit.ai --> ## Summary by CodeRabbit  

## Summary by CodeRabbit  * **New Features**   * Added a clearer, more consistent comparison-table layout with improved spacing, borders, alignment, themed headers, and status colors.

 * **Documentation**   * Updated the Layer5 Academy versus Moocit comparison content.  
 *** Improved comparison labels, notes, grammar, punctuation, and metadata.   * Standardized table values using “Yes,” “No,” and “Partial” for easier scanning. 
* **Style**   * Added consistent error-state coloring across light and dark themes. <!-- end of auto-generated comment:** release notes by coderabbit.ai -->