### PR TITLE
Fix focus-visible outlines

### DIFF
--- a/src/collections/handbook/faq/faq-wrapper.style.js
+++ b/src/collections/handbook/faq/faq-wrapper.style.js
@@ -36,7 +36,7 @@ const HandbookFaqWrapper = styled.div`
       }
 
       > div {
-        &:focus {
+        &:focus:not(:focus-visible) {
           outline: none;
         }
       }

--- a/src/components/Features-carousel/FeaturesCarousel.style.js
+++ b/src/components/Features-carousel/FeaturesCarousel.style.js
@@ -55,7 +55,7 @@ export const FeaturesWrapper = styled.div`
       /* nuka-carousel overrides */
       & :global {
         & .slider-frame,
-        & .slider-slide:focus {
+        & .slider-slide:focus:not(:focus-visible) {
           outline: none !important;
         }
       }

--- a/src/components/Ripple-Effect-Animation/ripple-effect.style.js
+++ b/src/components/Ripple-Effect-Animation/ripple-effect.style.js
@@ -45,7 +45,7 @@ button {
     animation: ripple 1.5s linear infinite;
     transform: scale(1.1);
   }
-  &:focus {
+  &:focus:not(:focus-visible) {
     outline: none;
   }
 

--- a/src/reusecore/Accordion/accordion.style.js
+++ b/src/reusecore/Accordion/accordion.style.js
@@ -47,7 +47,7 @@ export const AccordionTitleWrapper = styled(AccordionItemHeading)`
     }
   }
 
-  &:focus {
+  &:focus:not(:focus-visible) {
     outline: none;
   }
   * {

--- a/src/reusecore/Search/searchbox.style.js
+++ b/src/reusecore/Search/searchbox.style.js
@@ -50,7 +50,6 @@ export const SearchWrapper = styled.div`
 
    input{
     border:none;
-    outline: none;
     box-shadow: rgba(100, 100, 111, 0.2) 0px 3px 9px 0px;
     
    }

--- a/src/sections/Adventures-Callout/discuss.style.js
+++ b/src/sections/Adventures-Callout/discuss.style.js
@@ -57,7 +57,7 @@ const AdventuresWrapper = styled.div`
                     margin-top: 1rem;
                 }
                 &:hover,
-                &:focus {
+                &:focus:not(:focus-visible) {
                    outline: none;
                 }
                 &:hover{

--- a/src/sections/Blog/Blog-sidebar/blogSidebar.style.js
+++ b/src/sections/Blog/Blog-sidebar/blogSidebar.style.js
@@ -216,7 +216,7 @@ const BlogSideBarWrapper = styled.div`
                  width: 100%;  
                  }
                 &:hover,
-                &:focus {
+                &:focus:not(:focus-visible) {
                    outline: none;
                 }
                 &:hover{

--- a/src/sections/Blog/Blog-sidebar/blogSidebar.style.js
+++ b/src/sections/Blog/Blog-sidebar/blogSidebar.style.js
@@ -215,7 +215,6 @@ const BlogSideBarWrapper = styled.div`
                 .logo{
                  width: 100%;  
                  }
-                &:hover,
                 &:focus:not(:focus-visible) {
                    outline: none;
                 }

--- a/src/sections/DeployServiceMesh/DeployServiceMesh.style.js
+++ b/src/sections/DeployServiceMesh/DeployServiceMesh.style.js
@@ -142,7 +142,6 @@ const DeployServiceMeshWrapper = styled.div`
         height: 10px;
         border-radius: 5px;
         background: #d3d3d3;
-        outline: none;
         opacity: 0.7;
         -webkit-transition: .2s;
         transition: opacity .2s;

--- a/src/sections/Discuss-Callout/discuss.style.js
+++ b/src/sections/Discuss-Callout/discuss.style.js
@@ -57,7 +57,6 @@ const DiscussWrapper = styled.div`
                     margin-bottom: 0rem;
                     margin-top: 1rem;
                 }
-                &:hover,
                 &:focus:not(:focus-visible) {
                    outline: none;
                 }

--- a/src/sections/Discuss-Callout/discuss.style.js
+++ b/src/sections/Discuss-Callout/discuss.style.js
@@ -58,7 +58,7 @@ const DiscussWrapper = styled.div`
                     margin-top: 1rem;
                 }
                 &:hover,
-                &:focus {
+                &:focus:not(:focus-visible) {
                    outline: none;
                 }
                 &:hover{

--- a/src/sections/General/Faq/faqSection.style.js
+++ b/src/sections/General/Faq/faqSection.style.js
@@ -134,7 +134,7 @@ const FaqSectionWrapper = styled.section`
         color: ${props => props.theme.white};
       }
       > div {
-        &:focus {
+        &:focus:not(:focus-visible) {
           outline: none;
         }
       }

--- a/src/sections/General/Navigation/navigation.style.js
+++ b/src/sections/General/Navigation/navigation.style.js
@@ -777,7 +777,6 @@ const NavigationWrap = styled.header`
   .toggle {
     --size: 1.5rem;
     appearance: none;
-    outline: none;
     cursor: pointer;
     width: var(--size);
     height: var(--size);

--- a/src/sections/Home/So-Special-Section/so-special-style.js
+++ b/src/sections/Home/So-Special-Section/so-special-style.js
@@ -138,7 +138,6 @@ const SoSpecialWrapper = styled.div`
         background-color:${(props) => props.theme.body};
         color:black;
         height: 30rem;
-        outline:none;
         border:none;
         transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1); 
     }

--- a/src/sections/Learn/Workshop-grid/WorkshopsGrid.style.js
+++ b/src/sections/Learn/Workshop-grid/WorkshopsGrid.style.js
@@ -56,7 +56,6 @@ export const WorkshopPageWrapper = styled.div`
 		border: none;
 		font-family: "Qanelas Soft", "Open Sans", sans-serif;
 		border-radius: 0.9375rem;
-		outline: none;
 	}
 
 	.left-icons {

--- a/src/sections/Projects/Sistent/sistent.style.js
+++ b/src/sections/Projects/Sistent/sistent.style.js
@@ -924,7 +924,6 @@ const SistentWrapper = styled.div`
     border-radius: 4px;
     border: 1px solid #ccc;
     font-size: 16px;
-    outline: none;
     transition: border-color 0.3s ease;
   }
 
@@ -1022,6 +1021,5 @@ const SistentWrapper = styled.div`
 `;
 
 export default SistentWrapper;
-
 
 

--- a/src/sections/app.style.js
+++ b/src/sections/app.style.js
@@ -20,8 +20,13 @@ const GlobalStyle = createGlobalStyle`
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
-  *:focus {
+  *:focus:not(:focus-visible) {
     outline: none;
+  }
+
+  *:focus-visible {
+    outline: 3px solid ${(props) => props.theme.secondaryColor};
+    outline-offset: 3px;
   }
   ::-webkit-scrollbar {
     width: 0.5rem; 
@@ -207,13 +212,16 @@ section{
     border: 1px solid rgb(204, 204, 204);
     background: ${(props) => props.theme.body};
     border-radius: 0.5rem;
-    outline: none;
     padding: 20px;
     margin-right: -50%;
     transform: translate(-50%, -50%);
     max-width: 50rem;
     max-height: 40rem;
     overflow-y: hidden;
+
+    &:focus:not(:focus-visible) {
+        outline: none;
+    }
 
     .close-modal-btn {
         min-width: 2rem;


### PR DESCRIPTION
## Description

This PR restores visible keyboard focus indicators across the Layer5 site. It replaces unconditional focus-outline suppression with `:focus-visible`-aware styling and introduces a consistent, theme-aware global focus ring.

## Changes

- Added a global keyboard-visible focus outline using the theme’s secondary color.
- Limited outline suppression to `:focus:not(:focus-visible)`.
- Removed unconditional `outline: none` rules from interactive controls.
- Updated focus behavior for accordions, carousels, search fields, navigation controls, callout cards, workshop buttons, and modals.
- Kept hover styling separate from keyboard focus styling.

## Impact

Keyboard users can clearly identify the currently focused element in both light and dark themes. Mouse and touch interactions remain visually unchanged.

## Validation

- ESLint passed for all changed files.
- `git diff --check` passed.
- DCO check passed.
- Verified that the final signed commits preserve the original code changes.

Fixes #7959

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility Improvements**
  - Improved keyboard focus visibility across accordions, carousels, buttons, cards, sliders, navigation controls, and search fields.
  - Preserved focus outlines for keyboard users while keeping pointer interactions visually unobtrusive.
  - Added consistent themed focus styling with improved outline visibility and offset.
  - Restored default focus indicators for several interactive controls and inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->