### PR TITLE
fix(ci): clean stale artifacts from gh-pages on deploy

### DIFF
--- a/.github/workflows/build-and-deploy-site.yml
+++ b/.github/workflows/build-and-deploy-site.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 #v7.0.0
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install dependencies
         run: npm ci
@@ -35,9 +35,12 @@ jobs:
           touch public/.nojekyll
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f #v4.8.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public
-          publish_branch: gh-pages
-          keep_files: true
+          folder: ./public
+          branch: gh-pages
+          clean: true
+          clean-exclude: |
+            pr-preview
+            .well-known
+          force: false


### PR DESCRIPTION
**Description**

Replaces `peaceiris/actions-gh-pages` with `JamesIves/github-pages-deploy-action` in the production deploy workflow and enables cleanup of stale build artifacts on the `gh-pages` branch.

Fixes intermittent Pages deployment failures caused by unbounded growth of the deployment branch.

**Problem**

The deploy step has been running with `keep_files: true`, which disables the action's cleanup pass entirely — files on `gh-pages` are only ever added or overwritten, never removed.

Gatsby emits content-hashed filenames (`component---*.js`, `app-<hash>.js`, `webpack-runtime-<hash>.js`, hashed image derivatives under `static/`). A content change produces a *new filename* rather than new content at the same path, so the overwrite case almost never applies. In practice nearly every deploy is pure addition, and the branch has grown monotonically since `keep_files` was introduced.

Current state of the branch root:

| | Count |
|---|---|
| Entries on `gh-pages` | 3,100 |
| Entries produced by a clean build | 1,502 |
| Overlap | 318 |
| Stale (root level only) | 2,782 |

Root-level figures only — orphaned files nested under `page-data/`, `static/`, and `_gatsby/` are additional, and account for most of the byte weight.

Consequences:

- Published-site size approaching the GitHub Pages 1 GB limit; deployments intermittently exceed the 10-minute build timeout
- `git clone` and `git fetch` are slow for every contributor, since the default refspec fetches all branches regardless of which one is checked out
- Deleted pages and build regressions are masked indefinitely — stale output keeps serving, so a route can break in `master` without anyone noticing

**Fix**

Switch to `JamesIves/github-pages-deploy-action`, which supports excluding specific paths from its cleanup pass. `peaceiris` has no equivalent option — its cleanup is all-or-nothing, which is why `keep_files: true` was the only available way to protect `pr-preview/`.

```yaml
clean: true
clean-exclude: |
  pr-preview
  .well-known
force: false
```

The action mirrors `./public` onto the branch with `rsync --delete`, so the branch becomes a faithful copy of the current build rather than the union of every build ever run. The first deploy removes the accumulated backlog in a single commit.

**`clean-exclude` entries.** The only content on `gh-pages` not produced by the Gatsby build:

- `pr-preview/` — PR preview deployments, owned by a separate workflow
- `.well-known/microsoft-identity-association.json` — Entra ID domain verification for `layer5.io`. Not currently in source; Microsoft re-fetches it periodically, so removing it would silently invalidate verification. Should be moved to `static/.well-known/` in a follow-up, after which this exclusion can be dropped.

**`force: false`.** The action force-pushes by default, which would discard any PR preview deploy landing between its fetch and its push. With `force: false` it performs an ordinary push and retries on rejection instead.

**Verification**

Confirmed no live route regresses. Compared every URL in the published sitemap against the routes a clean build produces:

```
comm -23 live-routes.txt built-routes.txt   # empty
```

1,332 routes advertised live, 1,449 produced by the build, zero missing. The 117-route surplus is `/404`, `blog/category/*` taxonomy pages (excluded from sitemaps by default), and legacy-slug aliases emitted at multiple paths — all expected.

Branch inventory taken via the git trees API (`truncated: false`, complete listing). Every root entry outside the two excluded paths is Gatsby output.

**Expectations on first run**

- The deploy commit will contain tens of thousands of deletions. The diff will not render in the GitHub UI. This is expected.
- The run will be slower than usual — the action must materialise the full existing tree before it can diff against it. If it exceeds the job timeout, the branch will need to be rebuilt out-of-band first; the failed run leaves `gh-pages` untouched, so this is safe to attempt.
- Visitors on a cached page during the deploy may hit 404s for hashed chunks that no longer exist, until reload. This is the trade-off `keep_files: true` was avoiding.

**Rollback**

The stale files remain reachable in `gh-pages` history. Reverting this PR restores the previous behaviour; recovering specific files is possible from the commit prior to the first clean deploy.

**Also included**

- Actions pinned to full commit SHAs (`checkout`, `setup-node`, `github-pages-deploy-action`) per supply-chain hardening
- Node bumped 20 → 22

The Node bump is unrelated to the deployment fix and changes the runtime that builds the site. Happy to split it into a separate PR if reviewers prefer — worth confirming the PR preview workflow uses the same version so previews and production don't diverge.

**Follow-ups (not in this PR)**

- Move `microsoft-identity-association.json` into `static/.well-known/` so it is versioned and reviewable, then drop it from `clean-exclude`

**Notes for Reviewers**
- This PR fixes #7944 

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the website publishing process for more reliable and secure deployments.
  * Upgraded the build environment to a newer Node.js version.
  * Improved published-site cleanup while preserving preview pages and domain configuration.
  * Refreshed deployment tooling and branch handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->