### PR TITLE
fix(subscribe): prevent 'Join the Layer5 community. Subscribe.' headi…

### DIFF
--- a/src/sections/subscribe/subscribe.js
+++ b/src/sections/subscribe/subscribe.js
@@ -11,7 +11,7 @@ const subscribe = ({ msg = "Layer5" }) => {
         <form name="contactform" method="post" action="https://calcotestudios.us15.list-manage.com/subscribe/post?u=6b50be5aea3dfe1fd4c041d80&amp;id=6bb65defeb">
           <Row $Vcenter>
             <Col $md={6}>
-              <SectionTitle className="section-title" UniWidth="100%">
+              <SectionTitle className="section-title" $UniWidth="100%">
                 <h2>Join the <span className="meshy">{msg}</span> community. Subscribe.</h2>
               </SectionTitle>
             </Col>


### PR DESCRIPTION
**Description**
This PR fixes #7954

The "Join the Layer5 community. Subscribe." heading was wrapping onto 3 lines on desktop due to the h2 font-size being too large for its column width, creating unnecessary vertical space and an unbalanced layout.

**Changes**
- Fixed `SectionTitle` prop to `$UniWidth="100%"` in `src/sections/subscribe/subscribe.js`.

**Notes for Reviewers**
- Tested locally: heading now takes full column width on desktop and wraps naturally on mobile.
- Squashed into a single clean commit.


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

**Before**

<img width="1920" height="972" alt="Screenshot (700)" src="https://github.com/user-attachments/assets/bb3b0018-008b-4315-bf5a-2efe6c225371" />

**After**
<img width="1920" height="974" alt="Screenshot (699)" src="https://github.com/user-attachments/assets/2424dde9-4180-439b-88bf-2008aa96a47f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted subscribe-section heading sizing to use fixed dimensions.
  * Updated heading wrapping behavior across screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->