### PR TITLE
Fix button focus styling

### DIFF
--- a/src/reusecore/Button/btn.style.js
+++ b/src/reusecore/Button/btn.style.js
@@ -18,11 +18,17 @@ const ButtonStyle = styled.button`
     color: ${props => props.theme.white };
     background-color: #00B39F;
     z-index: 999;
-    &:hover,
-    &:focus {
+    &:hover {
         color: white;
         background: ${props => props.theme.activeColor}; 
         box-shadow: 0 2px 10px ${props => props.theme.whiteFourToBlackFour};
+    }
+    &:focus-visible {
+        outline: 3px solid ${props => props.theme.secondaryColor};
+        outline-offset: 3px;
+    }
+    &:focus:not(:focus-visible) {
+        outline: none;
     }
     &:active{
         box-shadow: 0 2px 10px ${props => props.theme.blackFourToWhiteFour};


### PR DESCRIPTION
## Description

Fixes the persistent dark state on the Next button after it is clicked.

Fixes #7940.

The shared button styling applied the same dark background to both `:hover` and `:focus`. After a mouse click, the button retained focus, so it stayed visually dark until focus moved elsewhere. This made the button look inactive or disabled.

This change keeps the dark styling on hover only and adds a `:focus-visible` outline so keyboard users still get a clear focus indicator.

## Before 


https://github.com/user-attachments/assets/0f4960a0-c76b-4ddf-b0d4-86f38051bcff



# After 



https://github.com/user-attachments/assets/de3d39d2-f736-4993-93a9-c10eda84a20a



The first section shows the original issue: the Next button remains dark after click. The final section shows the fixed behavior: the button returns to its normal yellow state immediately after click.

## Validation

- Ran `.\node_modules\.bin\eslint.cmd src\reusecore\Button\btn.style.js`
- Ran `git diff --check`
- Verified the behavior with a local before/after browser test page


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved button focus styling for keyboard navigation with a clear, offset outline.
  * Suppressed unnecessary focus outlines for non-keyboard interactions.
  * Preserved existing hover colors, backgrounds, and shadows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->