### PR TITLE
[chore]: Reduce PR preview retention to stay within the GitHub Pages size limit

### DIFF
--- a/.github/workflows/deploy-site-preview.yml
+++ b/.github/workflows/deploy-site-preview.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  PREVIEW_RETENTION_LIMIT: 6
+  PREVIEW_RETENTION_LIMIT: 3
 
 jobs:
   manage-preview:


### PR DESCRIPTION
 ## Context
 
GitHub Pages rejects published artifacts over 1 GB. `gh-pages` had grown well past that and `pages build and deployment` was failing continuously — every push to the branch republishes the whole thing, so production and preview deploys were both blocked.
 
Two contributing factors, now addressed:
 
- Production was deploying with `keep_files: true`, so stale fingerprinted assets were never removed. Fixed in #7945, which switched to `JamesIves/github-pages-deploy-action` with `clean-exclude`. Root entries dropped from 3,100 to 1,504, matching a clean build exactly.
- Preview retention caps by count, not size. Each preview is a full Gatsby build, so 6 previews is several times the production site's own footprint on a branch that must fit under 1 GB in total.
## Evidence
 
| | Artifact size |
|---|---|
| Before cleanup (21 previews) | 11.6 GB — deployment failed |
| After root cleanup + manual prune to 6 | 2.11 GB — deployment succeeded |
 
Still above the 1 GB limit at 6, hence this change.
 
## Verification
 
No site regressions. Every route in the published sitemap is reproduced by a clean build:
 
```
comm -23 live-routes.txt built-routes.txt 
```
 
1,332 routes live, 1,449 produced by the build, zero missing.
 
Stale fingerprints are gone — every `.js` chunk on the branch now appears exactly once:
 
```
gh api "repos/layer5io/layer5/git/trees/$sha" --jq '.tree[].path' \
  | grep -E '\.js$' | sed -E 's/-[0-9a-f]{16,}\.js$//' \
  | sort | uniq -c | sort -rn | head
```
 
All counts are 1. Previously this showed multiple generations of the same chunk coexisting.
 
## Follow-up
 
`prune` runs only when `manage-preview` succeeds, which depends on a successful Pages deployment. Pruning therefore stops precisely when size failures make it most necessary — that's how 21 previews accumulated against a limit of 6. Decoupling it should be tracked separately.


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced the number of retained site previews from six to three.
  * Older previews will be removed sooner to keep only the three most recently updated previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->