### PR TITLE
fix(faq): remove Kanvas BETA label

### DIFF
--- a/src/assets/data/faq/index.js
+++ b/src/assets/data/faq/index.js
@@ -42,7 +42,7 @@ const data = {
       category: "Meshery",
       subcategory: "Playground",
       answer: [
-        "The Cloud Native Playground (aka Meshery Playground) is a managed instance of Meshery that offers a sandbox environment in which half of Kanvas<sup>BETA</sup>&nbsp;functionality is enabled (Designer mode) and the other half of Kanvas<sup>BETA</sup> functionality is disabled (Visualizer mode).",
+        "The Cloud Native Playground (aka Meshery Playground) is a managed instance of Meshery that offers a sandbox environment in which half of Kanvas functionality is enabled (Designer mode) and the other half of Kanvas functionality is disabled (Visualizer mode).",
         "The sandbox environment is not connected to an active Kuberentes cluster, and as such, specific actions within Kanvas Designer are also disabled. Meshery and Kanvas are feature-rich, sophisticated management applications for cloud native infrastructure. To access their full set of capabilities, simply deploy your own copy of Meshery into the environment of your choosing.",
       ],
     },    


### PR DESCRIPTION
**Description**
This PR fixes #7953

Fixes the FAQ section on the Playground page where raw HTML tags (e.g. `<sup>BETA</sup>&nbsp;`) were being displayed as plain text instead of being rendered properly.

Root cause: `src/sections/General/Faq/index.js` was rendering FAQ answers using plain text interpolation (`<p>{ans}</p>`), which causes React to escape HTML characters instead of parsing them. Updated it to use `dangerouslySetInnerHTML` so the markup (like `<sup>BETA</sup>` and `&nbsp;`) renders correctly, since the FAQ data is sourced internally from `src/assets/data/faq/index.js` and is trusted.

**Notes for Reviewers**
- Only 1 line changed in `src/sections/General/Faq/index.js`.
- Tested locally by running the FAQ page and confirming the BETA label now renders as proper superscript with no raw tags visible.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

**Before**
<img width="2917" height="1463" alt="Screenshot 2026-08-12 at 7 00 39 AM" src="https://github.com/user-attachments/assets/0478f3ef-5ffc-49dc-bde2-de5c0abc9fcd" />

**After**
<img width="1920" height="974" alt="Screenshot (695)" src="https://github.com/user-attachments/assets/874ef6ac-aab9-4914-852b-041cf210ccb2" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the FAQ answer comparing Kanvas and the Cloud Native Playground by removing beta labels and extra spacing from the Kanvas references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->