### PR TITLE
[Community] Manager Profile: Maanvi Chetwani and Ishwar Chand Meena

### DIFF
--- a/src/collections/members/aastha-bhat/index.mdx
+++ b/src/collections/members/aastha-bhat/index.mdx
@@ -8,7 +8,6 @@ layer5: b7433816-de2b-4817-b816-f71ed22ea464
 location: Karnataka, India
 bio: "Hi, I'm Aastha Bhat, an Information Science student who enjoys building AI-powered applications and exploring cloud native technologies. I joined the Layer5 community to learn more about open source, but what kept me here was the collaborative environment and the willingness of community members to help one another grow. \nSince becoming a contributor, I've had the opportunity to work on Meshery and Layer5 projects, contribute fixes and improvements, and learn how large open source communities collaborate to build software. Every contribution has helped me grow—not just as a developer, but as someone who values knowledge sharing, thoughtful collaboration, and giving back to the community. \nI'm excited to continue contributing to open source, expanding my knowledge of cloud native technologies, and building software that is both practical and impactful."
 badges:
-  - meshery
 status: Active
 published: true
 ---

--- a/src/collections/members/aastha-bhat/index.mdx
+++ b/src/collections/members/aastha-bhat/index.mdx
@@ -9,7 +9,6 @@ location: Karnataka, India
 bio: "Hi, I'm Aastha Bhat, an Information Science student who enjoys building AI-powered applications and exploring cloud native technologies. I joined the Layer5 community to learn more about open source, but what kept me here was the collaborative environment and the willingness of community members to help one another grow. \nSince becoming a contributor, I've had the opportunity to work on Meshery and Layer5 projects, contribute fixes and improvements, and learn how large open source communities collaborate to build software. Every contribution has helped me grow—not just as a developer, but as someone who values knowledge sharing, thoughtful collaboration, and giving back to the community. \nI'm excited to continue contributing to open source, expanding my knowledge of cloud native technologies, and building software that is both practical and impactful."
 badges:
   - meshery
-  - community
 status: Active
 published: true
 ---

--- a/src/collections/members/ishwar-chand-meena/index.mdx
+++ b/src/collections/members/ishwar-chand-meena/index.mdx
@@ -10,6 +10,7 @@ location: Jaipur, Rajasthan, India
 bio: "I'm an engineer focused on backend systems and cloud-native infrastructure. I contribute to Meshery, mostly in Go, working on Kubernetes tooling. Still early in the journey, but genuinely curious about how large distributed systems hold together and open source has been the best way to actually learn that by doing."
 badges:
   - meshery
+  - community
 status: Active
 maintainer: no
 meshmate: no

--- a/src/collections/members/ishwar-chand-meena/index.mdx
+++ b/src/collections/members/ishwar-chand-meena/index.mdx
@@ -9,7 +9,6 @@ layer5: 4b2be538-4813-4946-b4a9-a175fa58623e
 location: Jaipur, Rajasthan, India
 bio: "I'm an engineer focused on backend systems and cloud-native infrastructure. I contribute to Meshery, mostly in Go, working on Kubernetes tooling. Still early in the journey, but genuinely curious about how large distributed systems hold together and open source has been the best way to actually learn that by doing."
 badges:
-  - meshery
   - community
 status: Active
 maintainer: no

--- a/src/collections/members/maanvi-chetwani/index.mdx
+++ b/src/collections/members/maanvi-chetwani/index.mdx
@@ -8,6 +8,8 @@ linkedin: maanvi-chetwani
 layer5: ebdd5d69-12af-4888-a852-1c4dda80861f
 location: Bengaluru, Karnataka, India
 bio: "I'm Maanvi, a CS student who builds things, breaks them, fixes them, and learns something every time. My interests currently revolve around backend development, TypeScript, Go, and cloud-native technologies, with open source being where I learn the most. I'm the kind of person who asks a lot of questions, enjoys understanding how things work, and believes every conversation is a chance to learn something new. Layer5 has shown me how much a welcoming community can accelerate growth, and I'm excited to give back by contributing code, sharing what I learn, asking thoughtful questions, and helping others wherever I can."
+badges:
+  - community
 status: Active
 published: true
 ---


### PR DESCRIPTION
## Changes

- **ishwar-chand-meena/index.mdx** - added community badge
- **maanvi-chetwani/index.mdx** - added badges field with community badge
- **aastha-bhat/index.mdx** - removed community badge

The community managers page queries members with badges containing community. These changes add Maanvi and Ishwar to the page and remove Aastha.

Fixes #7949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Updates

- Updated contributor profile badges to accurately reflect current community contributions.
- Added the **community** badge to Ishwar Chand Meena’s and Maanvi Chetwani’s profiles.
- Removed the **community** badge from Aastha Bhat’s profile, while retaining her **meshery** badge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->