### PR TITLE
[UI] Fix excessive spacing on large screens in Sistent pages

### DIFF
--- a/src/components/SistentNavigation/intra-page.js
+++ b/src/components/SistentNavigation/intra-page.js
@@ -4,6 +4,7 @@ import styled from "styled-components";
 
 const JoinCommunityWrapper = styled.div`
   width: 18rem;
+  margin-top: -5rem;
 
   @media screen and (max-width: 750px) {
     display: none;
@@ -13,12 +14,8 @@ const JoinCommunityWrapper = styled.div`
     display: none;
   }
   .intra-page {
-    position: sticky;
-    top: 17rem;
-    right: 0rem;
     margin-right: 1rem;
-    margin-top: 17rem;
-    padding-bottom: 5rem;
+    padding-bottom: 3rem;
     padding-right: 2rem;
     align-items: left;
     justify-content: space-around;
@@ -36,7 +33,6 @@ const JoinCommunityWrapper = styled.div`
 
     ul {
       list-style: none;
-      top: 3rem;
       li {
         padding-bottom: 0.5rem;
         padding-top: 0.5rem;
@@ -72,7 +68,7 @@ function IntraPage() {
           id: a.id,
           link: `#${a.id}`,
           text: a.id,
-        }))
+        })),
       );
     }
   }, []);

--- a/src/components/SistentNavigation/pagination.style.js
+++ b/src/components/SistentNavigation/pagination.style.js
@@ -4,7 +4,7 @@ const TocPaginationWrapper = styled.div`
   display: flex;
   gap: 1rem;
   justify-content: center;
-  margin: 3rem 2rem 4rem 2rem;
+  margin: 3rem 2rem 2rem 2rem;
 
   @media screen and (max-width: 540px) {
     margin: 0 0 2rem 0;

--- a/src/components/handbook-navigation/intra-page.js
+++ b/src/components/handbook-navigation/intra-page.js
@@ -6,11 +6,8 @@ const JoinCommunityWrapper = styled.div`
     display: none;
   }
   .intra-page {
-    position: sticky;
-    top: 10rem;
-    right: 0rem;
     margin-right: 1rem;
-    padding-bottom: 5rem;
+    padding-bottom: 3rem;
     padding-right: 2rem;
     align-items: left;
     justify-content: space-around;
@@ -19,7 +16,6 @@ const JoinCommunityWrapper = styled.div`
     overflow: hidden;
     ul {
       list-style: none;
-      top: 3rem;
       li {
         padding-bottom: 0.5rem;
         padding-top: 0.5rem;

--- a/src/components/legal-navigation/intra-page.js
+++ b/src/components/legal-navigation/intra-page.js
@@ -7,11 +7,8 @@ const JoinCommunityWrapper = styled.div`
     display: none;
   }
   .intra-page {
-    position: sticky;
-    top: 10rem;
-    right: 0rem;
     margin-right: 1rem;
-    padding-bottom: 5rem;
+    padding-bottom: 3rem;
     padding-right: 2rem;
     align-items: left;
     justify-content: space-around;
@@ -29,7 +26,6 @@ const JoinCommunityWrapper = styled.div`
 
     ul {
       list-style: none;
-      top: 3rem;
       li {
         padding-bottom: 0.5rem;
         padding-top: 0.5rem;

--- a/src/sections/Projects/Sistent/sistent.style.js
+++ b/src/sections/Projects/Sistent/sistent.style.js
@@ -40,11 +40,20 @@ const SistentWrapper = styled.div`
   }
   .page-container {
     display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 2rem;
+    justify-content: start;
+    gap: 3rem;
+    max-width: 1600px;
+    margin: 0 auto;
+    padding: 0 2rem;
+    box-sizing: border-box;
+
+    .page-section > div:first-child {
+      max-width: none;
+    }
+
     @media screen and (max-width: 750px) {
       display: block;
+      padding: 0;
     }
   }
 


### PR DESCRIPTION

**Description**

* On large screens, when navigating to a [[Sistent page](https://layer5.io/projects/sistent/components/permissions)](https://layer5.io/projects/sistent/components/permissions), the gap between the sidebar and the main content keeps increasing.
* On larger screens, links appearing after the **Previous** and **Next** buttons have an unnecessarily large top margin, creating excessive space above them.

This PR aims to fix both of these layout issues.

Find the demo reflecting the change here: https://mesheryio.slack.com/files/U0A474KR6L8/F0BRAU4GL6S/screen_recording_2026-08-19_at_23.18.43.mov



**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved intra-page navigation layout and spacing across handbook, legal, and Sistent pages.
  * Updated pagination spacing for a more compact desktop layout.
  * Refined Sistent page content alignment, width, gaps, and responsive behavior.
  * Improved mobile layouts by removing unnecessary container padding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->