### PR TITLE
fixed the Unwanted border and more

### DIFF
--- a/src/sections/Discuss-Callout/discuss.style.js
+++ b/src/sections/Discuss-Callout/discuss.style.js
@@ -13,6 +13,8 @@ const DiscussWrapper = styled.div`
     }
     .logo{
         width: 200px;
+        max-width: 100%;
+        height: auto;
     }
     
     .explain {
@@ -35,6 +37,13 @@ const DiscussWrapper = styled.div`
             padding: 1.5rem 2rem 0rem 2rem;
             background-color: none;
             border-radius: 25px;
+            a {
+                display: block;
+                border-radius: 25px;
+                &:focus:not(:focus-visible) {
+                    outline: none;
+                }
+            }
             .card {
                 height:20rem;
                 -webkit-transition: 450ms all;
@@ -64,17 +73,16 @@ const DiscussWrapper = styled.div`
                     transform: translateY(0.03rem);
                     box-shadow: 0 2px 10px #00d3a9;
                 }
-                }
             }
         }
     }
 
     button{
-        color: #1E2117;
-        padding: 0.2em 1em;
-        border: 2px solid;
+        color: inherit;
+        padding: 0;
+        border: 0;
         background: none;
-        transition: color 0.25s,border-color 0.25s,transform 0.25s,box-shadow 0.25s;
+        transition: transform 0.25s, box-shadow 0.25s;
         cursor: pointer;
     }
     @media only screen and (min-width: 768px){
@@ -114,11 +122,10 @@ const DiscussWrapper = styled.div`
                             width:23rem;
                             height:20rem;
                         }
-                    }
                 }
             }
         }
-     
+
         @media only screen and (max-width: 992px){
             .card-align{
               padding:1.1rem 0;


### PR DESCRIPTION
**Description**

This PR fixes #7958

The "JOIN THE CONVERSATION" card on the [Community page](https://layer5.io/community) rendered with an unintended white border around its container, and the Layer5 logo inside it appeared with inconsistent, off-brand colors.

While fixing the visible symptoms, I found the underlying cause was not the border declaration alone — the stylesheet had unbalanced braces that were leaking the component's `button` styles into the global scope. Both symptoms trace back to that.

### What was wrong

**1. Unintended white border**

`src/sections/Discuss-Callout/discuss.style.js` styled the logo button with:

```css
button {
    color: #1E2117;
    padding: 0.2em 1em;
    border: 2px solid;   /* ← no color specified */
}
```

`border: 2px solid` omits a color, so CSS falls back to `currentColor`. The border therefore painted itself using whatever color was inherited at that point — the card's white text — producing the white box seen in the issue screenshot.

For comparison, the sibling "Adventures of Five & Friends" card (`src/sections/Adventures-Callout/discuss.style.js`), which renders correctly, uses `border: 0; padding: 0;`.

**2. Off-brand / inconsistent logo colors — root cause**

The styled-component template literal contained **two stray closing braces** (one in the `.explain` block, one in the `max-width: 1211px` media query). These closed the component's style block early, so every rule after them — including the entire `button` rule — was emitted as a **bare global `button` selector** instead of being scoped to the component.

The consequence: this card's `border: 2px solid` was applied to buttons across the site, and collided with the Adventures card's leaked `border: 0`. Which one won depended purely on stylesheet injection order, which is exactly why the styling looked arbitrary and inconsistent rather than simply broken.

The logo asset itself (`static/images/layer5-discuss-white.webp`) was already correct Layer5 branding — white wordmark with the teal `5`. It only looked wrong because it was boxed inside the spurious bordered, padded container.

### Changes

All changes are confined to `src/sections/Discuss-Callout/discuss.style.js`:

- **Removed the unintended border** — `border: 2px solid` → `border: 0`, and `padding: 0.2em 1em` → `padding: 0`, bringing the button in line with the working Adventures card. `color: #1E2117` → `color: inherit` so no stale color is left to feed `currentColor`.
- **Fixed the brace nesting** (the actual root cause) — removed both stray `}` so the `button` rule is properly scoped to the component and can no longer leak globally or be decided by cascade order.
- **Made the logo responsive** — added `max-width: 100%; height: auto` so it scales within the card without distorting its aspect ratio.
- **Cleared the leftover click focus ring** on the wrapping `<a>` using `:focus:not(:focus-visible)`, matching the pattern already used elsewhere in this file. This removes the outline left after a mouse click **while preserving the keyboard focus outline**, consistent with the recent focus-visible accessibility work in #7960 and #7962.

### Verification

Brace balance was confirmed with a depth parser over the template literal:

```
src/sections/Discuss-Callout/discuss.style.js | final depth: 0 | stray closers: none | BALANCED
```

The file also passes `node --check`.

**Notes for Reviewers**

- No markup changes — `src/sections/Discuss-Callout/index.js` is untouched. This is a CSS-only fix.
- The component is also used on `/company/faq` and the Learn course-overview pages, so the fix applies there too. Worth a quick look at those while reviewing.
- Accessibility was deliberately preserved: only the non-keyboard focus outline is suppressed. Keyboard `:focus-visible` outlines still render.
- **Related, not fixed here:** `src/sections/Adventures-Callout/discuss.style.js` has the *same* latent defect — 2 stray closing braces (around lines 68 and 133) leaking its `button` rule globally. It does not affect this fix, since a properly scoped selector now outranks a bare global one. Happy to clean it up in this PR or open a follow-up issue — reviewer's call.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive sizing for the discuss callout logo.
  * Updated card links with block layout, rounded corners, and cleaner focus behavior.
  * Refined button styling with inherited colors, simplified spacing and borders, and smoother hover transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->