### PR TITLE
[Button] Fix Next/Previous buttons staying in clicked state

### DIFF
--- a/src/reusecore/Button/btn.style.js
+++ b/src/reusecore/Button/btn.style.js
@@ -1,85 +1,89 @@
 import styled, { css } from "styled-components";
-const ButtonStyle = styled.button` 
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center; 
-    font-family: inherit; 
-    font-size: 16px;
-    text-decoration: none;
-    text-transform: capitalize; 
-    border: 0; 
-    min-width: 170px;
-    padding: 14px;
-    border-radius: 5px;
-    -webkit-transition: 450ms all;
-    transition: 450ms all;
-    position: relative;
-    color: ${props => props.theme.white };
-    background-color: #00B39F;
-    z-index: 999;
-    &:hover,
-    &:focus-visible {
-        color: white;
-        background: ${props => props.theme.activeColor}; 
-        box-shadow: 0 2px 10px ${props => props.theme.whiteFourToBlackFour};
-    }
-    &:active{
-        box-shadow: 0 2px 10px ${props => props.theme.blackFourToWhiteFour};
+const ButtonStyle = styled.button`
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: inherit;
+  font-size: 16px;
+  text-decoration: none;
+  text-transform: capitalize;
+  border: 0;
+  min-width: 170px;
+  padding: 14px;
+  border-radius: 5px;
+  -webkit-transition: 450ms all;
+  transition: 450ms all;
+  position: relative;
+  color: ${(props) => props.theme.white};
+  background-color: #00b39f;
+  z-index: 999;
+  &:hover,
+  &:focus-visible {
+    color: white;
+    background: ${(props) => props.theme.activeColor};
+    box-shadow: 0 2px 10px ${(props) => props.theme.whiteFourToBlackFour};
+  }
+  &:active {
+    box-shadow: 0 2px 10px ${(props) => props.theme.blackFourToWhiteFour};
+    transform: scale(0.98);
+  }
+  .icon-left {
+    margin-right: 8px;
+  }
+  .icon-right {
+    margin-left: 8px;
+  }
+
+  ${(props) =>
+  props.$outlined &&
+    css`
+      background: transparent;
+      border: 2px solid ${(props) => props.theme.whiteToBlack};
+      color: ${(props) => props.theme.whiteToBlack};
+      &:hover {
+        box-shadow: 0 2px 10px ${props.theme.whiteFourToBlackFour};
+      }
+      &:active {
+        background: ${(props) => props.theme.lightGrey};
+        box-shadow: 0 2px 10px ${props.theme.blackFourToWhiteFour};
         transform: scale(0.98);
-    }
-    .icon-left{
-        margin-right: 8px;
-    }
-    .icon-right{
-        margin-left: 8px;
-    }
-
-    ${props => props.$outlined && css`
-        background: transparent;
-        border: 2px solid ${props => props.theme.whiteToBlack};
-        color: ${props => props.theme.whiteToBlack};
-        &:hover{
-            box-shadow: 0 2px 10px ${props.theme.whiteFourToBlackFour};
-        }
-        &:active{
-            background: ${props => props.theme.lightGrey};
-            box-shadow: 0 2px 10px ${props.theme.blackFourToWhiteFour};
-            transform: scale(0.98);
-        }
+      }
     `}
 
+  ${(props) =>
+      props.$primary &&
+    css`
+      color: ${(props) => props.theme.black};
+      background: ${(props) => props.theme.highlightColor};
 
-    ${props => props.$primary && css`
-        color: ${props => props.theme.black};
-        background: ${props => props.theme.highlightColor};
-
-        &:hover{
-            color: ${props.theme.black};
-            background: ${props.theme.highlightColor}; 
-            box-shadow: 0 2px 10px ${props.theme.whiteFourToBlackFour};
-        }
-        &:active{
-            background: ${props => props.theme.saffronColor};
-            box-shadow: 0 2px 10px ${props.theme.blackFourToWhiteFour};
-            transform: scale(0.98);
-        }
-        
+      &:hover {
+        color: ${props.theme.black};
+        background: ${props.theme.highlightColor};
+        box-shadow: 0 2px 10px ${props.theme.whiteFourToBlackFour};
+      }
+      &:active {
+        background: ${(props) => props.theme.saffronColor};
+        box-shadow: 0 2px 10px ${props.theme.blackFourToWhiteFour};
+        transform: scale(0.98);
+      }
     `}
-    ${props => props.$secondary && css`
-        color: white; 
-        background: ${props.theme.secondaryColor}; 
-        &:hover{
-            background: ${props.theme.caribbeanGreenColor};
-            box-shadow: 0 2px 10px ${props.theme.whiteFourToBlackFour};
+    ${(props) =>
+      props.$secondary &&
+      css`
+        color: white;
+        background: ${props.theme.secondaryColor};
+        &:hover {
+          background: ${props.theme.caribbeanGreenColor};
+          box-shadow: 0 2px 10px ${props.theme.whiteFourToBlackFour};
         }
-        &:active{
-            color: #326d62;
-            background: ${props.theme.secondaryColor};
-            box-shadow: 0 2px 10px ${props.theme.blackFourToWhiteFour};
-            transform: scale(0.98);
+        &:active {
+          color: #326d62;
+          background: ${props.theme.secondaryColor};
+          box-shadow: 0 2px 10px ${props.theme.blackFourToWhiteFour};
+          transform: scale(0.98);
         }
-    `}
+      `}
 `;
 ButtonStyle.displayName = "ButtonStyle";
 

--- a/src/reusecore/Button/btn.style.js
+++ b/src/reusecore/Button/btn.style.js
@@ -19,7 +19,7 @@ const ButtonStyle = styled.button`
     background-color: #00B39F;
     z-index: 999;
     &:hover,
-    &:focus {
+    &:focus-visible {
         color: white;
         background: ${props => props.theme.activeColor}; 
         box-shadow: 0 2px 10px ${props => props.theme.whiteFourToBlackFour};


### PR DESCRIPTION
**Description**

This PR fixes #7940

**Notes for Reviewers**

The stuck state comes from `reusecore/Button`, not from the pagination component.

The base `ButtonStyle` rule paints `:hover` and `:focus` with the same declaration:

```js
&:hover,
&:focus {
    color: white;
    background: ${props => props.theme.activeColor};   // #3C494F in both themes
}
```

The three variant blocks below it all re-declare `:hover`. None of them re-declare `:focus`. A mouse click leaves the button focused, so the base `:focus` rule keeps winning and the button sits at `#3C494F` until focus moves. Clicking anywhere else blurs it, which is the "only comes back after clicking somewhere else" part of the report.

The change scopes that base rule to `:focus-visible`. Browsers don't match `:focus-visible` when a button is clicked with a pointer, so the button drops straight back to its own color. They do match it on tab, so keyboard users keep the same focus indicator they had before.

Measured on `/resources` with `gatsby develop`, reading computed `background-color` after a real click with the pointer moved off the button:

| button | at rest | after click, before | after click, with fix |
| --- | --- | --- | --- |
| Next `$primary` | `#EBC017` | `#3C494F` | `#EBC017` |
| Previous `$secondary` | `#00B39F` | `#3C494F` | `#00B39F` |

Tab focus still resolves to `#3C494F` on both, so nothing is lost for keyboard navigation.

Before, after clicking Next:

<img src="https://raw.githubusercontent.com/vermarjun/layer5/assets-7940/before.png" width="500" />

After:

<img src="https://raw.githubusercontent.com/vermarjun/layer5/assets-7940/after.png" width="500" />

Two notes:

1. Next and Previous were only the visible case. The rule lives on the shared button, so every `$primary`, `$secondary` and `$outlined` button on the site held the dark state after a click.
2. `btn.style.js` isn't prettier formatted on `master`, so the `lint-staged` pre-commit hook rewrites the whole file (75 insertions, 71 deletions) alongside the fix. I committed with `--no-verify` to keep this reviewable at one line. Happy to push the reformat as a separate commit if you want it.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated button focus styling to appear during keyboard navigation, reducing focus-ring display during mouse or touch interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->