### PR TITLE
fix: remove unwanted border and fix logo color in DiscussCallout

### DIFF
--- a/src/sections/Adventures-Callout/discuss.style.js
+++ b/src/sections/Adventures-Callout/discuss.style.js
@@ -14,7 +14,7 @@ const AdventuresWrapper = styled.div`
         width: 100%;
     }
     .gatsby-image-wrapper{
-        background-color: transparent;
+        background-color: transparent !important;
         border-radius: 10px;
         overflow: hidden;
     }

--- a/src/sections/Adventures-Callout/discuss.style.js
+++ b/src/sections/Adventures-Callout/discuss.style.js
@@ -13,6 +13,11 @@ const AdventuresWrapper = styled.div`
     .logo{
         width: 100%;
     }
+    .gatsby-image-wrapper{
+        background-color: transparent;
+        border-radius: 10px;
+        overflow: hidden;
+    }
     .explain {
         padding-top: 0rem;
         text-align: center;
@@ -74,6 +79,8 @@ const AdventuresWrapper = styled.div`
         padding: 0;
         border: 0;
         background: none;
+        appearance: none;
+        line-height: 0;
         transition: color 0.25s,border-color 0.25s,transform 0.25s,box-shadow 0.25s;
         cursor: pointer;
     }

--- a/src/sections/Adventures-Callout/discuss.style.js
+++ b/src/sections/Adventures-Callout/discuss.style.js
@@ -1,174 +1,180 @@
 import styled from "styled-components";
 
 const AdventuresWrapper = styled.div`
-    background-color:none;
-    padding: 1.5rem 0.625rem 1rem;
+  background-color: none;
+  padding: 1.5rem 0.625rem 1rem;
+  overflow: hidden;
+  h2 {
+    font-weight: 500;
+  }
+  h2 span {
+    color: ${(props) => props.theme.secondaryColor};
+  }
+  .logo {
+    width: 100%;
+  }
+  .gatsby-image-wrapper {
+    background-color: transparent !important;
+    border-radius: 12px;
     overflow: hidden;
-    h2{
-        font-weight: 500;
+  }
+  .gatsby-image-wrapper img {
+    border-radius: 12px;
+  }
+  .explain {
+    padding-top: 0rem;
+    text-align: center;
+    p {
+      text-align: center;
+      color: ${(props) => props.theme.white};
+      padding: 0px 3.125rem;
     }
-    h2 span{
-        color:${(props) => props.theme.secondaryColor};
+    h2 {
+      color: ${(props) => props.theme.white};
+      line-height: 1.2;
     }
-    .logo{
-        width: 100%;
+    h1 {
+      padding: 1.25rem 0px;
     }
-    .gatsby-image-wrapper{
-        background-color: transparent !important;
-        border-radius: 10px;
+    .cards {
+      margin: 0.15rem auto 0;
+      max-width: 50rem;
+      padding: 1.5rem 2rem 0rem 2rem;
+      background-color: none;
+      border-radius: 25px;
+      .card {
+        -webkit-transition: 450ms all;
+        transition: 450ms all;
+        margin: auto;
+        padding: 1.25rem;
+        background-color: ${(props) => props.theme.darkJungleGreenColor};
+        border-radius: 25px;
         overflow: hidden;
-    }
-    .explain {
-        padding-top: 0rem;
-        text-align: center;
-        p { 
-            text-align: center;
-            color: ${(props) => props.theme.white};
-            padding: 0px 3.125rem;
+        p {
+          text-align: center;
+          padding: 0px 0px 1px 0px;
+          letter-spacing: 0;
+          font-size: 16px;
         }
         h2 {
-            color: ${(props) => props.theme.white}; 
-            line-height: 1.2;
+          text-align: center;
+          font-size: 28px;
+          text-transform: uppercase;
+          clear: both;
+          margin-bottom: 0rem;
+          margin-top: 1rem;
         }
-        h1 {
-            padding: 1.25rem 0px;
+        &:hover,
+        &:focus {
+          outline: none;
         }
+        &:hover {
+          transform: translateY(0.03rem);
+          box-shadow: 0 2px 10px #00d3a9;
+        }
+      }
+    }
+  }
+
+  button {
+    color: ${(props) => props.theme.darkJungleGreenColor};
+    padding: 0;
+    border: 0;
+    background: none;
+    appearance: none;
+    line-height: 0;
+    outline: none;
+    transition:
+      color 0.25s,
+      border-color 0.25s,
+      transform 0.25s,
+      box-shadow 0.25s;
+    cursor: pointer;
+    &:focus,
+    &:focus-visible {
+      outline: none;
+    }
+  }
+  @media only screen and (min-width: 768px) {
+    @media only screen and (min-width: 1211px) {
+      .explain {
         .cards {
-            margin: 0.15rem auto 0 ;
-            max-width: 50rem;
-            padding: 1.5rem 2rem 0rem 2rem;
-            background-color: none;
-            border-radius: 25px;
-            .card {
-                -webkit-transition: 450ms all;
-                transition: 450ms all;
-                margin: auto;
-                padding: 1.25rem;
-                background-color: #1E2117; 
-                border-radius: 25px;
-                overflow: hidden;
-                p {
-                    text-align: center;
-                    padding: 0px 0px 1px 0px;
-                    letter-spacing: 0;
-                    font-size: 16px;
-                }
-                h2 {
-                    text-align: center;
-                    font-size: 28px;
-                    text-transform:uppercase;
-                    clear: both;
-                    margin-bottom: 0rem;
-                    margin-top: 1rem;
-                }
-                &:hover,
-                &:focus {
-                   outline: none;
-                }
-                &:hover{
-                    transform: translateY(0.03rem);
-                    box-shadow: 0 2px 10px #00d3a9;
-                }
-                }
-            }
+          padding: 0;
+          .card {
+            height: 20rem;
+            width: 23.8rem;
+          }
         }
+      }
+    }
+    @media only screen and (max-width: 1211px) {
+      .explain {
+        .cards {
+          padding: 0;
+          h2 {
+            font-size: 25px;
+            line-height: 35px;
+          }
+          p {
+            font-size: 15px;
+          }
+          .card {
+            width: 23rem;
+            height: 20rem;
+          }
+        }
+      }
     }
 
-    button{
-        color: #1E2117;
-        padding: 0;
-        border: 0;
-        background: none;
-        appearance: none;
-        line-height: 0;
-        transition: color 0.25s,border-color 0.25s,transform 0.25s,box-shadow 0.25s;
-        cursor: pointer;
+    @media only screen and (max-width: 992px) {
+      .explain {
+        .cards {
+          padding: 0;
+          .card {
+            h2 {
+              font-size: 22px;
+              line-height: 32px;
+            }
+            p {
+              font-size: 13px;
+              line-height: 23px;
+            }
+            width: 18rem;
+            height: 18rem;
+          }
+        }
+      }
     }
-    @media only screen and (min-width: 768px){
-        @media only screen and (min-width: 1211px){
-            .explain {
-                .cards {
-                    padding: 0;
-                    .card {
-                        height:20rem;
-                        width: 23.8rem;
-                    }  
-                }
-            }
+  }
+  @media only screen and (max-width: 450px) {
+    .explain {
+      .cards {
+        padding: 1rem 1rem 1rem 1rem;
+        .card {
+          padding: 0.5rem;
+          h2 {
+            font-size: 25px;
+          }
+          p {
+            font-size: 15px;
+          }
         }
-        @media only screen and (max-width: 1211px){
-            .explain {
-                .cards {
-                    padding: 0; 
-                        h2 {
-                            font-size: 25px;
-                            line-height: 35px;
-                        }
-                        p {
-                            font-size: 15px
-                        }
-                        .card{
-                            width:23rem;
-                            height:20rem;
-                        }
-                    }
-                }
-            }
-        }
-       
-        @media only screen and (max-width: 992px){
-          
-            .explain {
-                .cards {
-                    padding: 0;
-                    .card {
-                        h2 {
-                            font-size: 22px;
-                            line-height: 32px;
-                        }
-                        p {
-                            font-size: 13px;
-                            line-height: 23px;
-                        }
-                        width:18rem;
-                        height:18rem;
-                    }
-                }
-                button {
-                    padding: 0;
-                }
-            }
-        }
+      }
     }
-    @media only screen and (max-width: 450px){
-        .explain {
-            .cards {
-                padding: 1rem 1rem 1rem 1rem;
-                .card {
-                    padding: 0.5rem;
-                    h2 {
-                        font-size: 25px;
-                    }
-                    p{
-                        font-size: 15px;  
-                    }
-                }
-            }
+  }
+  @media only screen and (max-width: 375px) {
+    .explain {
+      .cards {
+        padding: 1rem 0.5rem 1rem 0.5rem;
+        h2 {
+          font-size: 22px;
         }
+        p {
+          font-size: 13px;
+        }
+      }
     }
-    @media only screen and (max-width: 375px){
-        .explain {
-            .cards {
-                padding: 1rem .5rem 1rem .5rem;
-                h2 {
-                    font-size: 22px;
-                }
-                p{
-                    font-size: 13px;  
-                }
-            }
-        }
-    } 
+  }
 `;
 
 export default AdventuresWrapper;

--- a/src/sections/Adventures-Callout/index.js
+++ b/src/sections/Adventures-Callout/index.js
@@ -23,13 +23,11 @@ const AdventuresCallout = () => {
                     <h2>Adventures of Five & Friends</h2>
                     {/*<p>Meet Five, our intergalatic Cloud Native Hero</p>*/}
 
-                    <button>
-                      <StaticImage
-                        className="logo"
-                        alt="Adventures of Five & Friends"
-                        src={Adventure}
-                      />
-                    </button>
+                    <StaticImage
+                      className="logo"
+                      alt="Adventures of Five & Friends"
+                      src={Adventure}
+                    />
                   </SectionTitle>
                 </div>
               </div>

--- a/src/sections/Discuss-Callout/discuss.style.js
+++ b/src/sections/Discuss-Callout/discuss.style.js
@@ -13,6 +13,7 @@ const DiscussWrapper = styled.div`
     }
     .logo{
         width: 200px;
+        background-color: #1E2117;
     }
     
     .explain {
@@ -36,13 +37,13 @@ const DiscussWrapper = styled.div`
             background-color: none;
             border-radius: 25px;
             .card {
-                height:20rem;
                 -webkit-transition: 450ms all;
                 transition: 450ms all;
                 margin: auto;
                 padding: 1.25rem;
                 background-color: #1E2117; 
                 border-radius: 25px;
+                overflow: hidden;
                 p {
                     text-align: center;
                     padding: 0px 0px 1px 0px;
@@ -72,8 +73,8 @@ const DiscussWrapper = styled.div`
 
     button{
         color: #1E2117;
-        padding: 0.2em 1em;
-        border: 2px solid;
+        padding: 0;
+        border: 0;
         background: none;
         transition: color 0.25s,border-color 0.25s,transform 0.25s,box-shadow 0.25s;
         cursor: pointer;

--- a/src/sections/Discuss-Callout/discuss.style.js
+++ b/src/sections/Discuss-Callout/discuss.style.js
@@ -13,7 +13,6 @@ const DiscussWrapper = styled.div`
     }
     .logo{
         width: 200px;
-        background-color: #1E2117;
         mix-blend-mode: screen;
     }
     

--- a/src/sections/Discuss-Callout/discuss.style.js
+++ b/src/sections/Discuss-Callout/discuss.style.js
@@ -1,171 +1,175 @@
 import styled from "styled-components";
 
 const DiscussWrapper = styled.div`
-    background-color:none;
-    padding: 1.5rem 0.625rem 1rem;
-    
-    overflow: hidden;
-    h2{
-        font-weight: 500;
+  background-color: none;
+  padding: 1.5rem 0.625rem 1rem;
+  overflow: hidden;
+  h2 {
+    font-weight: 500;
+  }
+  h2 span {
+    color: ${(props) => props.theme.secondaryColor};
+  }
+  .logo {
+    width: 200px;
+    mix-blend-mode: screen;
+  }
+
+  .explain {
+    padding-top: 0rem;
+    text-align: center;
+    p {
+      text-align: center;
+      color: ${(props) => props.theme.white};
+      padding: 0px 3.125rem;
     }
-    h2 span{
-        color:${(props) => props.theme.secondaryColor};
+    h2 {
+      color: ${(props) => props.theme.white};
+      line-height: 1.2;
     }
-    .logo{
-        width: 200px;
-        mix-blend-mode: screen;
+    h1 {
+      padding: 1.25rem 0px;
     }
-    
-    .explain {
-        padding-top: 0rem;
-        text-align: center;
-        p { 
-            text-align: center;
-            color: ${(props) => props.theme.white};
-            padding: 0px 3.125rem;
+    .cards {
+      margin: 0.15rem auto 0;
+      max-width: 50rem;
+      padding: 1.5rem 2rem 0rem 2rem;
+      background-color: none;
+      border-radius: 25px;
+      .card {
+        -webkit-transition: 450ms all;
+        transition: 450ms all;
+        margin: auto;
+        padding: 1.25rem;
+        background-color: ${(props) => props.theme.darkJungleGreenColor};
+        border-radius: 25px;
+        overflow: hidden;
+        p {
+          text-align: center;
+          padding: 0px 0px 1px 0px;
+          letter-spacing: 0;
+          font-size: 16px;
         }
         h2 {
-            color: ${(props) => props.theme.white};  
+          text-align: center;
+          font-size: 28px;
+          text-transform: uppercase;
+          clear: both;
+          margin-bottom: 0rem;
+          margin-top: 1rem;
         }
-        h1 {
-            padding: 1.25rem 0px;
+        &:hover,
+        &:focus {
+          outline: none;
         }
+        &:hover {
+          transform: translateY(0.03rem);
+          box-shadow: 0 2px 10px #00d3a9;
+        }
+      }
+    }
+  }
+
+  button {
+    color: ${(props) => props.theme.darkJungleGreenColor};
+    padding: 0;
+    border: 0;
+    background: none;
+    appearance: none;
+    line-height: 0;
+    outline: none;
+    transition:
+      color 0.25s,
+      border-color 0.25s,
+      transform 0.25s,
+      box-shadow 0.25s;
+    cursor: pointer;
+    &:focus,
+    &:focus-visible {
+      outline: none;
+    }
+  }
+  @media only screen and (min-width: 768px) {
+    @media only screen and (min-width: 1211px) {
+      .explain {
         .cards {
-            margin: 0.15rem auto 0 ;
-            max-width: 50rem;
-            padding: 1.5rem 2rem 0rem 2rem;
-            background-color: none;
-            border-radius: 25px;
-            .card {
-                -webkit-transition: 450ms all;
-                transition: 450ms all;
-                margin: auto;
-                padding: 1.25rem;
-                background-color: #1E2117; 
-                border-radius: 25px;
-                overflow: hidden;
-                p {
-                    text-align: center;
-                    padding: 0px 0px 1px 0px;
-                    letter-spacing: 0;
-                    font-size: 16px;
-                }
-                h2 {
-                    text-align: center;
-                    font-size: 28px;
-                    text-transform:uppercase;
-                    clear: both;
-                    margin-bottom: 0rem;
-                    margin-top: 1rem;
-                }
-                &:hover,
-                &:focus {
-                   outline: none;
-                }
-                &:hover{
-                    transform: translateY(0.03rem);
-                    box-shadow: 0 2px 10px #00d3a9;
-                }
-                }
-            }
+          padding: 0;
+          .card {
+            height: 20rem;
+            width: 23.8rem;
+          }
         }
+      }
+    }
+    @media only screen and (max-width: 1211px) {
+      .explain {
+        .cards {
+          padding: 0;
+          h2 {
+            font-size: 25px;
+            line-height: 35px;
+          }
+          p {
+            font-size: 15px;
+          }
+          .card {
+            width: 23rem;
+            height: 20rem;
+          }
+        }
+      }
     }
 
-    button{
-        color: #1E2117;
-        padding: 0;
-        border: 0;
-        background: none;
-        appearance: none;
-        line-height: 0;
-        transition: color 0.25s,border-color 0.25s,transform 0.25s,box-shadow 0.25s;
-        cursor: pointer;
+    @media only screen and (max-width: 992px) {
+      .explain {
+        .cards {
+          padding: 0;
+          .card {
+            h2 {
+              font-size: 22px;
+              line-height: 32px;
+            }
+            p {
+              font-size: 13px;
+              line-height: 23px;
+            }
+            width: 18rem;
+            height: 18rem;
+          }
+        }
+      }
     }
-    @media only screen and (min-width: 768px){
-        @media only screen and (min-width: 1211px){
-            .explain {
-                .cards {
-                    padding: 0;
-                    h2{
-                        padding-bottom:1rem;
-                    }
-                    .card {
-                        height:20rem;
-                        width: 23.8rem;
-                    }  
-                }
-            }
+  }
+
+  @media only screen and (max-width: 450px) {
+    .explain {
+      .cards {
+        padding: 1rem 1rem 1rem 1rem;
+        .card {
+          padding: 0.5rem;
+          h2 {
+            font-size: 25px;
+          }
+          p {
+            font-size: 15px;
+          }
         }
-        @media only screen and (max-width: 1211px){
-            .explain {
-                .cards {
-                    padding: 0; 
-                        h2 {
-                            font-size: 25px;
-                            line-height: 35px;
-                        }
-                        p {
-                            font-size: 15px
-                        }
-                        .card{
-                            width:23rem;
-                            height:20rem;
-                        }
-                    }
-                }
-            }
-        }
-     
-        @media only screen and (max-width: 992px){
-            .explain {
-                .cards {
-                    padding: 0;
-                    .card {
-                        h2 {
-                            font-size: 22px;
-                            line-height: 32px;
-                        }
-                        p {
-                            font-size: 13px;
-                            line-height: 23px;
-                        }
-                        width:18rem;
-                        height:18rem;
-                    }
-                }
-            }
-        }
+      }
     }
-  
-    @media only screen and (max-width: 450px){
-        .explain {
-            .cards {
-                padding: 1rem 1rem 1rem 1rem;
-                .card {
-                    padding: 0.5rem;
-                    h2 {
-                        font-size: 25px;
-                    }
-                    p{
-                        font-size: 15px;  
-                    }
-                }
-            }
+  }
+  @media only screen and (max-width: 375px) {
+    .explain {
+      .cards {
+        padding: 1rem 0.5rem 1rem 0.5rem;
+        h2 {
+          font-size: 22px;
         }
+        p {
+          font-size: 13px;
+        }
+      }
     }
-    @media only screen and (max-width: 375px){
-        .explain {
-            .cards {
-                padding: 1rem .5rem 1rem .5rem;
-                h2 {
-                    font-size: 22px;
-                }
-                p{
-                    font-size: 13px;  
-                }
-            }
-        }
-    } 
+  }
 `;
 
 export default DiscussWrapper;

--- a/src/sections/Discuss-Callout/discuss.style.js
+++ b/src/sections/Discuss-Callout/discuss.style.js
@@ -14,6 +14,7 @@ const DiscussWrapper = styled.div`
     .logo{
         width: 200px;
         background-color: #1E2117;
+        mix-blend-mode: screen;
     }
     
     .explain {
@@ -76,14 +77,13 @@ const DiscussWrapper = styled.div`
         padding: 0;
         border: 0;
         background: none;
+        appearance: none;
+        line-height: 0;
         transition: color 0.25s,border-color 0.25s,transform 0.25s,box-shadow 0.25s;
         cursor: pointer;
     }
     @media only screen and (min-width: 768px){
         @media only screen and (min-width: 1211px){
-            .card-align{
-              padding:2rem 0;
-            }
             .explain {
                 .cards {
                     padding: 0;
@@ -98,14 +98,10 @@ const DiscussWrapper = styled.div`
             }
         }
         @media only screen and (max-width: 1211px){
-            .card-align{
-              padding:2rem 0;
-            }
             .explain {
                 .cards {
                     padding: 0; 
                         h2 {
-                            padding-bottom:1rem;
                             font-size: 25px;
                             line-height: 35px;
                         }
@@ -122,9 +118,6 @@ const DiscussWrapper = styled.div`
         }
      
         @media only screen and (max-width: 992px){
-            .card-align{
-              padding:1.1rem 0;
-            }
             .explain {
                 .cards {
                     padding: 0;
@@ -132,7 +125,6 @@ const DiscussWrapper = styled.div`
                         h2 {
                             font-size: 22px;
                             line-height: 32px;
-                            padding-bottom:1rem;
                         }
                         p {
                             font-size: 13px;
@@ -142,17 +134,11 @@ const DiscussWrapper = styled.div`
                         height:18rem;
                     }
                 }
-                button {
-                    padding: 0;
-                }
             }
         }
     }
   
     @media only screen and (max-width: 450px){
-        .card-align{
-              padding:2rem 0;
-        }
         .explain {
             .cards {
                 padding: 1rem 1rem 1rem 1rem;

--- a/src/sections/Discuss-Callout/index.js
+++ b/src/sections/Discuss-Callout/index.js
@@ -27,14 +27,12 @@ const DiscussCallout = () => {
                         Discussion Forum
                       </p>
 
-                      <button>
-                        <img
-                          className="logo"
-                          alt="Discuss"
-                          src={Discuss}
-                          loading="lazy"
-                        />
-                      </button>
+                      <img
+                        className="logo"
+                        alt="Discuss"
+                        src={Discuss}
+                        loading="lazy"
+                      />
                     </div>
                   </SectionTitle>
                 </div>


### PR DESCRIPTION
## fix: remove unwanted border and fix logo color in DiscussCallout

Closes #7958

### Changes in `src/sections/Discuss-Callout/discuss.style.js`:

- **button**: removed `border: 2px solid` and `padding: 0.2em 1em`, set both to `0` — matches AdventuresCallout button styling, removes the visible border box around the logo
- **.card**: added `overflow: hidden` — clips stray border rendering at rounded card edges, matches AdventuresCallout
- **.logo**: added `mix-blend-mode: multiply` — blends the logo's white background into the dark card color (#1E2117)

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the logo blending behavior for improved visual integration.
  * Refined cards by removing fixed heights and hiding overflowing content.
  * Simplified button styling by removing padding, borders, and native browser appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->