### PR TITLE
Fix sidebar layout shift on Sistent page refresh

### DIFF
--- a/src/components/SistentNavigation/toc.style.js
+++ b/src/components/SistentNavigation/toc.style.js
@@ -4,11 +4,7 @@ const TOCWrapper = styled.div`
   padding-top: 3rem;
   margin-left: 3rem;
   width: 15rem;
-  min-width: 15rem;
   padding-bottom: 2rem;
-  @media screen and (min-width: 1280px) and (max-width: 1350px) {
-    margin-left: 0;
-  }
 
   .go-back {
     margin-left: 1rem;

--- a/src/components/SistentNavigation/toc.style.js
+++ b/src/components/SistentNavigation/toc.style.js
@@ -4,6 +4,7 @@ const TOCWrapper = styled.div`
   padding-top: 3rem;
   margin-left: 3rem;
   width: 15rem;
+  flex: 0 0 15rem;
   padding-bottom: 2rem;
 
   .go-back {

--- a/src/components/SistentNavigation/toc.style.js
+++ b/src/components/SistentNavigation/toc.style.js
@@ -1,16 +1,13 @@
 import styled from "styled-components";
 
 const TOCWrapper = styled.div`
-  position: absolute;
-  top: 10rem;
-  left: 0rem;
+  padding-top: 3rem;
   margin-left: 3rem;
-  margin-top: 3rem;
   width: 15rem;
   min-width: 15rem;
   padding-bottom: 2rem;
   @media screen and (min-width: 1280px) and (max-width: 1350px) {
-    margin-left: 0.2rem;
+    margin-left: 0;
   }
 
   .go-back {

--- a/src/components/SistentNavigation/toc.style.js
+++ b/src/components/SistentNavigation/toc.style.js
@@ -7,6 +7,7 @@ const TOCWrapper = styled.div`
   margin-left: 3rem;
   margin-top: 3rem;
   width: 15rem;
+  min-width: 15rem;
   padding-bottom: 2rem;
   @media screen and (min-width: 1280px) and (max-width: 1350px) {
     margin-left: 0.2rem;
@@ -135,7 +136,9 @@ const TOCWrapper = styled.div`
     background-color: transparent;
   }
 
-  .identity, .components, .getting-started {
+  .identity,
+  .components,
+  .getting-started {
     display: flex;
     width: 100%;
     justify-content: space-between;
@@ -148,10 +151,12 @@ const TOCWrapper = styled.div`
     }
   }
 
-  .identity-sublinks, .components-sublinks {
+  .identity-sublinks,
+  .components-sublinks {
     padding-left: 0.56rem;
 
-    .identity-item, .components-item {
+    .identity-item,
+    .components-item {
       font-size: 1.05rem;
       margin-top: 0.45rem;
     }

--- a/src/sections/Projects/Sistent/components/index.js
+++ b/src/sections/Projects/Sistent/components/index.js
@@ -9,12 +9,13 @@ import { Link } from "gatsby";
 
 const SistentComponents = ({ data }) => {
   // Transform GraphQL data
-  const componentsData = data?.allMdx?.nodes.map(node => ({
-    id: node.id,
-    name: node.frontmatter.name,
-    description: node.frontmatter.description,
-    url: `/projects/sistent/components/${node.frontmatter.component}`
-  })) || [];
+  const componentsData =
+    data?.allMdx?.nodes.map((node) => ({
+      id: node.id,
+      name: node.frontmatter.name,
+      description: node.frontmatter.description,
+      url: `/projects/sistent/components/${node.frontmatter.component}`,
+    })) || [];
 
   const [searchQuery, setSearchQuery] = useState("");
   const { queryResults, searchData } = useDataList(
@@ -22,11 +23,11 @@ const SistentComponents = ({ data }) => {
     setSearchQuery,
     searchQuery,
     ["name"],
-    "id"
+    "id",
   );
 
   const compArray = [...queryResults].sort((a, b) =>
-    a.name.localeCompare(b.name)
+    a.name.localeCompare(b.name),
   );
 
   return (
@@ -34,53 +35,55 @@ const SistentComponents = ({ data }) => {
       <div className="page-header-section">
         <h1>Components</h1>
       </div>
-      <TOC />
-      <div className="page-section">
-        <Container className="components-container">
-          <div className="content">
-            <a id="Identity">
-              <h2>Components</h2>
-            </a>
-            <p>
-              Components are reusable elements that serve as the building blocks
-              of the design system. They are curated using the established
-              identity principles and can be combined to form various elements,
-              patterns, and templates that can be used to design user
-              interfaces.
-            </p>
-          </div>
-          <div className="main-content">
-            <div className="search-container">
-              <SearchBox searchQuery={searchQuery} searchData={searchData} />
+      <div className="page-container">
+        <TOC />
+        <div className="page-section">
+          <Container className="components-container">
+            <div className="content">
+              <a id="Identity">
+                <h2>Components</h2>
+              </a>
+              <p>
+                Components are reusable elements that serve as the building
+                blocks of the design system. They are curated using the
+                established identity principles and can be combined to form
+                various elements, patterns, and templates that can be used to
+                design user interfaces.
+              </p>
             </div>
-            <div className="product_cards">
-              <div className="cards">
-                {compArray.map((comp) => (
-                  <Link key={comp.id} to={comp.url}>
-                    <div className="card">
-                      <div className="card_head">
-                        <div className="title">{comp.name}</div>
-                        <div className="text">{comp.description}</div>
-                      </div>
-                      <div>
-                        <div className="card_bottom">
-                          <div className="learn" href={comp.url}>
-                            <div className="learn-more">
-                              <div>Learn more</div>
-                              <div className="icon">
-                                <FaArrowRight />
+            <div className="main-content">
+              <div className="search-container">
+                <SearchBox searchQuery={searchQuery} searchData={searchData} />
+              </div>
+              <div className="product_cards">
+                <div className="cards">
+                  {compArray.map((comp) => (
+                    <Link key={comp.id} to={comp.url}>
+                      <div className="card">
+                        <div className="card_head">
+                          <div className="title">{comp.name}</div>
+                          <div className="text">{comp.description}</div>
+                        </div>
+                        <div>
+                          <div className="card_bottom">
+                            <div className="learn" href={comp.url}>
+                              <div className="learn-more">
+                                <div>Learn more</div>
+                                <div className="icon">
+                                  <FaArrowRight />
+                                </div>
                               </div>
                             </div>
                           </div>
                         </div>
                       </div>
-                    </div>
-                  </Link>
-                ))}
+                    </Link>
+                  ))}
+                </div>
               </div>
             </div>
-          </div>
-        </Container>
+          </Container>
+        </div>
       </div>
     </SistentWrapper>
   );

--- a/src/sections/Projects/Sistent/getting-started/about/index.js
+++ b/src/sections/Projects/Sistent/getting-started/about/index.js
@@ -32,200 +32,250 @@ const SistentAbout = () => {
       <div className="page-header-section">
         <h1>About Sistent</h1>
       </div>
-      <TOC />
-      <div className="page-section">
-        <Container>
-          <div className="content">
-            <a id="About Sistent">
-              <h2>About Sistent</h2>
-            </a>
-            <p>
-              Sistent an open source design system
-              that offers building blocks to create consistent, accessible, and
-              user-friendly interfaces. It's aimed at developers who want to
-              design applications aligned with the same brand and ensure a
-              uniform user experience across different products.
-            </p>
-            <p>
-              Sistent leverages Material UI libraries and provides a custom
-              theme on top of it for a consistent look and feel. It includes
-              components, icons, and design tokens that developers can readily
-              integrate into their applications. By using Sistent, developers
-              can save time and effort while maintaining a high-quality user
-              experience.
-            </p>
-            <p>
-              <b>
-                Sistent provides a consistent user experience across any frontend
-                software projects that choose to use it.
-              </b>
-            </p>
-            <p>
-              'Sistent' is a play on words to ensure that we have a{" "}
-              <i>consistent</i> theme, components, design tokens, etc across all
-              of the apps that will be using this library. Sistent is a design
-              system that uses the <b>MUI v5 components</b> and a{" "}
-              <b>custom theme provider </b> instead of using the default theme
-              from MUI v5.
-            </p>
+      <div className="page-container">
+        <TOC />
+        <div className="page-section">
+          <Container>
+            <div className="content">
+              <a id="About Sistent">
+                <h2>About Sistent</h2>
+              </a>
+              <p>
+                Sistent an open source design system that offers building blocks
+                to create consistent, accessible, and user-friendly interfaces.
+                It's aimed at developers who want to design applications aligned
+                with the same brand and ensure a uniform user experience across
+                different products.
+              </p>
+              <p>
+                Sistent leverages Material UI libraries and provides a custom
+                theme on top of it for a consistent look and feel. It includes
+                components, icons, and design tokens that developers can readily
+                integrate into their applications. By using Sistent, developers
+                can save time and effort while maintaining a high-quality user
+                experience.
+              </p>
+              <p>
+                <b>
+                  Sistent provides a consistent user experience across any
+                  frontend software projects that choose to use it.
+                </b>
+              </p>
+              <p>
+                'Sistent' is a play on words to ensure that we have a{" "}
+                <i>consistent</i> theme, components, design tokens, etc across
+                all of the apps that will be using this library. Sistent is a
+                design system that uses the <b>MUI v5 components</b> and a{" "}
+                <b>custom theme provider </b> instead of using the default theme
+                from MUI v5.
+              </p>
 
-            <p>
-              Sistent is built with Typescript and Reactjs and contains
-              components and a large collection of icons that can be reused
-              across projects. If you’re interested in joining the project
-              (please do!), let us know, and we will help you get started on
-              contributing.
-            </p>
-            <h3>Layer5 Brand Resources</h3>
-            <ul>
-              <li><Link to="/brand/brand-guide.pdf">Brand Guide</Link></li>
-              <li><Link to="/brand">Logos and Brand Kits</Link></li>
-            </ul>
-            <a id="Installation">
-              <h2>Installation and Quickstart</h2>
-            </a>
-            <p>To install the Sistent NPM package, run:</p>
-            <div className="showcase">
-              <CodeBlock name="installation" collapsible code={codes[0]} />
-            </div>
-            <p>
-              After installation, you can import Sistent theme and any Sistent
-              component from "@sistent/sistent". The component needs to be
-              included inside "SistentThemeProvider".
-            </p>
-            <p>Taking button as an example:</p>
-            <div className="showcase">
-              <div className="items">
-                <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
-                  <Button variant="contained">Filled</Button>
-                  <Button variant="outlined">Outlined</Button>
-                  <Button variant="text">Text</Button>
-                </SistentThemeProvider>
+              <p>
+                Sistent is built with Typescript and Reactjs and contains
+                components and a large collection of icons that can be reused
+                across projects. If you’re interested in joining the project
+                (please do!), let us know, and we will help you get started on
+                contributing.
+              </p>
+              <h3>Layer5 Brand Resources</h3>
+              <ul>
+                <li>
+                  <Link to="/brand/brand-guide.pdf">Brand Guide</Link>
+                </li>
+                <li>
+                  <Link to="/brand">Logos and Brand Kits</Link>
+                </li>
+              </ul>
+              <a id="Installation">
+                <h2>Installation and Quickstart</h2>
+              </a>
+              <p>To install the Sistent NPM package, run:</p>
+              <div className="showcase">
+                <CodeBlock name="installation" collapsible code={codes[0]} />
               </div>
-              <CodeBlock name="checkbox" collapsible code={codes[1]} />
-            </div>
-
-            <a id="Using local Sistent">
-              <h2>Using your Local Sistent Fork in a Project</h2>
-            </a>
-            <br />
-            <ul>
-              <li>
-                <h3>Method 1: File Installation</h3>
-              </li>
-              <ol>
-                <li>
-                  <b>Install your local Sistent package in the project</b>
-                  <CodeBlock codeString="npm install &lt;path-to-sistent-on-local-machine&gt;" />
-                  <p>Example:</p>
-                  <CodeBlock
-                    codeString={"# relative path\n npm install ../../sistent\n\n# absolute path\n npm install /home/five/code/sistent"}
-                  />
-                  <p>This will update your Sistent dependency to:</p>
-                  <CodeBlock codeString={"\"@sistent/sistent\" : \"file:../../sistent\""} />
-                </li>
-                <li>
-                  <b>Build your local Sistent fork</b>
-                  <p>
-                    After making changes to your fork, run this command in your local Sistent package.
-                  </p>
-                  <CodeBlock codeString="make build" />
-                </li>
-                <li>
-                  <b>
-                    Run the build command in the project where your local Sistent fork is installed
-                  </b>
-                  <p>Example for Meshery UI:</p>
-                  <CodeBlock codeString="make ui-build" />
-                </li>
-              </ol>
               <p>
-                Now, your project should reflect changes from your local Sistent fork.
+                After installation, you can import Sistent theme and any Sistent
+                component from "@sistent/sistent". The component needs to be
+                included inside "SistentThemeProvider".
               </p>
-              <p>
-                If you want to remove the local Sistent fork from your project, run:
-              </p>
-              <CodeBlock codeString="npm uninstall @sistent/sistent" />
-              <p>
-                This will remove the local Sistent package from your project. You will have to install the standard package again after running this command:
-              </p>
-              <CodeBlock codeString="npm install @sistent/sistent" />
+              <p>Taking button as an example:</p>
+              <div className="showcase">
+                <div className="items">
+                  <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
+                    <Button variant="contained">Filled</Button>
+                    <Button variant="outlined">Outlined</Button>
+                    <Button variant="text">Text</Button>
+                  </SistentThemeProvider>
+                </div>
+                <CodeBlock name="checkbox" collapsible code={codes[1]} />
+              </div>
 
-
-              <li>
-                <h3>Method 2: Using npm link</h3>
-                <p>
-                  This method allows you to link your local Sistent fork globally for easier development. Follow these steps:
-                </p>
+              <a id="Using local Sistent">
+                <h2>Using your Local Sistent Fork in a Project</h2>
+              </a>
+              <br />
+              <ul>
+                <li>
+                  <h3>Method 1: File Installation</h3>
+                </li>
                 <ol>
                   <li>
-                    <b>Link your local Sistent package globally</b>
-                    <p>In your local Sistent repo, run the following command:</p>
-                    <CodeBlock codeString={"cd <path-to-sistent-on-local-machine>\n npm link"} />
-                  </li>
-                  <li>
-                    <b>Link Sistent in your project</b>
-                    <p>In the project where you want to use your local Sistent fork, run:</p>
-                    <CodeBlock codeString="npm link @sistent/sistent" />
-                    <p>This will create a symlink in your project's node_modules, pointing to your local Sistent package.</p>
+                    <b>Install your local Sistent package in the project</b>
+                    <CodeBlock codeString="npm install &lt;path-to-sistent-on-local-machine&gt;" />
+                    <p>Example:</p>
+                    <CodeBlock
+                      codeString={
+                        "# relative path\n npm install ../../sistent\n\n# absolute path\n npm install /home/five/code/sistent"
+                      }
+                    />
+                    <p>This will update your Sistent dependency to:</p>
+                    <CodeBlock
+                      codeString={'"@sistent/sistent" : "file:../../sistent"'}
+                    />
                   </li>
                   <li>
                     <b>Build your local Sistent fork</b>
-                    <p>After making changes to your fork, run this command in your local Sistent package.</p>
+                    <p>
+                      After making changes to your fork, run this command in
+                      your local Sistent package.
+                    </p>
                     <CodeBlock codeString="make build" />
                   </li>
                   <li>
-                    <b>Run the build command in the project where your local Sistent fork is installed</b>
-                    <p>Example for Meshery-UI:</p>
+                    <b>
+                      Run the build command in the project where your local
+                      Sistent fork is installed
+                    </b>
+                    <p>Example for Meshery UI:</p>
                     <CodeBlock codeString="make ui-build" />
                   </li>
-                  <li>
-                    <p>
-                      Verify that your local fork is correctly linked by running:
-                    </p>
-                    <CodeBlock codeString={"npm ls -g\n\n# expected output:\n├── @sistent/sistent@0.14.11 -> ./../../../../<path-to-local-sistent-fork>"} />
-                    <p>
-                      You can also try this command to verify that your fork is correctly linked:
-                    </p>
-                    <CodeBlock codeString={"ls -l node_modules/@sistent/sistent\n\n# expected output:\nnode_modules/@sistent/sistent -> ../../../../../sistent"} />
-                  </li>
-                  <li>
-                    <p>
-                      To revert back to the official version of Sistent, run:
-                    </p>
-                    <CodeBlock codeString="npm unlink @sistent/sistent" />
-                    <p>
-                      Then reinstall the official version, using this command:
-                    </p>
-                    <CodeBlock codeString="npm install @sistent/sistent" />
-                  </li>
                 </ol>
-              </li>
-            </ul>
+                <p>
+                  Now, your project should reflect changes from your local
+                  Sistent fork.
+                </p>
+                <p>
+                  If you want to remove the local Sistent fork from your
+                  project, run:
+                </p>
+                <CodeBlock codeString="npm uninstall @sistent/sistent" />
+                <p>
+                  This will remove the local Sistent package from your project.
+                  You will have to install the standard package again after
+                  running this command:
+                </p>
+                <CodeBlock codeString="npm install @sistent/sistent" />
 
-            <p>
-              To contribute to projects using Sistent e.g.{" "}
-              <a href="https://github.com/meshery/meshery/issues?q=is%3Aissue%20state%3Aopen%20label%3Acomponent%2Fui">
-                meshery-ui
-              </a>{" "}
-              and others, you can refer to the {" "}
-              <a href="https://github.com/layer5io/sistent?tab=readme-ov-file#installation">
-                Sistent set-up guide
-              </a>, {" "}
-              <a href="https://discuss.meshery.io/t/hands-on-training-session-migrating-components-to-mui-v5-and-sistent/6589">Hands-on Training Session: Migrating Components to MUI v5 and Sistent</a>, {" "}
-              <a href="https://www.youtube.com/live/lsw9KA__iu4?si=o8gpZdSHcqO2OKxE">
-                Training: contributing to Sistent,
-              </a>{" "}
-              and{" "}
-              <a href="https://www.youtube.com/live/yiXkxbibLUU?si=Dybj5qr0VLhLWEpl">
-                Websites call
-              </a>{" "}
-              , where experienced contributors demonstrate how to use Sistent in various projects.
-            </p>
-          </div>
-          <SistentPagination />
-        </Container>
-        <IntraPage contents={contents} />
+                <li>
+                  <h3>Method 2: Using npm link</h3>
+                  <p>
+                    This method allows you to link your local Sistent fork
+                    globally for easier development. Follow these steps:
+                  </p>
+                  <ol>
+                    <li>
+                      <b>Link your local Sistent package globally</b>
+                      <p>
+                        In your local Sistent repo, run the following command:
+                      </p>
+                      <CodeBlock
+                        codeString={
+                          "cd <path-to-sistent-on-local-machine>\n npm link"
+                        }
+                      />
+                    </li>
+                    <li>
+                      <b>Link Sistent in your project</b>
+                      <p>
+                        In the project where you want to use your local Sistent
+                        fork, run:
+                      </p>
+                      <CodeBlock codeString="npm link @sistent/sistent" />
+                      <p>
+                        This will create a symlink in your project's
+                        node_modules, pointing to your local Sistent package.
+                      </p>
+                    </li>
+                    <li>
+                      <b>Build your local Sistent fork</b>
+                      <p>
+                        After making changes to your fork, run this command in
+                        your local Sistent package.
+                      </p>
+                      <CodeBlock codeString="make build" />
+                    </li>
+                    <li>
+                      <b>
+                        Run the build command in the project where your local
+                        Sistent fork is installed
+                      </b>
+                      <p>Example for Meshery-UI:</p>
+                      <CodeBlock codeString="make ui-build" />
+                    </li>
+                    <li>
+                      <p>
+                        Verify that your local fork is correctly linked by
+                        running:
+                      </p>
+                      <CodeBlock
+                        codeString={
+                          "npm ls -g\n\n# expected output:\n├── @sistent/sistent@0.14.11 -> ./../../../../<path-to-local-sistent-fork>"
+                        }
+                      />
+                      <p>
+                        You can also try this command to verify that your fork
+                        is correctly linked:
+                      </p>
+                      <CodeBlock
+                        codeString={
+                          "ls -l node_modules/@sistent/sistent\n\n# expected output:\nnode_modules/@sistent/sistent -> ../../../../../sistent"
+                        }
+                      />
+                    </li>
+                    <li>
+                      <p>
+                        To revert back to the official version of Sistent, run:
+                      </p>
+                      <CodeBlock codeString="npm unlink @sistent/sistent" />
+                      <p>
+                        Then reinstall the official version, using this command:
+                      </p>
+                      <CodeBlock codeString="npm install @sistent/sistent" />
+                    </li>
+                  </ol>
+                </li>
+              </ul>
+
+              <p>
+                To contribute to projects using Sistent e.g.{" "}
+                <a href="https://github.com/meshery/meshery/issues?q=is%3Aissue%20state%3Aopen%20label%3Acomponent%2Fui">
+                  meshery-ui
+                </a>{" "}
+                and others, you can refer to the{" "}
+                <a href="https://github.com/layer5io/sistent?tab=readme-ov-file#installation">
+                  Sistent set-up guide
+                </a>
+                ,{" "}
+                <a href="https://discuss.meshery.io/t/hands-on-training-session-migrating-components-to-mui-v5-and-sistent/6589">
+                  Hands-on Training Session: Migrating Components to MUI v5 and
+                  Sistent
+                </a>
+                ,{" "}
+                <a href="https://www.youtube.com/live/lsw9KA__iu4?si=o8gpZdSHcqO2OKxE">
+                  Training: contributing to Sistent,
+                </a>{" "}
+                and{" "}
+                <a href="https://www.youtube.com/live/yiXkxbibLUU?si=Dybj5qr0VLhLWEpl">
+                  Websites call
+                </a>{" "}
+                , where experienced contributors demonstrate how to use Sistent
+                in various projects.
+              </p>
+            </div>
+            <SistentPagination />
+          </Container>
+          <IntraPage contents={contents} />
+        </div>
       </div>
     </SistentWrapper>
   );

--- a/src/sections/Projects/Sistent/getting-started/about/index.js
+++ b/src/sections/Projects/Sistent/getting-started/about/index.js
@@ -41,11 +41,11 @@ const SistentAbout = () => {
                 <h2>About Sistent</h2>
               </a>
               <p>
-                Sistent an open source design system that offers building blocks
-                to create consistent, accessible, and user-friendly interfaces.
-                It's aimed at developers who want to design applications aligned
-                with the same brand and ensure a uniform user experience across
-                different products.
+                Sistent is an open source design system that offers building
+                blocks to create consistent, accessible, and user-friendly
+                interfaces. It's aimed at developers who want to design
+                applications aligned with the same brand and ensure a uniform
+                user experience across different products.
               </p>
               <p>
                 Sistent leverages Material UI libraries and provides a custom

--- a/src/sections/Projects/Sistent/getting-started/installation/index.js
+++ b/src/sections/Projects/Sistent/getting-started/installation/index.js
@@ -39,80 +39,82 @@ const SistentInstallation = () => {
       <div className="page-header-section">
         <h1>Installation</h1>
       </div>
-      <TOC />
-      <div className="page-section">
-        <Container>
-          <div className="content">
-            <a id="overview">
-              <h2>Overview</h2>
-            </a>
-            <p>
-              Sistent is a React-based design system from Layer5. To get
-              started, make sure your environment meets the requirements
-              specified in the project's canonical{" "}
-              <a
-                href="https://github.com/layer5io/sistent/blob/master/package.json"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <code>package.json</code>
+      <div className="page-container">
+        <TOC />
+        <div className="page-section">
+          <Container>
+            <div className="content">
+              <a id="overview">
+                <h2>Overview</h2>
               </a>
-              . You will also need <strong>Node.js</strong>{" "}
-              <code>&gt;=16.x</code>.
-            </p>
-            <a id="installation">
-              <h2>Installation</h2>
-            </a>
-            <p>Install Sistent using your preferred package manager:</p>
-            <h3>Using npm</h3>
-            <CodeBlock
-              codeString={codeExamples.npmInstall}
-              language="javascript"
-            />
-            <h3>Using yarn</h3>
-            <CodeBlock
-              codeString={codeExamples.yarnInstall}
-              language="javascript"
-            />
-            <a id="quick-start">
-              <h2>Quick Start</h2>
-            </a>
-            <p>
-              Wrap your application with <code>SistentThemeProvider</code> to
-              enable theming and start using components. The theme provider
-              automatically handles light/dark mode switching based on system
-              preferences.
-            </p>
-            <CodeBlock
-              codeString={codeExamples.quickStart}
-              language="javascript"
-            />
-            <p>
-              <strong>That's it!</strong> Your Sistent components will
-              automatically inherit the Layer5 design system with proper
-              theming, spacing, and colors. Components such as{" "}
-              <code>Button</code> will also respond to system dark mode changes
-              automatically.
-            </p>
-            <a id="contributing">
-              <h2>Contributing</h2>
-            </a>
-            <p>
-              If you want to contribute or use it in your project locally, see
-              our &nbsp;
-              <a
-                href="https://github.com/layer5io/sistent#contributing-to-sistent"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Contributing Guide
-              </a>{" "}
-              for complete setup instructions.
-            </p>
-          </div>
-          <SistentPagination />
-        </Container>
-        <IntraPage contents={contents} />
+              <p>
+                Sistent is a React-based design system from Layer5. To get
+                started, make sure your environment meets the requirements
+                specified in the project's canonical{" "}
+                <a
+                  href="https://github.com/layer5io/sistent/blob/master/package.json"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <code>package.json</code>
+                </a>
+                . You will also need <strong>Node.js</strong>{" "}
+                <code>&gt;=16.x</code>.
+              </p>
+              <a id="installation">
+                <h2>Installation</h2>
+              </a>
+              <p>Install Sistent using your preferred package manager:</p>
+              <h3>Using npm</h3>
+              <CodeBlock
+                codeString={codeExamples.npmInstall}
+                language="javascript"
+              />
+              <h3>Using yarn</h3>
+              <CodeBlock
+                codeString={codeExamples.yarnInstall}
+                language="javascript"
+              />
+              <a id="quick-start">
+                <h2>Quick Start</h2>
+              </a>
+              <p>
+                Wrap your application with <code>SistentThemeProvider</code> to
+                enable theming and start using components. The theme provider
+                automatically handles light/dark mode switching based on system
+                preferences.
+              </p>
+              <CodeBlock
+                codeString={codeExamples.quickStart}
+                language="javascript"
+              />
+              <p>
+                <strong>That's it!</strong> Your Sistent components will
+                automatically inherit the Layer5 design system with proper
+                theming, spacing, and colors. Components such as{" "}
+                <code>Button</code> will also respond to system dark mode
+                changes automatically.
+              </p>
+              <a id="contributing">
+                <h2>Contributing</h2>
+              </a>
+              <p>
+                If you want to contribute or use it in your project locally, see
+                our &nbsp;
+                <a
+                  href="https://github.com/layer5io/sistent#contributing-to-sistent"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Contributing Guide
+                </a>{" "}
+                for complete setup instructions.
+              </p>
+            </div>
+            <SistentPagination />
+          </Container>
+          <IntraPage contents={contents} />
+        </div>
       </div>
     </SistentWrapper>
   );

--- a/src/sections/Projects/Sistent/getting-started/tokens/index.js
+++ b/src/sections/Projects/Sistent/getting-started/tokens/index.js
@@ -15,7 +15,7 @@ const contents = [
   { id: 2, link: "#color-system", text: "Color System" },
   { id: 3, link: "#typography", text: "Typography" },
   { id: 4, link: "#spacing", text: "Spacing" },
-  { id: 5, link: "#examples", text: "Examples" }
+  { id: 5, link: "#examples", text: "Examples" },
 ];
 
 const codeExamples = {
@@ -129,7 +129,7 @@ function ProductShowcase({ products }) {
       ))}
     </div>
   );
-}`
+}`,
 };
 
 const SistentTokens = () => {
@@ -140,213 +140,307 @@ const SistentTokens = () => {
       <div className="page-header-section">
         <h1>Design Tokens</h1>
       </div>
-      <TOC />
+      <div className="page-container">
+        <TOC />
 
-      <div className="page-section">
-        <Container>
-          <div className="content">
+        <div className="page-section">
+          <Container>
+            <div className="content">
+              <a id="overview">
+                <h2>Overview</h2>
+              </a>
+              <p>
+                Design tokens are the foundation of Sistent's design system.
+                They are named values that store visual design attributes like
+                colors, spacing, and typography scales. Instead of hardcoding
+                values like <code>#00B39F</code> or <code>16px</code>, you
+                reference semantic tokens that automatically adapt to different
+                themes and contexts.
+              </p>
 
-            <a id="overview">
-              <h2>Overview</h2>
-            </a>
-            <p>
-              Design tokens are the foundation of Sistent's design system. They are named values that store
-              visual design attributes like colors, spacing, and typography scales. Instead of hardcoding
-              values like <code>#00B39F</code> or <code>16px</code>, you reference semantic tokens that
-              automatically adapt to different themes and contexts.
-            </p>
+              <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
+                <Alert severity="info" sx={{ my: 2 }}>
+                  <strong>Why tokens matter:</strong> They ensure visual
+                  consistency across Layer5 projects, enable automatic theming
+                  (light/dark mode), and make maintenance significantly easier.
+                </Alert>
+              </SistentThemeProvider>
 
-            <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
-              <Alert severity="info" sx={{ my: 2 }}>
-                <strong>Why tokens matter:</strong> They ensure visual consistency across Layer5 projects,
-                enable automatic theming (light/dark mode), and make maintenance significantly easier.
-              </Alert>
-            </SistentThemeProvider>
+              <a id="accessing-tokens">
+                <h2>Accessing Tokens</h2>
+              </a>
+              <p>
+                All design tokens are available through the theme object using
+                the <code>useTheme</code> hook:
+              </p>
 
-            <a id="accessing-tokens">
-              <h2>Accessing Tokens</h2>
-            </a>
-            <p>
-              All design tokens are available through the theme object using the <code>useTheme</code> hook:
-            </p>
-
-            <div className="showcase">
-              <CodeBlock name="basic-access" collapsible code={codeExamples.basicAccess} />
-            </div>
-
-            <a id="color-system">
-              <h2>Color System</h2>
-            </a>
-            <p>
-              Sistent uses Layer5's brand colors as the foundation, with additional semantic colors
-              for UI states.
-            </p>
-
-            <div className="showcase">
-              <div className="items">
-                <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
-                  <Box display="grid" gridTemplateColumns="repeat(auto-fit, minmax(120px, 1fr))" gap={1} mb={2}>
-                    <Box sx={{
-                      bgcolor: "primary.main",
-                      color: "primary.contrastText",
-                      p: 1,
-                      textAlign: "center",
-                      fontSize: "12px",
-                      fontWeight: "bold"
-                    }}
-                    >
-                      Primary
-                    </Box>
-                    <Box sx={{
-                      bgcolor: "secondary.main",
-                      color: "secondary.contrastText",
-                      p: 1,
-                      textAlign: "center",
-                      fontSize: "12px",
-                      fontWeight: "bold"
-                    }}
-                    >
-                      Secondary
-                    </Box>
-                    <Box sx={{
-                      bgcolor: "error.main",
-                      color: "error.contrastText",
-                      p: 1,
-                      textAlign: "center",
-                      fontSize: "12px",
-                      fontWeight: "bold"
-                    }}
-                    >
-                      Error
-                    </Box>
-                    <Box sx={{
-                      bgcolor: "success.main",
-                      color: "success.contrastText",
-                      p: 1,
-                      textAlign: "center",
-                      fontSize: "12px",
-                      fontWeight: "bold"
-                    }}
-                    >
-                      Success
-                    </Box>
-                  </Box>
-                </SistentThemeProvider>
+              <div className="showcase">
+                <CodeBlock
+                  name="basic-access"
+                  collapsible
+                  code={codeExamples.basicAccess}
+                />
               </div>
-              <CodeBlock name="colors" collapsible code={codeExamples.colors} />
-            </div>
 
-            <a id="typography">
-              <h2>Typography</h2>
-            </a>
-            <p>
-              Typography tokens provide consistent text styling across all components.
-            </p>
+              <a id="color-system">
+                <h2>Color System</h2>
+              </a>
+              <p>
+                Sistent uses Layer5's brand colors as the foundation, with
+                additional semantic colors for UI states.
+              </p>
 
-            <div className="showcase">
-              <div className="items">
-                <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
-                  <Box>
-                    <Typography variant="h1" gutterBottom>Heading 1</Typography>
-                    <Typography variant="h3" gutterBottom>Heading 3</Typography>
-                    <Typography variant="h6" gutterBottom>Heading 6</Typography>
-                    <Typography variant="body1" gutterBottom>Body text primary</Typography>
-                    <Typography variant="body2">Body text secondary</Typography>
-                  </Box>
-                </SistentThemeProvider>
-              </div>
-              <CodeBlock name="Typography" collapsible code={codeExamples.typography} />
-            </div>
-
-            <a id="spacing">
-              <h2>Spacing</h2>
-            </a>
-            <p>
-              Sistent uses an 8px-based spacing system. All spacing values are multiples of 8px
-              for consistent layouts.
-            </p>
-
-            <div className="showcase">
-              <div className="items">
-                <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
-                  <Box>
-                    {[1, 2, 3, 4, 6, 8].map((multiplier) => (
-                      <Box key={multiplier} display="flex" alignItems="center" gap={2} mb={1}>
-                        <Typography variant="body2" sx={{ minWidth: 80, fontFamily: "monospace" }}>
-                          spacing({multiplier})
-                        </Typography>
-                        <Box
-                          sx={{
-                            width: `${multiplier * 8}px`,
-                            height: 20,
-                            backgroundColor: "primary.main",
-                            border: "1px solid",
-                            borderColor: "divider"
-                          }}
-                        />
-                        <Typography variant="body2" sx={{ fontFamily: "monospace", fontSize: "12px", color: "text.secondary" }}>
-                          {multiplier * 8}px
-                        </Typography>
+              <div className="showcase">
+                <div className="items">
+                  <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
+                    <Box
+                      display="grid"
+                      gridTemplateColumns="repeat(auto-fit, minmax(120px, 1fr))"
+                      gap={1}
+                      mb={2}
+                    >
+                      <Box
+                        sx={{
+                          bgcolor: "primary.main",
+                          color: "primary.contrastText",
+                          p: 1,
+                          textAlign: "center",
+                          fontSize: "12px",
+                          fontWeight: "bold",
+                        }}
+                      >
+                        Primary
                       </Box>
-                    ))}
-                  </Box>
-                </SistentThemeProvider>
+                      <Box
+                        sx={{
+                          bgcolor: "secondary.main",
+                          color: "secondary.contrastText",
+                          p: 1,
+                          textAlign: "center",
+                          fontSize: "12px",
+                          fontWeight: "bold",
+                        }}
+                      >
+                        Secondary
+                      </Box>
+                      <Box
+                        sx={{
+                          bgcolor: "error.main",
+                          color: "error.contrastText",
+                          p: 1,
+                          textAlign: "center",
+                          fontSize: "12px",
+                          fontWeight: "bold",
+                        }}
+                      >
+                        Error
+                      </Box>
+                      <Box
+                        sx={{
+                          bgcolor: "success.main",
+                          color: "success.contrastText",
+                          p: 1,
+                          textAlign: "center",
+                          fontSize: "12px",
+                          fontWeight: "bold",
+                        }}
+                      >
+                        Success
+                      </Box>
+                    </Box>
+                  </SistentThemeProvider>
+                </div>
+                <CodeBlock
+                  name="colors"
+                  collapsible
+                  code={codeExamples.colors}
+                />
               </div>
-              <CodeBlock name="Spacing" collapsible code={codeExamples.spacing} />
-            </div>
 
-            <a id="examples">
-              <h2>Practical Examples</h2>
-            </a>
-            <p>
-              Here's how to use multiple token categories together in real components:
-            </p>
+              <a id="typography">
+                <h2>Typography</h2>
+              </a>
+              <p>
+                Typography tokens provide consistent text styling across all
+                components.
+              </p>
 
-            <div className="showcase">
-              <div className="items">
-                <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
-                  <Card sx={{
-                    p: 3,
-                    mb: 2,
-                    border: "1px solid",
-                    borderColor: "divider",
-                    "&:hover": {
-                      bgcolor: "action.hover",
-                      transform: "translateY(-2px)",
-                      transition: "all 0.2s ease-in-out"
-                    }
-                  }}
-                  >
-                    <Typography variant="h5" color="text.primary" gutterBottom fontWeight="medium">
-                      Product Card
-                    </Typography>
-                    <Typography variant="body1" color="text.secondary" sx={{ mb: 2, lineHeight: 1.6 }}>
-                      A beautifully designed card component using Sistent design tokens for consistent styling and theming.
-                    </Typography>
-                    <Typography variant="h6" color="primary.main" fontWeight="bold">
-                      $99.99
-                    </Typography>
-                  </Card>
-                </SistentThemeProvider>
+              <div className="showcase">
+                <div className="items">
+                  <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
+                    <Box>
+                      <Typography variant="h1" gutterBottom>
+                        Heading 1
+                      </Typography>
+                      <Typography variant="h3" gutterBottom>
+                        Heading 3
+                      </Typography>
+                      <Typography variant="h6" gutterBottom>
+                        Heading 6
+                      </Typography>
+                      <Typography variant="body1" gutterBottom>
+                        Body text primary
+                      </Typography>
+                      <Typography variant="body2">
+                        Body text secondary
+                      </Typography>
+                    </Box>
+                  </SistentThemeProvider>
+                </div>
+                <CodeBlock
+                  name="Typography"
+                  collapsible
+                  code={codeExamples.typography}
+                />
               </div>
-              <CodeBlock name="practical-example" collapsible code={codeExamples.practicalExample} />
+
+              <a id="spacing">
+                <h2>Spacing</h2>
+              </a>
+              <p>
+                Sistent uses an 8px-based spacing system. All spacing values are
+                multiples of 8px for consistent layouts.
+              </p>
+
+              <div className="showcase">
+                <div className="items">
+                  <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
+                    <Box>
+                      {[1, 2, 3, 4, 6, 8].map((multiplier) => (
+                        <Box
+                          key={multiplier}
+                          display="flex"
+                          alignItems="center"
+                          gap={2}
+                          mb={1}
+                        >
+                          <Typography
+                            variant="body2"
+                            sx={{ minWidth: 80, fontFamily: "monospace" }}
+                          >
+                            spacing({multiplier})
+                          </Typography>
+                          <Box
+                            sx={{
+                              width: `${multiplier * 8}px`,
+                              height: 20,
+                              backgroundColor: "primary.main",
+                              border: "1px solid",
+                              borderColor: "divider",
+                            }}
+                          />
+                          <Typography
+                            variant="body2"
+                            sx={{
+                              fontFamily: "monospace",
+                              fontSize: "12px",
+                              color: "text.secondary",
+                            }}
+                          >
+                            {multiplier * 8}px
+                          </Typography>
+                        </Box>
+                      ))}
+                    </Box>
+                  </SistentThemeProvider>
+                </div>
+                <CodeBlock
+                  name="Spacing"
+                  collapsible
+                  code={codeExamples.spacing}
+                />
+              </div>
+
+              <a id="examples">
+                <h2>Practical Examples</h2>
+              </a>
+              <p>
+                Here's how to use multiple token categories together in real
+                components:
+              </p>
+
+              <div className="showcase">
+                <div className="items">
+                  <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
+                    <Card
+                      sx={{
+                        p: 3,
+                        mb: 2,
+                        border: "1px solid",
+                        borderColor: "divider",
+                        "&:hover": {
+                          bgcolor: "action.hover",
+                          transform: "translateY(-2px)",
+                          transition: "all 0.2s ease-in-out",
+                        },
+                      }}
+                    >
+                      <Typography
+                        variant="h5"
+                        color="text.primary"
+                        gutterBottom
+                        fontWeight="medium"
+                      >
+                        Product Card
+                      </Typography>
+                      <Typography
+                        variant="body1"
+                        color="text.secondary"
+                        sx={{ mb: 2, lineHeight: 1.6 }}
+                      >
+                        A beautifully designed card component using Sistent
+                        design tokens for consistent styling and theming.
+                      </Typography>
+                      <Typography
+                        variant="h6"
+                        color="primary.main"
+                        fontWeight="bold"
+                      >
+                        $99.99
+                      </Typography>
+                    </Card>
+                  </SistentThemeProvider>
+                </div>
+                <CodeBlock
+                  name="practical-example"
+                  collapsible
+                  code={codeExamples.practicalExample}
+                />
+              </div>
+
+              <h3>Implementation Guidelines</h3>
+              <br />
+              <ul>
+                <li>
+                  Always use tokens instead of hardcoded values for maintainable
+                  code
+                </li>
+                <li>
+                  Tokens automatically adapt to light/dark themes without
+                  additional configuration
+                </li>
+                <li>
+                  Use <code>useTheme()</code> hook to access all available
+                  design tokens
+                </li>
+                <li>
+                  Prefer semantic color names (primary, error) over specific hex
+                  values
+                </li>
+                <li>
+                  Follow the 8px spacing grid system for consistent visual
+                  rhythm
+                </li>
+                <li>
+                  Test components in both light and dark themes to ensure proper
+                  contrast
+                </li>
+              </ul>
             </div>
-
-            <h3>Implementation Guidelines</h3>
-            <br/>
-            <ul>
-              <li>Always use tokens instead of hardcoded values for maintainable code</li>
-              <li>Tokens automatically adapt to light/dark themes without additional configuration</li>
-              <li>Use <code>useTheme()</code> hook to access all available design tokens</li>
-              <li>Prefer semantic color names (primary, error) over specific hex values</li>
-              <li>Follow the 8px spacing grid system for consistent visual rhythm</li>
-              <li>Test components in both light and dark themes to ensure proper contrast</li>
-            </ul>
-
-          </div>
-          <SistentPagination />
-        </Container>
-        <IntraPage contents={contents} />
+            <SistentPagination />
+          </Container>
+          <IntraPage contents={contents} />
+        </div>
       </div>
     </SistentWrapper>
   );

--- a/src/sections/Projects/Sistent/getting-started/usage/index.js
+++ b/src/sections/Projects/Sistent/getting-started/usage/index.js
@@ -7,14 +7,21 @@ import SistentPagination from "../../../../../components/SistentNavigation/pagin
 import { useStyledDarkMode } from "../../../../../theme/app/useStyledDarkMode";
 import CodeBlock from "../../../../../components/CodeBlock";
 import { SistentThemeProvider } from "@sistent/sistent";
-import { Button, TextField, Card, CardContent, Typography, Alert } from "@sistent/sistent";
+import {
+  Button,
+  TextField,
+  Card,
+  CardContent,
+  Typography,
+  Alert,
+} from "@sistent/sistent";
 
 const contents = [
   { id: 0, link: "#overview", text: "Overview" },
   { id: 1, link: "#theme-provider", text: "Theme Provider" },
   { id: 2, link: "#component-examples", text: "Component Examples" },
   { id: 3, link: "#advanced-usage", text: "Advanced Usage" },
-  { id: 4, link: "#best-practices", text: "Best Practices" }
+  { id: 4, link: "#best-practices", text: "Best Practices" },
 ];
 
 const codeExamples = {
@@ -330,7 +337,7 @@ function ResponsiveGrid() {
       </div>
     </Box>
   );
-}`
+}`,
 };
 
 const SistentUsage = () => {
@@ -341,325 +348,459 @@ const SistentUsage = () => {
       <div className="page-header-section">
         <h1>Usage Guide</h1>
       </div>
+      <div className="page-container">
+        <TOC />
+        <div className="page-section">
+          <Container className="components-container">
+            <div className="content">
+              <a id="overview">
+                <h2>Overview</h2>
+              </a>
+              <section>
+                <p>
+                  After installing Sistent, you can immediately start using
+                  components in your React application. The most important step
+                  is wrapping your application with the
+                  <code> SistentThemeProvider </code>
+                  to ensure all components have access to the theme context.
+                </p>
 
-      <TOC />
-      <div className="page-section">
-        <Container className="components-container">
-          <div className="content">
-            <a id="overview">
-              <h2>Overview</h2>
-            </a>
-            <section>
-              <p>
-                After installing Sistent, you can immediately start using components in your React application.
-                The most important step is wrapping your application with the
-                <code> SistentThemeProvider </code>
-                 to ensure all components have access to the theme context.
-              </p>
+                <Alert severity="info" sx={{ my: 2 }}>
+                  <strong>Prerequisites:</strong> Ensure you have React 16.8+
+                  and have installed Sistent using
+                  <code style={{ margin: "0 4px" }}>
+                    npm install @sistent/sistent
+                  </code>
+                </Alert>
 
-              <Alert severity="info" sx={{ my: 2 }}>
-                <strong>Prerequisites:</strong> Ensure you have React 16.8+ and have installed Sistent using
-                <code style={{ margin: "0 4px" }}>npm install @sistent/sistent</code>
-              </Alert>
+                <h3>Quick Start Example</h3>
+                <p>Here's the minimal setup to get started with Sistent:</p>
 
-              <h3>Quick Start Example</h3>
-              <p>
-                Here's the minimal setup to get started with Sistent:
-              </p>
-
-              <div className="showcase">
-                <div className="items">
-                  <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
-                    <Button variant="contained" color="primary">
-                      Hello Sistent!
-                    </Button>
-                  </SistentThemeProvider>
+                <div className="showcase">
+                  <div className="items">
+                    <SistentThemeProvider
+                      initialMode={isDark ? "dark" : "light"}
+                    >
+                      <Button variant="contained" color="primary">
+                        Hello Sistent!
+                      </Button>
+                    </SistentThemeProvider>
+                  </div>
+                  <CodeBlock
+                    name="basic-usage"
+                    collapsible
+                    code={codeExamples.basicUsage}
+                  />
                 </div>
-                <CodeBlock name="basic-usage" collapsible code={codeExamples.basicUsage} />
-              </div>
-            </section>
+              </section>
 
-            {/* Theme Provider Section */}
-            <h2>Theme Provider Setup</h2>
-            <section id="theme-provider">
-              <p>
-                The <code>SistentThemeProvider</code> is the foundation of your Sistent application.
-                It provides theme context, manages color modes, and ensures consistent styling across all components.
-              </p>
+              {/* Theme Provider Section */}
+              <h2>Theme Provider Setup</h2>
+              <section id="theme-provider">
+                <p>
+                  The <code>SistentThemeProvider</code> is the foundation of
+                  your Sistent application. It provides theme context, manages
+                  color modes, and ensures consistent styling across all
+                  components.
+                </p>
 
-              <h3>Theme Configuration</h3>
-              <p>
-                Configure your theme provider with various options:
-              </p>
+                <h3>Theme Configuration</h3>
+                <p>Configure your theme provider with various options:</p>
 
-              <div className="showcase">
-                <CodeBlock name="Theme-provider" collapsible code={codeExamples.themeProvider} />
-              </div>
-
-              <div className="parameter-table">
-                <h4>Theme Provider Props</h4>
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Prop</th>
-                      <th>Type</th>
-                      <th>Default</th>
-                      <th>Description</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td><code>initialMode</code></td>
-                      <td><code>"light" | "dark" | "system"</code></td>
-                      <td><code>"system"</code></td>
-                      <td>Sets the initial color mode</td>
-                    </tr>
-                    <tr>
-                      <td><code>theme</code></td>
-                      <td><code>Theme</code></td>
-                      <td>Default theme</td>
-                      <td>Custom theme object</td>
-                    </tr>
-                    <tr>
-                      <td><code>children</code></td>
-                      <td><code>ReactNode</code></td>
-                      <td>-</td>
-                      <td>Your application components</td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-
-              <Alert severity="warning" sx={{ my: 3 }}>
-                <strong>Important:</strong> Place the <code>SistentThemeProvider</code> at the root of your
-                component tree, typically in your <code>App.js</code> or <code>index.js</code> file.
-              </Alert>
-            </section>
-
-            {/* Component Examples Section */}
-            <section id="component-examples">
-              <h2>Component Examples</h2>
-              <p>
-                Explore practical examples of Sistent components with different configurations and use cases.
-              </p>
-
-              <h3>Button Variations</h3>
-              <p>
-                Sistent provides multiple button variants, colors, and sizes to fit different design needs:
-              </p>
-
-              <div className="showcase">
-                <div className="items">
-                  <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
-                    <div style={{ display: "flex", gap: "12px", flexWrap: "wrap", alignItems: "center" }}>
-                      <Button variant="contained" color="primary">Contained</Button>
-                      <Button variant="outlined" color="secondary">Outlined</Button>
-                      <Button variant="text">Text Button</Button>
-                      <Button variant="contained" disabled>Disabled</Button>
-                    </div>
-                  </SistentThemeProvider>
+                <div className="showcase">
+                  <CodeBlock
+                    name="Theme-provider"
+                    collapsible
+                    code={codeExamples.themeProvider}
+                  />
                 </div>
-                <CodeBlock name="button-variants" collapsible code={codeExamples.buttonVariants} />
-              </div>
 
-              <h3>Interactive Form Example</h3>
-              <p>
-                A complete form example showcasing multiple components working together:
-              </p>
-
-              <div className="showcase">
-                <div className="items">
-                  <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
-                    <Card sx={{ maxWidth: 500, mx: "auto" }}>
-                      <CardContent>
-                        <Typography variant="h5" component="h2" gutterBottom>
-                          Get in Touch
-                        </Typography>
-                        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-                          Fill out the form below and we'll get back to you soon.
-                        </Typography>
-                        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
-                          <TextField
-                            label="Full Name"
-                            variant="outlined"
-                            fullWidth
-                            size="small"
-                          />
-                          <TextField
-                            label="Email Address"
-                            type="email"
-                            variant="outlined"
-                            fullWidth
-                            size="small"
-                          />
-                          <TextField
-                            label="Message"
-                            multiline
-                            rows={3}
-                            variant="outlined"
-                            fullWidth
-                            size="small"
-                          />
-                          <Button
-                            variant="contained"
-                            color="primary"
-                            fullWidth
-                            sx={{ mt: 1 }}
-                          >
-                            Send Message
-                          </Button>
-                        </div>
-                      </CardContent>
-                    </Card>
-                  </SistentThemeProvider>
+                <div className="parameter-table">
+                  <h4>Theme Provider Props</h4>
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Prop</th>
+                        <th>Type</th>
+                        <th>Default</th>
+                        <th>Description</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td>
+                          <code>initialMode</code>
+                        </td>
+                        <td>
+                          <code>"light" | "dark" | "system"</code>
+                        </td>
+                        <td>
+                          <code>"system"</code>
+                        </td>
+                        <td>Sets the initial color mode</td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <code>theme</code>
+                        </td>
+                        <td>
+                          <code>Theme</code>
+                        </td>
+                        <td>Default theme</td>
+                        <td>Custom theme object</td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <code>children</code>
+                        </td>
+                        <td>
+                          <code>ReactNode</code>
+                        </td>
+                        <td>-</td>
+                        <td>Your application components</td>
+                      </tr>
+                    </tbody>
+                  </table>
                 </div>
-                <CodeBlock name="form-example" collapsible code={codeExamples.formExample} />
-              </div>
-            </section>
 
-            {/* Advanced Usage Section */}
-            <h2>Advanced Usage</h2>
-            <section id="advanced-usage">
+                <Alert severity="warning" sx={{ my: 3 }}>
+                  <strong>Important:</strong> Place the{" "}
+                  <code>SistentThemeProvider</code> at the root of your
+                  component tree, typically in your <code>App.js</code> or{" "}
+                  <code>index.js</code> file.
+                </Alert>
+              </section>
 
-              <h3>Theme Customization</h3>
-              <p>
-                Create custom themes and use the theme hook for advanced styling:
-              </p>
+              {/* Component Examples Section */}
+              <section id="component-examples">
+                <h2>Component Examples</h2>
+                <p>
+                  Explore practical examples of Sistent components with
+                  different configurations and use cases.
+                </p>
 
-              <div className="showcase">
-                <CodeBlock name="theme-customization" collapsible code={codeExamples.themeCustomization} />
-              </div>
+                <h3>Button Variations</h3>
+                <p>
+                  Sistent provides multiple button variants, colors, and sizes
+                  to fit different design needs:
+                </p>
 
-              <h3>Import Strategies</h3>
-              <p>
-                Optimize your bundle size with smart import strategies:
-              </p>
-
-              <div className="showcase">
-                <CodeBlock name="import-strategies" collapsible code={codeExamples.importStrategies} />
-              </div>
-
-              <h3>Working with Icons</h3>
-              <p>
-                Integrate Sistent's comprehensive icon library:
-              </p>
-
-              <div className="showcase">
-                <div className="items">
-                  <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
-                    <div style={{ display: "flex", gap: "12px", alignItems: "center", flexWrap: "wrap" }}>
-                      <Button startIcon="🔍" variant="contained">Search</Button>
-                      <Button endIcon="📥" variant="outlined">Download</Button>
-                      <Button variant="text">Menu ☰</Button>
-                      <Button variant="contained" color="secondary">❤️</Button>
-                    </div>
-                  </SistentThemeProvider>
-                </div>
-                <CodeBlock name="icon-usage" collapsible code={codeExamples.iconUsage} />
-              </div>
-
-              <h3>Responsive Design</h3>
-              <p>
-                Build responsive layouts with Sistent's grid system and breakpoint utilities:
-              </p>
-              <div className="showcase">
-                <div className="items">
-                  <SistentThemeProvider initialMode={isDark ? "dark" : "light"}>
-                    <div style={{ padding: "16px", backgroundColor: isDark ? "#1a1a1a" : "#f5f5f5", borderRadius: "8px" }}>
-                      <div style={{ display: "grid", gap: "16px", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))" }}>
-                        <Card>
-                          <CardContent>
-                            <Typography variant="h6" gutterBottom>
-                              Responsive Card 1
-                            </Typography>
-                            <Typography variant="body2" color="text.secondary">
-                              This card adapts to different screen sizes automatically.
-                            </Typography>
-                          </CardContent>
-                        </Card>
-                        <Card>
-                          <CardContent>
-                            <Typography variant="h6" gutterBottom>
-                              Responsive Card 2
-                            </Typography>
-                            <Typography variant="body2" color="text.secondary">
-                              On mobile, cards stack vertically for better readability.
-                            </Typography>
-                          </CardContent>
-                        </Card>
-                        <Card>
-                          <CardContent>
-                            <Typography variant="h6" gutterBottom>
-                              Responsive Card 3
-                            </Typography>
-                            <Typography variant="body2" color="text.secondary">
-                              Grid system provides flexible layouts across all devices.
-                            </Typography>
-                          </CardContent>
-                        </Card>
-                        <Card>
-                          <CardContent>
-                            <Typography variant="h6" gutterBottom>
-                              Responsive Card 4
-                            </Typography>
-                            <Typography variant="body2" color="text.secondary">
-                            Design system ensures visual unity.
-                            </Typography>
-                          </CardContent>
-                        </Card>
+                <div className="showcase">
+                  <div className="items">
+                    <SistentThemeProvider
+                      initialMode={isDark ? "dark" : "light"}
+                    >
+                      <div
+                        style={{
+                          display: "flex",
+                          gap: "12px",
+                          flexWrap: "wrap",
+                          alignItems: "center",
+                        }}
+                      >
+                        <Button variant="contained" color="primary">
+                          Contained
+                        </Button>
+                        <Button variant="outlined" color="secondary">
+                          Outlined
+                        </Button>
+                        <Button variant="text">Text Button</Button>
+                        <Button variant="contained" disabled>
+                          Disabled
+                        </Button>
                       </div>
-                    </div>
-                  </SistentThemeProvider>
+                    </SistentThemeProvider>
+                  </div>
+                  <CodeBlock
+                    name="button-variants"
+                    collapsible
+                    code={codeExamples.buttonVariants}
+                  />
                 </div>
-                <CodeBlock name="responsive-usage" collapsible code={codeExamples.responsiveUsage} />
-              </div>
-            </section>
-            {/* Best Practices Section */}
-            <h2>Best Practices</h2>
-            <section id="best-practices">
-              <ul>
-                <li>
-                  <strong>Theme Provider:</strong> Always wrap your application root with <code>SistentThemeProvider</code>.
-                  Place it as high as possible in your component tree to ensure all components
-                  have access to the theme context.
-                </li>
 
-                <li>
-                  <strong>Import Optimization:</strong> Import only the components you need to keep your bundle size minimal.
-                  Use individual imports or group related components together rather than
-                  importing everything.
-                </li>
+                <h3>Interactive Form Example</h3>
+                <p>
+                  A complete form example showcasing multiple components working
+                  together:
+                </p>
 
-                <li>
-                  <strong>Consistent Design:</strong> Use consistent component variants, colors, and sizing throughout your application.
-                  Create reusable component wrappers for commonly used patterns.
-                </li>
+                <div className="showcase">
+                  <div className="items">
+                    <SistentThemeProvider
+                      initialMode={isDark ? "dark" : "light"}
+                    >
+                      <Card sx={{ maxWidth: 500, mx: "auto" }}>
+                        <CardContent>
+                          <Typography variant="h5" component="h2" gutterBottom>
+                            Get in Touch
+                          </Typography>
+                          <Typography
+                            variant="body2"
+                            color="text.secondary"
+                            sx={{ mb: 3 }}
+                          >
+                            Fill out the form below and we'll get back to you
+                            soon.
+                          </Typography>
+                          <div
+                            style={{
+                              display: "flex",
+                              flexDirection: "column",
+                              gap: "16px",
+                            }}
+                          >
+                            <TextField
+                              label="Full Name"
+                              variant="outlined"
+                              fullWidth
+                              size="small"
+                            />
+                            <TextField
+                              label="Email Address"
+                              type="email"
+                              variant="outlined"
+                              fullWidth
+                              size="small"
+                            />
+                            <TextField
+                              label="Message"
+                              multiline
+                              rows={3}
+                              variant="outlined"
+                              fullWidth
+                              size="small"
+                            />
+                            <Button
+                              variant="contained"
+                              color="primary"
+                              fullWidth
+                              sx={{ mt: 1 }}
+                            >
+                              Send Message
+                            </Button>
+                          </div>
+                        </CardContent>
+                      </Card>
+                    </SistentThemeProvider>
+                  </div>
+                  <CodeBlock
+                    name="form-example"
+                    collapsible
+                    code={codeExamples.formExample}
+                  />
+                </div>
+              </section>
 
-                <li>
-                  <strong>Mobile-First:</strong> Leverage Sistent's responsive utilities and breakpoints to create mobile-first
-                  designs. Test your components across different screen sizes.
-                </li>
+              {/* Advanced Usage Section */}
+              <h2>Advanced Usage</h2>
+              <section id="advanced-usage">
+                <h3>Theme Customization</h3>
+                <p>
+                  Create custom themes and use the theme hook for advanced
+                  styling:
+                </p>
 
-                <li>
-                  <strong>Accessibility:</strong> Take advantage of Sistent's built-in accessibility features. Always provide
-                  proper labels, ARIA attributes, and ensure adequate color contrast.
-                </li>
+                <div className="showcase">
+                  <CodeBlock
+                    name="theme-customization"
+                    collapsible
+                    code={codeExamples.themeCustomization}
+                  />
+                </div>
 
-                <li>
-                  <strong>Theme Customization:</strong> Use design tokens and theme customization for styling rather than overriding
-                  CSS directly. This ensures consistency and easier maintenance.
-                </li>
-              </ul>
+                <h3>Import Strategies</h3>
+                <p>Optimize your bundle size with smart import strategies:</p>
 
-              <Alert severity="success" sx={{ my: 3 }}>
-                <strong>Pro Tip:</strong> Create a custom hook to manage commonly used theme values
-                and component configurations across your application.
-              </Alert>
-            </section>
-          </div>
-          <SistentPagination />
-        </Container>
-        <IntraPage contents={contents} />
+                <div className="showcase">
+                  <CodeBlock
+                    name="import-strategies"
+                    collapsible
+                    code={codeExamples.importStrategies}
+                  />
+                </div>
+
+                <h3>Working with Icons</h3>
+                <p>Integrate Sistent's comprehensive icon library:</p>
+
+                <div className="showcase">
+                  <div className="items">
+                    <SistentThemeProvider
+                      initialMode={isDark ? "dark" : "light"}
+                    >
+                      <div
+                        style={{
+                          display: "flex",
+                          gap: "12px",
+                          alignItems: "center",
+                          flexWrap: "wrap",
+                        }}
+                      >
+                        <Button startIcon="🔍" variant="contained">
+                          Search
+                        </Button>
+                        <Button endIcon="📥" variant="outlined">
+                          Download
+                        </Button>
+                        <Button variant="text">Menu ☰</Button>
+                        <Button variant="contained" color="secondary">
+                          ❤️
+                        </Button>
+                      </div>
+                    </SistentThemeProvider>
+                  </div>
+                  <CodeBlock
+                    name="icon-usage"
+                    collapsible
+                    code={codeExamples.iconUsage}
+                  />
+                </div>
+
+                <h3>Responsive Design</h3>
+                <p>
+                  Build responsive layouts with Sistent's grid system and
+                  breakpoint utilities:
+                </p>
+                <div className="showcase">
+                  <div className="items">
+                    <SistentThemeProvider
+                      initialMode={isDark ? "dark" : "light"}
+                    >
+                      <div
+                        style={{
+                          padding: "16px",
+                          backgroundColor: isDark ? "#1a1a1a" : "#f5f5f5",
+                          borderRadius: "8px",
+                        }}
+                      >
+                        <div
+                          style={{
+                            display: "grid",
+                            gap: "16px",
+                            gridTemplateColumns:
+                              "repeat(auto-fit, minmax(150px, 1fr))",
+                          }}
+                        >
+                          <Card>
+                            <CardContent>
+                              <Typography variant="h6" gutterBottom>
+                                Responsive Card 1
+                              </Typography>
+                              <Typography
+                                variant="body2"
+                                color="text.secondary"
+                              >
+                                This card adapts to different screen sizes
+                                automatically.
+                              </Typography>
+                            </CardContent>
+                          </Card>
+                          <Card>
+                            <CardContent>
+                              <Typography variant="h6" gutterBottom>
+                                Responsive Card 2
+                              </Typography>
+                              <Typography
+                                variant="body2"
+                                color="text.secondary"
+                              >
+                                On mobile, cards stack vertically for better
+                                readability.
+                              </Typography>
+                            </CardContent>
+                          </Card>
+                          <Card>
+                            <CardContent>
+                              <Typography variant="h6" gutterBottom>
+                                Responsive Card 3
+                              </Typography>
+                              <Typography
+                                variant="body2"
+                                color="text.secondary"
+                              >
+                                Grid system provides flexible layouts across all
+                                devices.
+                              </Typography>
+                            </CardContent>
+                          </Card>
+                          <Card>
+                            <CardContent>
+                              <Typography variant="h6" gutterBottom>
+                                Responsive Card 4
+                              </Typography>
+                              <Typography
+                                variant="body2"
+                                color="text.secondary"
+                              >
+                                Design system ensures visual unity.
+                              </Typography>
+                            </CardContent>
+                          </Card>
+                        </div>
+                      </div>
+                    </SistentThemeProvider>
+                  </div>
+                  <CodeBlock
+                    name="responsive-usage"
+                    collapsible
+                    code={codeExamples.responsiveUsage}
+                  />
+                </div>
+              </section>
+              {/* Best Practices Section */}
+              <h2>Best Practices</h2>
+              <section id="best-practices">
+                <ul>
+                  <li>
+                    <strong>Theme Provider:</strong> Always wrap your
+                    application root with <code>SistentThemeProvider</code>.
+                    Place it as high as possible in your component tree to
+                    ensure all components have access to the theme context.
+                  </li>
+
+                  <li>
+                    <strong>Import Optimization:</strong> Import only the
+                    components you need to keep your bundle size minimal. Use
+                    individual imports or group related components together
+                    rather than importing everything.
+                  </li>
+
+                  <li>
+                    <strong>Consistent Design:</strong> Use consistent component
+                    variants, colors, and sizing throughout your application.
+                    Create reusable component wrappers for commonly used
+                    patterns.
+                  </li>
+
+                  <li>
+                    <strong>Mobile-First:</strong> Leverage Sistent's responsive
+                    utilities and breakpoints to create mobile-first designs.
+                    Test your components across different screen sizes.
+                  </li>
+
+                  <li>
+                    <strong>Accessibility:</strong> Take advantage of Sistent's
+                    built-in accessibility features. Always provide proper
+                    labels, ARIA attributes, and ensure adequate color contrast.
+                  </li>
+
+                  <li>
+                    <strong>Theme Customization:</strong> Use design tokens and
+                    theme customization for styling rather than overriding CSS
+                    directly. This ensures consistency and easier maintenance.
+                  </li>
+                </ul>
+
+                <Alert severity="success" sx={{ my: 3 }}>
+                  <strong>Pro Tip:</strong> Create a custom hook to manage
+                  commonly used theme values and component configurations across
+                  your application.
+                </Alert>
+              </section>
+            </div>
+            <SistentPagination />
+          </Container>
+          <IntraPage contents={contents} />
+        </div>
       </div>
     </SistentWrapper>
   );

--- a/src/sections/Projects/Sistent/sistent-layout.js
+++ b/src/sections/Projects/Sistent/sistent-layout.js
@@ -11,12 +11,14 @@ export const SistentLayout = ({ title, children }) => {
       <div className="page-header-section">
         <h1>{title}</h1>
       </div>
-      <TOC />
-      <div className="page-section">
-        <Container>
-          {children} <SistentPagination />
-        </Container>
-        <IntraPage />
+      <div className="page-container">
+        <TOC />
+        <div className="page-section">
+          <Container>
+            {children} <SistentPagination />
+          </Container>
+          <IntraPage />
+        </div>
       </div>
     </SistentWrapper>
   );

--- a/src/sections/Projects/Sistent/sistent.style.js
+++ b/src/sections/Projects/Sistent/sistent.style.js
@@ -66,13 +66,16 @@ const SistentWrapper = styled.div`
       padding-top: 1rem;
       margin-top: 1rem;
     }
-  }
-
-  .page-section .heading-top {
-    @media screen and (min-width: 751px) {
-      padding-top: 1rem;
+    @media screen and (max-width: 751px) {
+      h1,
+      h2,
+      h3 {
+        padding-top: 0;
+        margin-top: 0;
+      }
     }
   }
+
   .sidebar {
     margin: 0;
     padding: 0;
@@ -287,9 +290,6 @@ const SistentWrapper = styled.div`
   }
 
   @media only screen and (max-width: 750px) {
-    .content > a:first-of-type > h2:first-of-type {
-      padding-top: 7rem;
-    }
     .page-section {
       margin-top: -2rem;
       margin-left: 0;

--- a/src/sections/Projects/Sistent/sistent.style.js
+++ b/src/sections/Projects/Sistent/sistent.style.js
@@ -5,7 +5,7 @@ export const ActionBox = styled(Box)(() => ({
   display: "flex",
   justifyContent: "end",
   width: "100%",
-  gap: "1rem"
+  gap: "1rem",
 }));
 
 const SistentWrapper = styled.div`
@@ -38,31 +38,36 @@ const SistentWrapper = styled.div`
       transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
     }
   }
+  .page-container {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 2rem;
+    @media screen and (max-width: 751px) {
+      display: block;
+    }
+  }
 
-  h2 h3 {
+  h1,
+  h2,
+  h3 {
     margin: 0.5rem 0;
     color: ${(props) => props.theme.tertiaryColor};
     transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
   }
 
   .page-section {
-    h2 {
-      padding-top: 1rem;
-      margin-top: 1rem;
-    }
+    flex: 1 1 auto;
+    width: auto;
+    min-width: 0;
+    h1,
+    h2,
     h3 {
       padding-top: 1rem;
       margin-top: 1rem;
     }
-    padding-left: 20rem;
-    margin-top: 4rem;
-    display: flex;
   }
-  .conduct-section {
-    @media screen and (min-width: 751px) {
-      margin-top: -43rem;
-    }
-  }
+
   .page-section .heading-top {
     @media screen and (min-width: 751px) {
       padding-top: 1rem;
@@ -682,34 +687,33 @@ const SistentWrapper = styled.div`
   .card_head .title {
     font-size: 32px;
     font-weight: 700;
-    color: ${props => props.theme.text};
+    color: ${(props) => props.theme.text};
   }
-    .card .text {
-  padding-top: 1rem;
-  padding-bottom: 2rem;
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 400;
-  color: ${(props) => props.theme.whiteToBlack};
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-height: calc(1.5rem * 4);
-}
+  .card .text {
+    padding-top: 1rem;
+    padding-bottom: 2rem;
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 400;
+    color: ${(props) => props.theme.whiteToBlack};
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-height: calc(1.5rem * 4);
+  }
 
   .card {
-    box-shadow: 0px 2px 6px 0px ${props => props.theme.green00D3A9ToBlackTwo};
+    box-shadow: 0px 2px 6px 0px ${(props) => props.theme.green00D3A9ToBlackTwo};
     transition: all 0.8s cubic-bezier(0.2, 0.8, 0.2, 1) 0s;
 
-      &:hover {
-        box-shadow: 0px 2px 15px 4px ${props => props.theme.whiteNineToBlackOne};
-        transform: scale(1.045);
-      }
+    &:hover {
+      box-shadow: 0px 2px 15px 4px ${(props) => props.theme.whiteNineToBlackOne};
+      transform: scale(1.045);
+    }
   }
 
-  
   .card_bottom {
     border-top: 2px solid #2c2c2c;
     display: flex;
@@ -945,70 +949,70 @@ const SistentWrapper = styled.div`
   }
 
   /* IconCard container */
-.icon-card-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 16px;
-  border-radius: 8px;
-  cursor: pointer;
-  transition: background-color 0.3s ease;
-}
+  .icon-card-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+  }
 
-.icon-card-container.dark {
-  background-color: #2d2d2d;
-  color: #fff;
-}
+  .icon-card-container.dark {
+    background-color: #2d2d2d;
+    color: #fff;
+  }
 
-.icon-card-container.light {
-  background-color: #fff;
-  color: #000;
-}
+  .icon-card-container.light {
+    background-color: #fff;
+    color: #000;
+  }
 
-.icon-card-container:hover {
-  background-color: #444;
-}
+  .icon-card-container:hover {
+    background-color: #444;
+  }
 
-.icon-card-container.light:hover {
-  background-color: #f5f5f5;
-}
+  .icon-card-container.light:hover {
+    background-color: #f5f5f5;
+  }
 
-/* Icon container */
-.icon-container {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 8px;
-}
+  /* Icon container */
+  .icon-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 8px;
+  }
 
-/* Icon name */
-.icon-name {
-  font-size: 14px;
-  font-weight: 500;
-  text-align: center;
-}
+  /* Icon name */
+  .icon-name {
+    font-size: 14px;
+    font-weight: 500;
+    text-align: center;
+  }
 
-.icon-name.dark {
-  color: #fff;
-}
+  .icon-name.dark {
+    color: #fff;
+  }
 
-.icon-name.light {
-  color: #000;
-}
+  .icon-name.light {
+    color: #000;
+  }
 
-/* No icons found message */
-.no-icons-found {
-  text-align: center;
-  font-size: 16px;
-  color: inherit;
-}
+  /* No icons found message */
+  .no-icons-found {
+    text-align: center;
+    font-size: 16px;
+    color: inherit;
+  }
 
-/* Code block styles */
-.code-block {
-  margin-top: 16px;
-  margin-bottom: 24px;
-}
+  /* Code block styles */
+  .code-block {
+    margin-top: 16px;
+    margin-bottom: 24px;
+  }
   /* Responsive adjustments */
   @media (max-width: 768px) {
     .icon-grid {
@@ -1022,6 +1026,3 @@ const SistentWrapper = styled.div`
 `;
 
 export default SistentWrapper;
-
-
-

--- a/src/sections/Projects/Sistent/sistent.style.js
+++ b/src/sections/Projects/Sistent/sistent.style.js
@@ -43,7 +43,7 @@ const SistentWrapper = styled.div`
     align-items: flex-start;
     justify-content: space-between;
     gap: 2rem;
-    @media screen and (max-width: 751px) {
+    @media screen and (max-width: 750px) {
       display: block;
     }
   }
@@ -66,7 +66,7 @@ const SistentWrapper = styled.div`
       padding-top: 1rem;
       margin-top: 1rem;
     }
-    @media screen and (max-width: 751px) {
+    @media screen and (max-width: 750px) {
       h1,
       h2,
       h3 {


### PR DESCRIPTION
**Description**
Fixes a layout shift that occurs when refreshing pages under Sistent. The sidebar now maintains a fixed width during page load, preventing the content from shifting and ensuring a more stable layout.

### Before

https://github.com/user-attachments/assets/817d1698-2044-430c-bde9-d03fadade738

### After

https://github.com/user-attachments/assets/7180c5ae-179e-4bd5-9065-1b6113523379



This PR fixes #7937

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved responsive layouts across Sistent pages for more consistent table-of-contents and content alignment.
  * Refined navigation spacing, card typography, icon themes, labels, shadows, and hover effects.
  * Improved code block spacing and no-results styling.
  * Reformatted documentation pages for a more consistent presentation without changing functionality.

* **Documentation**
  * Corrected introductory wording on the About page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->