### PR TITLE
fix(community): remove unused buttons from callout cards and match ca…

### DIFF
--- a/src/sections/Adventures-Callout/discuss.style.js
+++ b/src/sections/Adventures-Callout/discuss.style.js
@@ -75,6 +75,9 @@ const AdventuresWrapper = styled.div`
             .explain {
                 .cards {
                     padding: 0;
+                    h2 {
+                        font-size: 24px;
+                    }
                     .card {
                         min-height: 20rem;
                         height: 100%;
@@ -88,8 +91,8 @@ const AdventuresWrapper = styled.div`
                 .cards {
                     padding: 0; 
                     h2 {
-                        font-size: 24px;
-                        line-height: 33px;
+                        font-size: 20px;
+                        line-height: 28px;
                     }
                     p {
                         font-size: 14px;
@@ -108,13 +111,15 @@ const AdventuresWrapper = styled.div`
                 .cards {
                     padding: 0;
                     .card {
+                        padding: 1rem 0.75rem;
                         h2 {
-                            font-size: 21px;
-                            line-height: 28px;
+                            font-size: 18px;
+                            line-height: 24px;
+                            letter-spacing: -0.01em;
                         }
                         p {
-                            font-size: 13.5px;
-                            line-height: 20px;
+                            font-size: 13px;
+                            line-height: 18px;
                         }
                         .logo {
                             margin-top: 0.75rem;
@@ -132,12 +137,13 @@ const AdventuresWrapper = styled.div`
             .cards {
                 padding: 1rem 1rem 1rem 1rem;
                 .card {
-                    padding: 0.5rem;
+                    padding: 0.75rem 0.5rem;
                     h2 {
-                        font-size: 22px;
+                        font-size: 18px;
+                        letter-spacing: -0.01em;
                     }
                     p{
-                        font-size: 14px;  
+                        font-size: 13px;  
                     }
                 }
             }
@@ -148,10 +154,11 @@ const AdventuresWrapper = styled.div`
             .cards {
                 padding: 1rem .5rem 1rem .5rem;
                 h2 {
-                    font-size: 20px;
+                    font-size: 17px;
+                    letter-spacing: -0.01em;
                 }
                 p{
-                    font-size: 13px;  
+                    font-size: 12.5px;  
                 }
             }
         }

--- a/src/sections/Adventures-Callout/discuss.style.js
+++ b/src/sections/Adventures-Callout/discuss.style.js
@@ -77,7 +77,7 @@ const AdventuresWrapper = styled.div`
                     padding: 0;
                     .card {
                         height:20rem;
-                        width: 23.8rem;
+                        max-width: 23.8rem;
                     }  
                 }
             }
@@ -94,7 +94,7 @@ const AdventuresWrapper = styled.div`
                             font-size: 15px
                         }
                         .card{
-                            width:23rem;
+                            max-width:23rem;
                             height:20rem;
                         }
                     }
@@ -116,7 +116,7 @@ const AdventuresWrapper = styled.div`
                             font-size: 13px;
                             line-height: 23px;
                         }
-                        width:18rem;
+                        max-width:18rem;
                         height:18rem;
                     }
                 }

--- a/src/sections/Adventures-Callout/discuss.style.js
+++ b/src/sections/Adventures-Callout/discuss.style.js
@@ -12,7 +12,7 @@ const AdventuresWrapper = styled.div`
     }
     .logo{
         width: 100%;
-        margin-top: 1.5rem;
+        margin-top: 1rem;
     }
     .explain {
         padding-top: 0rem;

--- a/src/sections/Adventures-Callout/discuss.style.js
+++ b/src/sections/Adventures-Callout/discuss.style.js
@@ -1,128 +1,136 @@
 import styled from "styled-components";
 
 const AdventuresWrapper = styled.div`
-    background-color:none;
-    padding: 1.5rem 1.25rem 1rem;
-    overflow: hidden;
-    h2{
-        font-weight: 500;
-    }
-    h2 span{
-        color:${(props) => props.theme.secondaryColor};
-    }
-    .logo{
-        width: 100%;
-        margin-top: 1rem;
-    }
+    background-color: none;
+    padding: 0;
+    width: 100%;
+    max-width: 25rem;
+    display: flex;
+    flex-direction: column;
+    align-self: stretch;
+
     .explain {
-        padding-top: 0rem;
+        padding-top: 0;
         text-align: center;
-        p { 
-            text-align: center;
-            color: ${(props) => props.theme.white};
-            padding: 0px 3.125rem;
-        }
-        h2 {
-            color: ${(props) => props.theme.white}; 
-            line-height: 1.2;
-        }
-        h1 {
-            padding: 1.25rem 0px;
-        }
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+
         .cards {
-            margin: 0.15rem auto 0 ;
-            max-width: 50rem;
-            padding: 1.5rem 2rem 0rem 2rem;
-            background-color: none;
-            border-radius: 25px;
+            margin: 0 auto;
+            width: 100%;
+            height: 100%;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+            flex: 1;
+
+            a {
+                display: flex;
+                flex-direction: column;
+                height: 100%;
+                width: 100%;
+                text-decoration: none;
+                flex: 1;
+            }
+
             .card {
                 -webkit-transition: 450ms all;
                 transition: 450ms all;
-                margin: auto;
-                padding: 1.25rem;
-                background-color: #1E2117; 
+                margin: 0 auto;
+                padding: 1.75rem 1.25rem;
+                background-color: #1E2117;
                 border-radius: 25px;
                 overflow: hidden;
-                p {
-                    text-align: center;
-                    padding: 0px 0px 1px 0px;
-                    letter-spacing: 0;
-                    font-size: 16px;
+                width: 100%;
+                max-width: 25rem;
+                min-height: 22rem;
+                height: 100%;
+                display: flex;
+                flex-direction: column;
+                justify-content: space-between;
+                box-sizing: border-box;
+                flex: 1;
+
+                .parentcard, .section-title, .card-content {
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: space-between;
+                    align-items: center;
+                    height: 100%;
+                    width: 100%;
+                    margin: 0;
+                    padding: 0;
                 }
+
                 h2 {
                     text-align: center;
-                    font-size: 28px;
-                    text-transform:uppercase;
+                    font-size: 25px;
+                    line-height: 34px;
+                    font-weight: 500;
+                    text-transform: uppercase;
                     clear: both;
-                    margin-bottom: 0rem;
-                    margin-top: 1rem;
+                    margin: 0 0 0.75rem 0;
+                    padding: 0;
+                    color: ${(props) => props.theme.white};
                 }
-                &:hover,
+
+                p {
+                    text-align: center;
+                    color: ${(props) => props.theme.white};
+                    padding: 0 0.5rem;
+                    margin: 0 0 1.25rem 0;
+                    letter-spacing: 0;
+                    font-size: 15px;
+                    line-height: 22px;
+                }
+
+                .logo {
+                    width: 100%;
+                    max-width: 260px;
+                    height: auto;
+                    margin-top: auto;
+                    border-radius: 12px;
+                }
+
                 &:focus:not(:focus-visible) {
                    outline: none;
                 }
-                &:hover{
-                    transform: translateY(0.03rem);
-                    box-shadow: 0 2px 10px #00d3a9;
-                }
+                &:hover {
+                    transform: translateY(-0.15rem);
+                    box-shadow: 0 4px 15px #00d3a9;
                 }
             }
         }
     }
 
-    @media only screen and (min-width: 768px){
-        .explain {
-            .cards {
-                padding: 0;
-                h2 {
-                    font-size: 25px;
-                    line-height: 34px;
-                }
-                p {
-                    font-size: 15px;
-                    line-height: 22px;
-                }
-                .logo {
-                    margin-top: 1rem;
-                }
-                .card {
-                    max-width: 23.8rem;
-                    min-height: 20rem;
-                    height: 100%;
-                    padding: 1.25rem 1rem;
-                }
+    @media only screen and (max-width: 992px) {
+        .explain .cards .card {
+            h2 {
+                font-size: 22px;
+                line-height: 30px;
+            }
+            p {
+                font-size: 14px;
+                line-height: 20px;
             }
         }
     }
-    @media only screen and (max-width: 450px){
-        .explain {
-            .cards {
-                padding: 1rem 1rem 1rem 1rem;
-                .card {
-                    padding: 0.75rem 0.5rem;
-                    h2 {
-                        font-size: 20px;
-                    }
-                    p{
-                        font-size: 13.5px;  
-                    }
-                }
+
+    @media only screen and (max-width: 450px) {
+        .explain .cards .card {
+            padding: 1.25rem 0.75rem;
+            h2 {
+                font-size: 20px;
+                line-height: 28px;
+            }
+            p {
+                font-size: 13.5px;
+                line-height: 19px;
             }
         }
     }
-    @media only screen and (max-width: 375px){
-        .explain {
-            .cards {
-                padding: 1rem .5rem 1rem .5rem;
-                h2 {
-                    font-size: 18px;
-                }
-                p{
-                    font-size: 13px;  
-                }
-            }
-        }
-    } 
 `;
 
 export default AdventuresWrapper;

--- a/src/sections/Adventures-Callout/discuss.style.js
+++ b/src/sections/Adventures-Callout/discuss.style.js
@@ -2,66 +2,56 @@ import styled from "styled-components";
 
 const AdventuresWrapper = styled.div`
     background-color: none;
-    padding: 0;
+    padding: 1rem 0;
     width: 100%;
-    max-width: 25rem;
-    display: flex;
-    flex-direction: column;
-    align-self: stretch;
+    max-width: 23rem;
+    margin: 0 auto;
+
+    a {
+        display: block;
+        text-decoration: none;
+        height: 100%;
+    }
 
     .explain {
-        padding-top: 0;
         text-align: center;
-        width: 100%;
         height: 100%;
-        display: flex;
-        flex-direction: column;
 
         .cards {
-            margin: 0 auto;
-            width: 100%;
             height: 100%;
-            padding: 0;
-            display: flex;
-            flex-direction: column;
-            flex: 1;
-
-            a {
-                display: flex;
-                flex-direction: column;
-                height: 100%;
-                width: 100%;
-                text-decoration: none;
-                flex: 1;
-            }
 
             .card {
                 -webkit-transition: 450ms all;
                 transition: 450ms all;
-                margin: 0 auto;
-                padding: 1.75rem 1.25rem;
+                padding: 1.5rem 1.25rem;
                 background-color: #1E2117;
                 border-radius: 25px;
                 overflow: hidden;
-                width: 100%;
-                max-width: 25rem;
-                min-height: 22rem;
                 height: 100%;
+                min-height: 20rem;
+                box-sizing: border-box;
                 display: flex;
                 flex-direction: column;
-                justify-content: space-between;
-                box-sizing: border-box;
-                flex: 1;
 
-                .parentcard, .section-title, .card-content {
+                .parentcard {
                     display: flex;
                     flex-direction: column;
-                    justify-content: space-between;
+                    height: 100%;
+                }
+
+                .section-title {
+                    width: 100% !important;
+                    margin: 0;
+                    display: flex;
+                    flex-direction: column;
+                    height: 100%;
+                }
+
+                .card-content {
+                    display: flex;
+                    flex-direction: column;
                     align-items: center;
                     height: 100%;
-                    width: 100%;
-                    margin: 0;
-                    padding: 0;
                 }
 
                 h2 {
@@ -71,16 +61,15 @@ const AdventuresWrapper = styled.div`
                     font-weight: 500;
                     text-transform: uppercase;
                     clear: both;
-                    margin: 0 0 0.75rem 0;
-                    padding: 0;
+                    margin: 0 0 0.5rem 0;
                     color: ${(props) => props.theme.white};
                 }
 
                 p {
                     text-align: center;
                     color: ${(props) => props.theme.white};
-                    padding: 0 0.5rem;
-                    margin: 0 0 1.25rem 0;
+                    padding: 0 0.25rem;
+                    margin: 0;
                     letter-spacing: 0;
                     font-size: 15px;
                     line-height: 22px;
@@ -88,46 +77,38 @@ const AdventuresWrapper = styled.div`
 
                 .logo {
                     width: 100%;
-                    max-width: 260px;
+                    max-width: 240px;
                     height: auto;
                     margin-top: auto;
-                    border-radius: 12px;
+                    padding-top: 0.75rem;
+                    border-radius: 10px;
                 }
 
                 &:focus:not(:focus-visible) {
                    outline: none;
                 }
                 &:hover {
-                    transform: translateY(-0.15rem);
-                    box-shadow: 0 4px 15px #00d3a9;
+                    transform: translateY(-0.1rem);
+                    box-shadow: 0 2px 10px #00d3a9;
                 }
             }
         }
     }
 
-    @media only screen and (max-width: 992px) {
-        .explain .cards .card {
-            h2 {
-                font-size: 22px;
-                line-height: 30px;
-            }
-            p {
-                font-size: 14px;
-                line-height: 20px;
-            }
-        }
+    @media only screen and (max-width: 767px) {
+        max-width: 23rem;
+        margin: 0 auto;
     }
 
     @media only screen and (max-width: 450px) {
         .explain .cards .card {
             padding: 1.25rem 0.75rem;
             h2 {
-                font-size: 20px;
-                line-height: 28px;
+                font-size: 22px;
+                line-height: 30px;
             }
             p {
-                font-size: 13.5px;
-                line-height: 19px;
+                font-size: 14px;
             }
         }
     }

--- a/src/sections/Adventures-Callout/discuss.style.js
+++ b/src/sections/Adventures-Callout/discuss.style.js
@@ -71,63 +71,25 @@ const AdventuresWrapper = styled.div`
     }
 
     @media only screen and (min-width: 768px){
-        @media only screen and (min-width: 1211px){
-            .explain {
-                .cards {
-                    padding: 0;
-                    h2 {
-                        font-size: 24px;
-                    }
-                    .card {
-                        min-height: 20rem;
-                        height: 100%;
-                        max-width: 23.8rem;
-                    }  
+        .explain {
+            .cards {
+                padding: 0;
+                h2 {
+                    font-size: 24px;
+                    line-height: 32px;
                 }
-            }
-        }
-        @media only screen and (max-width: 1211px){
-            .explain {
-                .cards {
-                    padding: 0; 
-                    h2 {
-                        font-size: 20px;
-                        line-height: 28px;
-                    }
-                    p {
-                        font-size: 14px;
-                    }
-                    .card{
-                        max-width: 22.5rem;
-                        min-height: 20rem;
-                        height: 100%;
-                    }
+                p {
+                    font-size: 14.5px;
+                    line-height: 22px;
                 }
-            }
-        }
-       
-        @media only screen and (max-width: 992px){
-            .explain {
-                .cards {
-                    padding: 0;
-                    .card {
-                        padding: 1rem 0.75rem;
-                        h2 {
-                            font-size: 18px;
-                            line-height: 24px;
-                            letter-spacing: -0.01em;
-                        }
-                        p {
-                            font-size: 13px;
-                            line-height: 18px;
-                        }
-                        .logo {
-                            margin-top: 0.75rem;
-                        }
-                        max-width: 22rem;
-                        min-height: 20rem;
-                        height: 100%;
-                    }
+                .logo {
+                    margin-top: 0.75rem;
+                }
+                .card {
+                    max-width: 23rem;
+                    min-height: 20rem;
+                    height: 100%;
+                    padding: 1.25rem 1rem;
                 }
             }
         }
@@ -139,11 +101,10 @@ const AdventuresWrapper = styled.div`
                 .card {
                     padding: 0.75rem 0.5rem;
                     h2 {
-                        font-size: 18px;
-                        letter-spacing: -0.01em;
+                        font-size: 20px;
                     }
                     p{
-                        font-size: 13px;  
+                        font-size: 13.5px;  
                     }
                 }
             }
@@ -154,11 +115,10 @@ const AdventuresWrapper = styled.div`
             .cards {
                 padding: 1rem .5rem 1rem .5rem;
                 h2 {
-                    font-size: 17px;
-                    letter-spacing: -0.01em;
+                    font-size: 18px;
                 }
                 p{
-                    font-size: 12.5px;  
+                    font-size: 13px;  
                 }
             }
         }

--- a/src/sections/Adventures-Callout/discuss.style.js
+++ b/src/sections/Adventures-Callout/discuss.style.js
@@ -76,7 +76,8 @@ const AdventuresWrapper = styled.div`
                 .cards {
                     padding: 0;
                     .card {
-                        height:20rem;
+                        min-height: 20rem;
+                        height: 100%;
                         max-width: 23.8rem;
                     }  
                 }
@@ -86,38 +87,41 @@ const AdventuresWrapper = styled.div`
             .explain {
                 .cards {
                     padding: 0; 
-                        h2 {
-                            font-size: 25px;
-                            line-height: 35px;
-                        }
-                        p {
-                            font-size: 15px
-                        }
-                        .card{
-                            max-width:23rem;
-                            height:20rem;
-                        }
+                    h2 {
+                        font-size: 24px;
+                        line-height: 33px;
+                    }
+                    p {
+                        font-size: 14px;
+                    }
+                    .card{
+                        max-width: 22.5rem;
+                        min-height: 20rem;
+                        height: 100%;
                     }
                 }
             }
         }
        
         @media only screen and (max-width: 992px){
-          
             .explain {
                 .cards {
                     padding: 0;
                     .card {
                         h2 {
-                            font-size: 22px;
-                            line-height: 32px;
+                            font-size: 21px;
+                            line-height: 28px;
                         }
                         p {
-                            font-size: 13px;
-                            line-height: 23px;
+                            font-size: 13.5px;
+                            line-height: 20px;
                         }
-                        max-width:18rem;
-                        height:18rem;
+                        .logo {
+                            margin-top: 0.75rem;
+                        }
+                        max-width: 22rem;
+                        min-height: 20rem;
+                        height: 100%;
                     }
                 }
             }
@@ -130,10 +134,10 @@ const AdventuresWrapper = styled.div`
                 .card {
                     padding: 0.5rem;
                     h2 {
-                        font-size: 25px;
+                        font-size: 22px;
                     }
                     p{
-                        font-size: 15px;  
+                        font-size: 14px;  
                     }
                 }
             }
@@ -144,7 +148,7 @@ const AdventuresWrapper = styled.div`
             .cards {
                 padding: 1rem .5rem 1rem .5rem;
                 h2 {
-                    font-size: 22px;
+                    font-size: 20px;
                 }
                 p{
                     font-size: 13px;  

--- a/src/sections/Adventures-Callout/discuss.style.js
+++ b/src/sections/Adventures-Callout/discuss.style.js
@@ -75,18 +75,18 @@ const AdventuresWrapper = styled.div`
             .cards {
                 padding: 0;
                 h2 {
-                    font-size: 24px;
-                    line-height: 32px;
+                    font-size: 25px;
+                    line-height: 34px;
                 }
                 p {
-                    font-size: 14.5px;
+                    font-size: 15px;
                     line-height: 22px;
                 }
                 .logo {
-                    margin-top: 0.75rem;
+                    margin-top: 1rem;
                 }
                 .card {
-                    max-width: 23rem;
+                    max-width: 23.8rem;
                     min-height: 20rem;
                     height: 100%;
                     padding: 1.25rem 1rem;

--- a/src/sections/Adventures-Callout/discuss.style.js
+++ b/src/sections/Adventures-Callout/discuss.style.js
@@ -2,7 +2,7 @@ import styled from "styled-components";
 
 const AdventuresWrapper = styled.div`
     background-color:none;
-    padding: 1.5rem 0.625rem 1rem;
+    padding: 1.5rem 1.25rem 1rem;
     overflow: hidden;
     h2{
         font-weight: 500;

--- a/src/sections/Adventures-Callout/discuss.style.js
+++ b/src/sections/Adventures-Callout/discuss.style.js
@@ -12,7 +12,7 @@ const AdventuresWrapper = styled.div`
     }
     .logo{
         width: 100%;
-        margin-top: 2.5rem;
+        margin-top: 1.5rem;
     }
     .explain {
         padding-top: 0rem;

--- a/src/sections/Adventures-Callout/discuss.style.js
+++ b/src/sections/Adventures-Callout/discuss.style.js
@@ -69,14 +69,6 @@ const AdventuresWrapper = styled.div`
         }
     }
 
-    button{
-        color: #1E2117;
-        padding: 0;
-        border: 0;
-        background: none;
-        transition: color 0.25s,border-color 0.25s,transform 0.25s,box-shadow 0.25s;
-        cursor: pointer;
-    }
     @media only screen and (min-width: 768px){
         @media only screen and (min-width: 1211px){
             .explain {
@@ -126,9 +118,6 @@ const AdventuresWrapper = styled.div`
                         width:18rem;
                         height:18rem;
                     }
-                }
-                button {
-                    padding: 0;
                 }
             }
         }

--- a/src/sections/Adventures-Callout/discuss.style.js
+++ b/src/sections/Adventures-Callout/discuss.style.js
@@ -24,7 +24,7 @@ const AdventuresWrapper = styled.div`
                 -webkit-transition: 450ms all;
                 transition: 450ms all;
                 padding: 1.5rem 1.25rem;
-                background-color: #1E2117;
+                background-color: ${(props) => props.theme.darkJungleGreenColor};
                 border-radius: 25px;
                 overflow: hidden;
                 height: 100%;

--- a/src/sections/Adventures-Callout/discuss.style.js
+++ b/src/sections/Adventures-Callout/discuss.style.js
@@ -12,6 +12,7 @@ const AdventuresWrapper = styled.div`
     }
     .logo{
         width: 100%;
+        margin-top: 2.5rem;
     }
     .explain {
         padding-top: 0rem;

--- a/src/sections/Adventures-Callout/index.js
+++ b/src/sections/Adventures-Callout/index.js
@@ -11,7 +11,7 @@ const AdventuresCallout = () => {
     <AdventuresWrapper>
       <div className="explain">
         <div className="cards">
-          <Col lg={12} md={12} sm={12}>
+          <Col $lg={12} $md={12} $sm={12}>
             <a
               target="_blank"
               href="/community/adventures-of-five-and-friends"
@@ -20,14 +20,14 @@ const AdventuresCallout = () => {
               <div className="card">
                 <div className="parentcard">
                   <SectionTitle className="section-title" $UniWidth="100%">
-                    <h2>Adventures of Five & Friends</h2>
-                    {/*<p>Meet Five, our intergalatic Cloud Native Hero</p>*/}
-
-                    <StaticImage
-                      className="logo"
-                      alt="Adventures of Five & Friends"
-                      src={Adventure}
-                    />
+                    <div className="card-content">
+                      <h2>Adventures of Five & Friends</h2>
+                      <StaticImage
+                        className="logo"
+                        alt="Adventures of Five & Friends"
+                        src={Adventure}
+                      />
+                    </div>
                   </SectionTitle>
                 </div>
               </div>

--- a/src/sections/Adventures-Callout/index.js
+++ b/src/sections/Adventures-Callout/index.js
@@ -22,6 +22,10 @@ const AdventuresCallout = () => {
                   <SectionTitle className="section-title" $UniWidth="100%">
                     <div className="card-content">
                       <h2>Adventures of Five & Friends</h2>
+                      <p>
+                        Meet Five, our intergalactic Cloud Native Hero &
+                        friends
+                      </p>
                       <StaticImage
                         className="logo"
                         alt="Adventures of Five & Friends"

--- a/src/sections/Adventures-Callout/index.js
+++ b/src/sections/Adventures-Callout/index.js
@@ -23,13 +23,11 @@ const AdventuresCallout = () => {
                     <h2>Adventures of Five & Friends</h2>
                     {/*<p>Meet Five, our intergalatic Cloud Native Hero</p>*/}
 
-                    <button>
-                      <StaticImage
-                        className="logo"
-                        alt="Adventures of Five & Friends"
-                        src={Adventure}
-                      />
-                    </button>
+                    <StaticImage
+                      className="logo"
+                      alt="Adventures of Five & Friends"
+                      src={Adventure}
+                    />
                   </SectionTitle>
                 </div>
               </div>

--- a/src/sections/Community/community.style.js
+++ b/src/sections/Community/community.style.js
@@ -271,6 +271,7 @@ const CommunitySectionWrapper = styled.div`
     flex-direction: column;
     align-items: center;
     gap: 1.5rem;
+    padding-top: 2rem;
 
     @media screen and (min-width: 768px) {
       flex-direction: row;

--- a/src/sections/Community/community.style.js
+++ b/src/sections/Community/community.style.js
@@ -252,11 +252,11 @@ const CommunitySectionWrapper = styled.div`
         flex-direction: column; 
         align-items: center;
 
-        @media screen and (min-width: 768px) {
-            flex-direction: row; 
-            justify-content: center; 
-            align-items: flex-start; 
-            gap: 2rem; 
+        @media screen and (min-width: 1211px) {
+            flex-direction: row;
+            justify-content: center;
+            align-items: flex-start;
+            gap: 2rem;
         }
     }
     .recognition-program {

--- a/src/sections/Community/community.style.js
+++ b/src/sections/Community/community.style.js
@@ -1,269 +1,288 @@
 import styled from "styled-components";
 
 const CommunitySectionWrapper = styled.div`
-    margin-bottom: 3.25rem;
-    .community-header{
-        color: white;
-        height: 35rem;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
+  margin-bottom: 3.25rem;
+  .community-header {
+    color: white;
+    height: 35rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    h1,
+    h2 {
+      color: white;
+    }
+    h2 {
+      font-size: 1.75rem;
+      font-weight: 500;
+    }
+  }
+
+  .community-section-wrapper {
+    margin-bottom: 3.125rem;
+  }
+
+  .service-mesh-projects {
+    margin-top: 2rem;
+    h2 {
+      line-height: 3.1rem;
+      margin-bottom: 1rem;
+      @media (max-width: 62rem) {
+        line-height: 2.5rem;
+      }
+      transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
+    }
+
+    img {
+      display: block;
+      margin: auto;
+    }
+    @media (max-width: 62rem) {
+      text-align: center;
+    }
+  }
+
+  .open-source-projects {
+    margin-top: 5rem;
+    margin-bottom: 5rem;
+    text-align: center;
+
+    h2 {
+      margin: auto;
+      margin-bottom: 1rem;
+    }
+    p {
+      max-width: 60rem;
+      margin: auto;
+    }
+  }
+
+  .our-community-members {
+    margin-top: 2rem;
+    color: white;
+    background: linear-gradient(
+      to right,
+      ${(props) => props.theme.secondaryColor} 50%,
+      ${(props) => props.theme.black} 50%
+    );
+    transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
+    @media (max-width: 991px) {
+      background: linear-gradient(
+        to bottom,
+        ${(props) => props.theme.secondaryColor} 42rem,
+        ${(props) => props.theme.black} 42rem
+      );
+    }
+    @media (max-width: 550px) {
+      background: linear-gradient(
+        to bottom,
+        ${(props) => props.theme.secondaryColor} 48rem,
+        ${(props) => props.theme.black} 42rem
+      );
+    }
+    @media (max-width: 440px) {
+      background: linear-gradient(
+        to bottom,
+        ${(props) => props.theme.secondaryColor} 55rem,
+        ${(props) => props.theme.black} 42rem
+      );
+    }
+
+    .our-community-members_row {
+      margin: auto 3rem;
+      align-items: center;
+
+      @media (max-width: 650px) {
+        margin: auto 1.25rem;
+      }
+    }
+
+    .community {
+      margin: 5rem auto;
+      @media (max-width: 62rem) {
+        margin: 5rem auto 8rem;
         text-align: center;
-        h1,h2{
-            color: white;
-        }
-        h2{
-            font-size: 1.75rem;
-            font-weight: 500;
-        }
-    }
-
-    .community-section-wrapper{
-        margin-bottom: 3.125rem;
-    }
-
-    .service-mesh-projects{
-        margin-top: 2rem;
-        h2{
-            line-height: 3.1rem;
-            margin-bottom: 1rem;
-            @media (max-width: 62rem) {
-                line-height: 2.5rem;
-            }
-            transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);  
-        }
-
-        img{
-            display:block;
-            margin:auto;
-        }
-        @media (max-width: 62rem) {
-             text-align:center;
-        }
-    }
-
-    .open-source-projects{
-        margin-top: 5rem;
-        margin-bottom: 5rem;
-        text-align: center;
-
-        h2{
-            margin:auto;
-            margin-bottom: 1rem;
-        }
-        p{
-            max-width: 60rem;
-            margin: auto;
-        }
-    }
-
-    .our-community-members{
-        margin-top: 2rem;
+      }
+      @media (max-width: 600px) {
+        margin: 2.5rem auto;
+      }
+      h3 {
+        margin: 0.5rem auto 0.5rem auto;
         color: white;
-        background: linear-gradient(to right, ${props => props.theme.secondaryColor} 50%, ${props => props.theme.black} 50%);
+      }
+      h1 {
+        color: white;
+        margin: 1rem auto 1rem auto;
+      }
+      button {
+        margin-top: 2.5rem;
+      }
+    }
+
+    .slider {
+      padding: 0 3rem;
+    }
+  }
+  .meshmate {
+    margin-top: 5rem;
+    .content {
+      h1,
+      h3,
+      h4 {
         transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
-        @media (max-width: 991px) {
-            background: linear-gradient(to bottom, ${props => props.theme.secondaryColor} 42rem, ${props => props.theme.black} 42rem);
-        }
-        @media (max-width: 550px) {
-            background: linear-gradient(to bottom, ${props => props.theme.secondaryColor} 48rem, ${props => props.theme.black} 42rem);
-        }
-        @media (max-width: 440px) {
-            background: linear-gradient(to bottom, ${props => props.theme.secondaryColor} 55rem, ${props => props.theme.black} 42rem);
-        }
-
-        .our-community-members_row {
-            margin: auto 3rem;
-            align-items: center;
-
-            @media (max-width: 650px) {
-                margin: auto 1.25rem;
-            }
-        }
-
-        .community{
-            margin: 5rem auto;
-            @media (max-width: 62rem) {
-                margin: 5rem auto 8rem;
-                text-align:center;
-            }
-            @media (max-width: 600px) {
-                margin: 2.5rem auto;
-            }
-            h3{
-                margin: 0.5rem auto 0.5rem auto;
-                color: white;
-            }
-            h1{
-                color: white;
-                margin: 1rem auto 1rem auto;
-            }
-            button{
-                margin-top: 2.5rem;
-            }
-        }
-
-        .slider {
-            padding: 0 3rem;
-        }
+      }
+      h3 {
+        margin: 0.5rem auto 0.5rem auto;
+      }
+      h4 {
+        margin: 1rem auto 1rem auto;
+      }
+      h1.onboarding {
+        margin: 0.5rem auto 0.5rem auto;
+        font-size: 1.75rem;
+        font-weight: 500;
+      }
+      @media (max-width: 62rem) {
+        text-align: center;
+      }
     }
-    .meshmate{
-        margin-top: 5rem;
-        .content{
-            h1, h3, h4 {
-                transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
-            }
-            h3{
-                margin: 0.5rem auto 0.5rem auto;
-            }
-            h4{
-                margin: 1rem auto 1rem auto;
-            }
-            h1.onboarding{
-                margin: 0.5rem auto 0.5rem auto;
-                font-size: 1.75rem;
-                font-weight: 500;
-            }
-            @media (max-width: 62rem) {
-              text-align:center;
-            }
-        }
-        .meshmate-img{
-            max-width: 25rem;
-            display:block;
-            margin: auto;
-            background-color: ${props => props.theme.secondaryLightColorTwo};
-            transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
-        }
-
-        .meshmate-img-transparent {
-            background-color: transparent;
-        }
-
-        svg {
-            max-width: 25rem;
-            .meshmate-stack-colorMode_svg__colorMode1 {
-              fill: ${props => props.theme.whiteToGreen3C494F};
-              transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
-            }
-          }
-
-        .meshmate-link{
-            background-color: ${props => props.theme.secondaryLightColorTwo};
-            padding-bottom: 2rem;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
-            .icon{
-                align-items: center;
-                width: 40px;
-                height: 40px;
-                min-width: auto;
-                align-self: center;
-                margin: auto 1rem auto 1rem;
-                padding: 0;
-                font-size: 1.25rem;
-                border: 0px;
-                border-radius: 1rem;
-                left: 0;
-                background: ${props => props.theme.secondaryColor};
-                border-color: ${props => props.theme.secondaryColor};
-                color: white;
-            }
-            .icon svg {
-              display: flex;
-              margin: auto;
-            }
-            h2 {
-                font-size: 1.75rem;
-                font-weight: 500;
-            }
-
-            @media (max-width: 36rem) {
-               h4{
-                  font-size: 18px;
-               }
-            }
-
-            &:hover{
-                h4{
-                    color: ${props => props.theme.primaryLightColorTwo};
-                }
-                .icon{
-                    background: ${props => props.theme.primaryLightColorTwo};
-                    border-color: ${props => props.theme.primaryLightColorTwo};
-                    cursor: pointer;
-                }
-            }
-        }
-
-        .meshmate-link-transparent {
-            background-color: transparent;
-        }
+    .meshmate-img {
+      max-width: 25rem;
+      display: block;
+      margin: auto;
+      background-color: ${(props) => props.theme.secondaryLightColorTwo};
+      transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
     }
 
-    .newcomers-section {
-        width:100%;
-        margin: 5rem 0;
-        padding: 2rem 0;
-        .text{
-            h2{
-                font-size: 1.75rem;
-                font-weight: 500;
-            }
-            text-align: center;
-        }
-        h4{
-            padding: 1rem auto;
-        }
-
-        .newcomers-arrow {
-            align-items: center;
-                min-width: auto;
-                vertical-align:middle;
-                align-self: center;
-                font-size: 1.25rem;
-                color: ${props => props.theme.secondaryColor};
-        }
-        h3 {
-            margin: 1.5rem auto 1.5rem auto;
-        }
-        .invitation {
-            margin: 2rem 0rem 2rem 0rem;
-            a {
-                font-weight: 600;
-                transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
-            }
-        }
+    .meshmate-img-transparent {
+      background-color: transparent;
     }
 
-    @media screen and (max-width: 992px) {
-        .newcomers-section {
-            .text {
-                margin-top: 1.5rem;
-            }
-        }
+    svg {
+      max-width: 25rem;
+      .meshmate-stack-colorMode_svg__colorMode1 {
+        fill: ${(props) => props.theme.whiteToGreen3C494F};
+        transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
+      }
     }
 
-    .Callout {
-        display: flex;
-        flex-direction: column; 
+    .meshmate-link {
+      background-color: ${(props) => props.theme.secondaryLightColorTwo};
+      padding-bottom: 2rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
+      .icon {
         align-items: center;
-        gap: 1.5rem;
+        width: 40px;
+        height: 40px;
+        min-width: auto;
+        align-self: center;
+        margin: auto 1rem auto 1rem;
+        padding: 0;
+        font-size: 1.25rem;
+        border: 0px;
+        border-radius: 1rem;
+        left: 0;
+        background: ${(props) => props.theme.secondaryColor};
+        border-color: ${(props) => props.theme.secondaryColor};
+        color: white;
+      }
+      .icon svg {
+        display: flex;
+        margin: auto;
+      }
+      h2 {
+        font-size: 1.75rem;
+        font-weight: 500;
+      }
 
-        @media screen and (min-width: 768px) {
-            flex-direction: row;
-            justify-content: center;
-            align-items: stretch;
-            gap: 1.5rem;
+      @media (max-width: 36rem) {
+        h4 {
+          font-size: 18px;
         }
-        @media screen and (min-width: 1211px) {
-            gap: 2rem;
+      }
+
+      &:hover {
+        h4 {
+          color: ${(props) => props.theme.primaryLightColorTwo};
         }
+        .icon {
+          background: ${(props) => props.theme.primaryLightColorTwo};
+          border-color: ${(props) => props.theme.primaryLightColorTwo};
+          cursor: pointer;
+        }
+      }
     }
-    .recognition-program {
+
+    .meshmate-link-transparent {
+      background-color: transparent;
+    }
+  }
+
+  .newcomers-section {
+    width: 100%;
+    margin: 5rem 0;
+    padding: 2rem 0;
+    .text {
+      h2 {
+        font-size: 1.75rem;
+        font-weight: 500;
+      }
+      text-align: center;
+    }
+    h4 {
+      padding: 1rem auto;
+    }
+
+    .newcomers-arrow {
+      align-items: center;
+      min-width: auto;
+      vertical-align: middle;
+      align-self: center;
+      font-size: 1.25rem;
+      color: ${(props) => props.theme.secondaryColor};
+    }
+    h3 {
+      margin: 1.5rem auto 1.5rem auto;
+    }
+    .invitation {
+      margin: 2rem 0rem 2rem 0rem;
+      a {
+        font-weight: 600;
+        transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
+      }
+    }
+  }
+
+  @media screen and (max-width: 992px) {
+    .newcomers-section {
+      .text {
+        margin-top: 1.5rem;
+      }
+    }
+  }
+
+  .Callout {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+
+    @media screen and (min-width: 768px) {
+      flex-direction: row;
+      justify-content: center;
+      align-items: stretch;
+      gap: 1.5rem;
+    }
+    @media screen and (min-width: 1211px) {
+      gap: 2rem;
+    }
+  }
+  .recognition-program {
     margin-top: 5rem;
     .recognition-content {
       display: grid;

--- a/src/sections/Community/community.style.js
+++ b/src/sections/Community/community.style.js
@@ -251,11 +251,15 @@ const CommunitySectionWrapper = styled.div`
         display: flex;
         flex-direction: column; 
         align-items: center;
+        gap: 1.5rem;
 
-        @media screen and (min-width: 1211px) {
+        @media screen and (min-width: 768px) {
             flex-direction: row;
             justify-content: center;
-            align-items: flex-start;
+            align-items: stretch;
+            gap: 1.5rem;
+        }
+        @media screen and (min-width: 1211px) {
             gap: 2rem;
         }
     }

--- a/src/sections/Discuss-Callout/discuss.style.js
+++ b/src/sections/Discuss-Callout/discuss.style.js
@@ -13,6 +13,7 @@ const DiscussWrapper = styled.div`
     }
     .logo{
         width: 200px;
+        margin-top: 1.5rem;
     }
     
     .explain {

--- a/src/sections/Discuss-Callout/discuss.style.js
+++ b/src/sections/Discuss-Callout/discuss.style.js
@@ -1,138 +1,138 @@
 import styled from "styled-components";
 
 const DiscussWrapper = styled.div`
-    background-color:none;
-    padding: 1.5rem 1.25rem 1rem;
-    
-    overflow: hidden;
-    h2{
-        font-weight: 500;
-    }
-    h2 span{
-        color:${(props) => props.theme.secondaryColor};
-    }
-    .logo{
-        width: 200px;
-        margin-top: 1.5rem;
-    }
-    
+    background-color: none;
+    padding: 0;
+    width: 100%;
+    max-width: 25rem;
+    display: flex;
+    flex-direction: column;
+    align-self: stretch;
+
     .explain {
-        padding-top: 0rem;
+        padding-top: 0;
         text-align: center;
-        p { 
-            text-align: center;
-            color: ${(props) => props.theme.white};
-            padding: 0px 3.125rem;
-        }
-        h2 {
-            color: ${(props) => props.theme.white};  
-        }
-        h1 {
-            padding: 1.25rem 0px;
-        }
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+
         .cards {
-            margin: 0.15rem auto 0 ;
-            max-width: 50rem;
-            padding: 1.5rem 2rem 0rem 2rem;
-            background-color: none;
-            border-radius: 25px;
+            margin: 0 auto;
+            width: 100%;
+            height: 100%;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+            flex: 1;
+
+            a {
+                display: flex;
+                flex-direction: column;
+                height: 100%;
+                width: 100%;
+                text-decoration: none;
+                flex: 1;
+            }
+
             .card {
                 -webkit-transition: 450ms all;
                 transition: 450ms all;
-                margin: auto;
-                padding: 1.25rem;
+                margin: 0 auto;
+                padding: 1.75rem 1.25rem;
                 background: ${(props) => props.theme.darkJungleGreenColor};
                 border-radius: 25px;
                 overflow: hidden;
-                p {
-                    text-align: center;
-                    padding: 0px 0px 1px 0px;
-                    letter-spacing: 0;
-                    font-size: 16px;
+                width: 100%;
+                max-width: 25rem;
+                min-height: 22rem;
+                height: 100%;
+                display: flex;
+                flex-direction: column;
+                justify-content: space-between;
+                box-sizing: border-box;
+                flex: 1;
+
+                .parentcard, .section-title, .card-content {
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: space-between;
+                    align-items: center;
+                    height: 100%;
+                    width: 100%;
+                    margin: 0;
+                    padding: 0;
                 }
+
                 h2 {
                     text-align: center;
-                    font-size: 28px;
-                    text-transform:uppercase;
+                    font-size: 25px;
+                    line-height: 34px;
+                    font-weight: 500;
+                    text-transform: uppercase;
                     clear: both;
-                    margin-bottom: 0rem;
-                    margin-top: 1rem;
+                    margin: 0 0 0.75rem 0;
+                    padding: 0;
+                    color: ${(props) => props.theme.white};
                 }
+
+                p {
+                    text-align: center;
+                    color: ${(props) => props.theme.white};
+                    padding: 0 0.5rem;
+                    margin: 0 0 1.25rem 0;
+                    letter-spacing: 0;
+                    font-size: 15px;
+                    line-height: 22px;
+                }
+
+                .logo {
+                    width: 200px;
+                    max-width: 100%;
+                    height: auto;
+                    margin-top: auto;
+                }
+
                 &:focus:not(:focus-visible) {
                    outline: none;
                 }
-                &:hover{
-                    transform: translateY(0.03rem);
-                    box-shadow: 0 2px 10px #00d3a9;
-                }
+                &:hover {
+                    transform: translateY(-0.15rem);
+                    box-shadow: 0 4px 15px #00d3a9;
                 }
             }
         }
     }
 
-    @media only screen and (min-width: 768px){
-        .card-align {
-            padding: 1.5rem 0;
-        }
-        .logo {
-            width: 200px;
-            margin-top: 1.25rem;
-        }
-        .explain {
-            .cards {
-                padding: 0;
-                h2 {
-                    padding-bottom: 0.75rem;
-                    font-size: 25px;
-                    line-height: 34px;
-                }
-                p {
-                    font-size: 15px;
-                    line-height: 22px;
-                    padding: 0 0.5rem;
-                }
-                .card {
-                    max-width: 23.8rem;
-                    min-height: 20rem;
-                    height: 100%;
-                    padding: 1.25rem 1rem;
-                }
+    @media only screen and (max-width: 992px) {
+        .explain .cards .card {
+            h2 {
+                font-size: 22px;
+                line-height: 30px;
+            }
+            p {
+                font-size: 14px;
+                line-height: 20px;
+            }
+            .logo {
+                width: 180px;
             }
         }
     }
-  
-    @media only screen and (max-width: 450px){
-        .card-align{
-              padding: 1rem 0;
-        }
-        .explain {
-            .cards {
-                padding: 1rem 1rem 1rem 1rem;
-                .card {
-                    padding: 0.75rem 0.5rem;
-                    h2 {
-                        font-size: 20px;
-                    }
-                    p{
-                        font-size: 13.5px;  
-                    }
-                }
+
+    @media only screen and (max-width: 450px) {
+        .explain .cards .card {
+            padding: 1.25rem 0.75rem;
+            h2 {
+                font-size: 20px;
+                line-height: 28px;
+            }
+            p {
+                font-size: 13.5px;
+                line-height: 19px;
             }
         }
     }
-    @media only screen and (max-width: 375px){
-        .explain {
-            .cards {
-                padding: 1rem .5rem 1rem .5rem;
-                h2 {
-                    font-size: 18px;
-                }
-                p{
-                    font-size: 13px;  
-                }
-            }
-        }
-    } 
 `;
 
 export default DiscussWrapper;

--- a/src/sections/Discuss-Callout/discuss.style.js
+++ b/src/sections/Discuss-Callout/discuss.style.js
@@ -80,6 +80,7 @@ const DiscussWrapper = styled.div`
                     padding: 0;
                     h2{
                         padding-bottom: 0.75rem;
+                        font-size: 24px;
                     }
                     .card {
                         max-width: 23.8rem;
@@ -91,19 +92,19 @@ const DiscussWrapper = styled.div`
         }
         @media only screen and (max-width: 1211px){
             .card-align{
-              padding: 1.25rem 0;
+              padding: 1rem 0;
             }
             .explain {
                 .cards {
                     padding: 0; 
                     h2 {
                         padding-bottom: 0.75rem;
-                        font-size: 24px;
-                        line-height: 33px;
+                        font-size: 20px;
+                        line-height: 28px;
                     }
                     p {
                         font-size: 14px;
-                        line-height: 22px;
+                        line-height: 20px;
                     }
                     .card{
                         max-width: 22.5rem;
@@ -116,25 +117,27 @@ const DiscussWrapper = styled.div`
      
         @media only screen and (max-width: 992px){
             .card-align{
-              padding: 0.75rem 0;
+              padding: 0.5rem 0;
             }
             .logo {
-                width: 170px;
-                margin-top: 1rem;
+                width: 160px;
+                margin-top: 0.75rem;
             }
             .explain {
                 .cards {
                     padding: 0;
                     .card {
+                        padding: 1rem 0.75rem;
                         h2 {
-                            font-size: 21px;
-                            line-height: 28px;
+                            font-size: 18px;
+                            line-height: 24px;
                             padding-bottom: 0.5rem;
+                            letter-spacing: -0.01em;
                         }
                         p {
-                            font-size: 13.5px;
-                            line-height: 20px;
-                            padding: 0 0.5rem;
+                            font-size: 13px;
+                            line-height: 18px;
+                            padding: 0 0.25rem;
                         }
                         max-width: 22rem;
                         min-height: 20rem;
@@ -156,12 +159,13 @@ const DiscussWrapper = styled.div`
             .cards {
                 padding: 1rem 1rem 1rem 1rem;
                 .card {
-                    padding: 0.5rem;
+                    padding: 0.75rem 0.5rem;
                     h2 {
-                        font-size: 22px;
+                        font-size: 18px;
+                        letter-spacing: -0.01em;
                     }
                     p{
-                        font-size: 14px;  
+                        font-size: 13px;  
                     }
                 }
             }
@@ -172,10 +176,11 @@ const DiscussWrapper = styled.div`
             .cards {
                 padding: 1rem .5rem 1rem .5rem;
                 h2 {
-                    font-size: 20px;
+                    font-size: 17px;
+                    letter-spacing: -0.01em;
                 }
                 p{
-                    font-size: 13px;  
+                    font-size: 12.5px;  
                 }
             }
         }

--- a/src/sections/Discuss-Callout/discuss.style.js
+++ b/src/sections/Discuss-Callout/discuss.style.js
@@ -2,7 +2,7 @@ import styled from "styled-components";
 
 const DiscussWrapper = styled.div`
     background-color:none;
-    padding: 1.5rem 0.625rem 1rem;
+    padding: 1.5rem 1.25rem 1rem;
     
     overflow: hidden;
     h2{

--- a/src/sections/Discuss-Callout/discuss.style.js
+++ b/src/sections/Discuss-Callout/discuss.style.js
@@ -82,8 +82,8 @@ const DiscussWrapper = styled.div`
                         padding-bottom:1rem;
                     }
                     .card {
+                        max-width: 23.8rem;
                         height:20rem;
-                        width: 23.8rem;
                     }  
                 }
             }
@@ -104,7 +104,7 @@ const DiscussWrapper = styled.div`
                             font-size: 15px
                         }
                         .card{
-                            width:23rem;
+                            max-width:23rem;
                             height:20rem;
                         }
                     }
@@ -129,7 +129,7 @@ const DiscussWrapper = styled.div`
                             font-size: 13px;
                             line-height: 23px;
                         }
-                        width:18rem;
+                        max-width:18rem;
                         height:18rem;
                     }
                 }

--- a/src/sections/Discuss-Callout/discuss.style.js
+++ b/src/sections/Discuss-Callout/discuss.style.js
@@ -2,66 +2,56 @@ import styled from "styled-components";
 
 const DiscussWrapper = styled.div`
     background-color: none;
-    padding: 0;
+    padding: 1rem 0;
     width: 100%;
-    max-width: 25rem;
-    display: flex;
-    flex-direction: column;
-    align-self: stretch;
+    max-width: 23rem;
+    margin: 0 auto;
+
+    a {
+        display: block;
+        text-decoration: none;
+        height: 100%;
+    }
 
     .explain {
-        padding-top: 0;
         text-align: center;
-        width: 100%;
         height: 100%;
-        display: flex;
-        flex-direction: column;
 
         .cards {
-            margin: 0 auto;
-            width: 100%;
             height: 100%;
-            padding: 0;
-            display: flex;
-            flex-direction: column;
-            flex: 1;
-
-            a {
-                display: flex;
-                flex-direction: column;
-                height: 100%;
-                width: 100%;
-                text-decoration: none;
-                flex: 1;
-            }
 
             .card {
                 -webkit-transition: 450ms all;
                 transition: 450ms all;
-                margin: 0 auto;
-                padding: 1.75rem 1.25rem;
+                padding: 1.5rem 1.25rem;
                 background: ${(props) => props.theme.darkJungleGreenColor};
                 border-radius: 25px;
                 overflow: hidden;
-                width: 100%;
-                max-width: 25rem;
-                min-height: 22rem;
                 height: 100%;
+                min-height: 20rem;
+                box-sizing: border-box;
                 display: flex;
                 flex-direction: column;
-                justify-content: space-between;
-                box-sizing: border-box;
-                flex: 1;
 
-                .parentcard, .section-title, .card-content {
+                .parentcard {
                     display: flex;
                     flex-direction: column;
-                    justify-content: space-between;
+                    height: 100%;
+                }
+
+                .section-title {
+                    width: 100% !important;
+                    margin: 0;
+                    display: flex;
+                    flex-direction: column;
+                    height: 100%;
+                }
+
+                .card-content {
+                    display: flex;
+                    flex-direction: column;
                     align-items: center;
                     height: 100%;
-                    width: 100%;
-                    margin: 0;
-                    padding: 0;
                 }
 
                 h2 {
@@ -71,16 +61,15 @@ const DiscussWrapper = styled.div`
                     font-weight: 500;
                     text-transform: uppercase;
                     clear: both;
-                    margin: 0 0 0.75rem 0;
-                    padding: 0;
+                    margin: 0 0 0.5rem 0;
                     color: ${(props) => props.theme.white};
                 }
 
                 p {
                     text-align: center;
                     color: ${(props) => props.theme.white};
-                    padding: 0 0.5rem;
-                    margin: 0 0 1.25rem 0;
+                    padding: 0 0.25rem;
+                    margin: 0;
                     letter-spacing: 0;
                     font-size: 15px;
                     line-height: 22px;
@@ -91,45 +80,34 @@ const DiscussWrapper = styled.div`
                     max-width: 100%;
                     height: auto;
                     margin-top: auto;
+                    padding-top: 1rem;
                 }
 
                 &:focus:not(:focus-visible) {
                    outline: none;
                 }
                 &:hover {
-                    transform: translateY(-0.15rem);
-                    box-shadow: 0 4px 15px #00d3a9;
+                    transform: translateY(-0.1rem);
+                    box-shadow: 0 2px 10px #00d3a9;
                 }
             }
         }
     }
 
-    @media only screen and (max-width: 992px) {
-        .explain .cards .card {
-            h2 {
-                font-size: 22px;
-                line-height: 30px;
-            }
-            p {
-                font-size: 14px;
-                line-height: 20px;
-            }
-            .logo {
-                width: 180px;
-            }
-        }
+    @media only screen and (max-width: 767px) {
+        max-width: 23rem;
+        margin: 0 auto;
     }
 
     @media only screen and (max-width: 450px) {
         .explain .cards .card {
             padding: 1.25rem 0.75rem;
             h2 {
-                font-size: 20px;
-                line-height: 28px;
+                font-size: 22px;
+                line-height: 30px;
             }
             p {
-                font-size: 13.5px;
-                line-height: 19px;
+                font-size: 14px;
             }
         }
     }

--- a/src/sections/Discuss-Callout/discuss.style.js
+++ b/src/sections/Discuss-Callout/discuss.style.js
@@ -72,27 +72,27 @@ const DiscussWrapper = styled.div`
 
     @media only screen and (min-width: 768px){
         .card-align {
-            padding: 1.25rem 0;
+            padding: 1.5rem 0;
         }
         .logo {
-            width: 180px;
-            margin-top: 1rem;
+            width: 200px;
+            margin-top: 1.25rem;
         }
         .explain {
             .cards {
                 padding: 0;
                 h2 {
                     padding-bottom: 0.75rem;
-                    font-size: 24px;
-                    line-height: 32px;
+                    font-size: 25px;
+                    line-height: 34px;
                 }
                 p {
-                    font-size: 14.5px;
+                    font-size: 15px;
                     line-height: 22px;
                     padding: 0 0.5rem;
                 }
                 .card {
-                    max-width: 23rem;
+                    max-width: 23.8rem;
                     min-height: 20rem;
                     height: 100%;
                     padding: 1.25rem 1rem;

--- a/src/sections/Discuss-Callout/discuss.style.js
+++ b/src/sections/Discuss-Callout/discuss.style.js
@@ -73,40 +73,42 @@ const DiscussWrapper = styled.div`
     @media only screen and (min-width: 768px){
         @media only screen and (min-width: 1211px){
             .card-align{
-              padding:2rem 0;
+              padding: 1.5rem 0;
             }
             .explain {
                 .cards {
                     padding: 0;
                     h2{
-                        padding-bottom:1rem;
+                        padding-bottom: 0.75rem;
                     }
                     .card {
                         max-width: 23.8rem;
-                        height:20rem;
+                        min-height: 20rem;
+                        height: 100%;
                     }  
                 }
             }
         }
         @media only screen and (max-width: 1211px){
             .card-align{
-              padding:2rem 0;
+              padding: 1.25rem 0;
             }
             .explain {
                 .cards {
                     padding: 0; 
-                        h2 {
-                            padding-bottom:1rem;
-                            font-size: 25px;
-                            line-height: 35px;
-                        }
-                        p {
-                            font-size: 15px
-                        }
-                        .card{
-                            max-width:23rem;
-                            height:20rem;
-                        }
+                    h2 {
+                        padding-bottom: 0.75rem;
+                        font-size: 24px;
+                        line-height: 33px;
+                    }
+                    p {
+                        font-size: 14px;
+                        line-height: 22px;
+                    }
+                    .card{
+                        max-width: 22.5rem;
+                        min-height: 20rem;
+                        height: 100%;
                     }
                 }
             }
@@ -114,23 +116,29 @@ const DiscussWrapper = styled.div`
      
         @media only screen and (max-width: 992px){
             .card-align{
-              padding:1.1rem 0;
+              padding: 0.75rem 0;
+            }
+            .logo {
+                width: 170px;
+                margin-top: 1rem;
             }
             .explain {
                 .cards {
                     padding: 0;
                     .card {
                         h2 {
-                            font-size: 22px;
-                            line-height: 32px;
-                            padding-bottom:1rem;
+                            font-size: 21px;
+                            line-height: 28px;
+                            padding-bottom: 0.5rem;
                         }
                         p {
-                            font-size: 13px;
-                            line-height: 23px;
+                            font-size: 13.5px;
+                            line-height: 20px;
+                            padding: 0 0.5rem;
                         }
-                        max-width:18rem;
-                        height:18rem;
+                        max-width: 22rem;
+                        min-height: 20rem;
+                        height: 100%;
                     }
                 }
                 button {
@@ -142,7 +150,7 @@ const DiscussWrapper = styled.div`
   
     @media only screen and (max-width: 450px){
         .card-align{
-              padding:2rem 0;
+              padding: 1rem 0;
         }
         .explain {
             .cards {
@@ -150,10 +158,10 @@ const DiscussWrapper = styled.div`
                 .card {
                     padding: 0.5rem;
                     h2 {
-                        font-size: 25px;
+                        font-size: 22px;
                     }
                     p{
-                        font-size: 15px;  
+                        font-size: 14px;  
                     }
                 }
             }
@@ -164,7 +172,7 @@ const DiscussWrapper = styled.div`
             .cards {
                 padding: 1rem .5rem 1rem .5rem;
                 h2 {
-                    font-size: 22px;
+                    font-size: 20px;
                 }
                 p{
                     font-size: 13px;  

--- a/src/sections/Discuss-Callout/discuss.style.js
+++ b/src/sections/Discuss-Callout/discuss.style.js
@@ -41,7 +41,7 @@ const DiscussWrapper = styled.div`
                 transition: 450ms all;
                 margin: auto;
                 padding: 1.25rem;
-                background-color: #1E2117;
+                background: ${(props) => props.theme.darkJungleGreenColor};
                 border-radius: 25px;
                 overflow: hidden;
                 p {

--- a/src/sections/Discuss-Callout/discuss.style.js
+++ b/src/sections/Discuss-Callout/discuss.style.js
@@ -40,8 +40,9 @@ const DiscussWrapper = styled.div`
                 transition: 450ms all;
                 margin: auto;
                 padding: 1.25rem;
-                background-color: #1E2117; 
+                background-color: #1E2117;
                 border-radius: 25px;
+                overflow: hidden;
                 p {
                     text-align: center;
                     padding: 0px 0px 1px 0px;
@@ -69,14 +70,6 @@ const DiscussWrapper = styled.div`
         }
     }
 
-    button{
-        color: #1E2117;
-        padding: 0.2em 1em;
-        border: 2px solid;
-        background: none;
-        transition: color 0.25s,border-color 0.25s,transform 0.25s,box-shadow 0.25s;
-        cursor: pointer;
-    }
     @media only screen and (min-width: 768px){
         @media only screen and (min-width: 1211px){
             .card-align{

--- a/src/sections/Discuss-Callout/discuss.style.js
+++ b/src/sections/Discuss-Callout/discuss.style.js
@@ -36,7 +36,6 @@ const DiscussWrapper = styled.div`
             background-color: none;
             border-radius: 25px;
             .card {
-                height:20rem;
                 -webkit-transition: 450ms all;
                 transition: 450ms all;
                 margin: auto;

--- a/src/sections/Discuss-Callout/discuss.style.js
+++ b/src/sections/Discuss-Callout/discuss.style.js
@@ -71,81 +71,31 @@ const DiscussWrapper = styled.div`
     }
 
     @media only screen and (min-width: 768px){
-        @media only screen and (min-width: 1211px){
-            .card-align{
-              padding: 1.5rem 0;
-            }
-            .explain {
-                .cards {
-                    padding: 0;
-                    h2{
-                        padding-bottom: 0.75rem;
-                        font-size: 24px;
-                    }
-                    .card {
-                        max-width: 23.8rem;
-                        min-height: 20rem;
-                        height: 100%;
-                    }  
-                }
-            }
+        .card-align {
+            padding: 1.25rem 0;
         }
-        @media only screen and (max-width: 1211px){
-            .card-align{
-              padding: 1rem 0;
-            }
-            .explain {
-                .cards {
-                    padding: 0; 
-                    h2 {
-                        padding-bottom: 0.75rem;
-                        font-size: 20px;
-                        line-height: 28px;
-                    }
-                    p {
-                        font-size: 14px;
-                        line-height: 20px;
-                    }
-                    .card{
-                        max-width: 22.5rem;
-                        min-height: 20rem;
-                        height: 100%;
-                    }
-                }
-            }
+        .logo {
+            width: 180px;
+            margin-top: 1rem;
         }
-     
-        @media only screen and (max-width: 992px){
-            .card-align{
-              padding: 0.5rem 0;
-            }
-            .logo {
-                width: 160px;
-                margin-top: 0.75rem;
-            }
-            .explain {
-                .cards {
-                    padding: 0;
-                    .card {
-                        padding: 1rem 0.75rem;
-                        h2 {
-                            font-size: 18px;
-                            line-height: 24px;
-                            padding-bottom: 0.5rem;
-                            letter-spacing: -0.01em;
-                        }
-                        p {
-                            font-size: 13px;
-                            line-height: 18px;
-                            padding: 0 0.25rem;
-                        }
-                        max-width: 22rem;
-                        min-height: 20rem;
-                        height: 100%;
-                    }
+        .explain {
+            .cards {
+                padding: 0;
+                h2 {
+                    padding-bottom: 0.75rem;
+                    font-size: 24px;
+                    line-height: 32px;
                 }
-                button {
-                    padding: 0;
+                p {
+                    font-size: 14.5px;
+                    line-height: 22px;
+                    padding: 0 0.5rem;
+                }
+                .card {
+                    max-width: 23rem;
+                    min-height: 20rem;
+                    height: 100%;
+                    padding: 1.25rem 1rem;
                 }
             }
         }
@@ -161,11 +111,10 @@ const DiscussWrapper = styled.div`
                 .card {
                     padding: 0.75rem 0.5rem;
                     h2 {
-                        font-size: 18px;
-                        letter-spacing: -0.01em;
+                        font-size: 20px;
                     }
                     p{
-                        font-size: 13px;  
+                        font-size: 13.5px;  
                     }
                 }
             }
@@ -176,11 +125,10 @@ const DiscussWrapper = styled.div`
             .cards {
                 padding: 1rem .5rem 1rem .5rem;
                 h2 {
-                    font-size: 17px;
-                    letter-spacing: -0.01em;
+                    font-size: 18px;
                 }
                 p{
-                    font-size: 12.5px;  
+                    font-size: 13px;  
                 }
             }
         }

--- a/src/sections/Discuss-Callout/index.js
+++ b/src/sections/Discuss-Callout/index.js
@@ -20,7 +20,7 @@ const DiscussCallout = () => {
               <div className="card">
                 <div className="parentcard">
                   <SectionTitle className="section-title" $UniWidth="100%">
-                    <div className="card-align">
+                    <div className="card-content">
                       <h2>Join the Conversation</h2>
                       <p>
                         Ask questions, find answers and share knowledge on our

--- a/src/sections/Discuss-Callout/index.js
+++ b/src/sections/Discuss-Callout/index.js
@@ -27,14 +27,12 @@ const DiscussCallout = () => {
                         Discussion Forum
                       </p>
 
-                      <button>
-                        <img
-                          className="logo"
-                          alt="Discuss"
-                          src={Discuss}
-                          loading="lazy"
-                        />
-                      </button>
+                      <img
+                        className="logo"
+                        alt="Discuss"
+                        src={Discuss}
+                        loading="lazy"
+                      />
                     </div>
                   </SectionTitle>
                 </div>


### PR DESCRIPTION
fix(community): remove unused buttons from callout cards and match card sizing

- src/sections/Discuss-Callout/index.js — removed unused `<button>` around the Discuss logo
- src/sections/Adventures-Callout/index.js — removed unused `<button>` around the Five & Friends image
- src/sections/Discuss-Callout/discuss.style.js — dropped base `height: 20rem` from `.card` so it sizes with content below 768px, matching the Adventures card

Both callout cards on /community now render at the same size across breakpoints.

This PR fixes #7958 

Screenshot/ demo


https://github.com/user-attachments/assets/42c3247d-cdb3-4f23-b466-3d53ce5a4ceb



**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Updated Adventures and Discussion callout images to display without unnecessary button behavior.
- Preserved lazy loading for the Discussion callout image.
- Improved callout layouts by preventing content overflow and retaining responsive card sizing.
- Removed outdated styling that could affect appearance and interaction.
- Improved focus behavior for clearer keyboard navigation.
- Adjusted logo spacing for better visual alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->