### PR TITLE
docs(sistent): add UniversalFilter component documentation

### DIFF
--- a/src/collections/sistent/components/universal-filter/code.mdx
+++ b/src/collections/sistent/components/universal-filter/code.mdx
@@ -1,0 +1,471 @@
+---
+title: Universal Filter Code
+component: universal-filter
+description: Implementation examples and props specification for the UniversalFilter component, covering attribute filtering, search integration, and date-range selection.
+---
+
+import { useMemo, useState } from "react";
+import {
+  NoSsr,
+  ResponsiveDataTable,
+  Stack,
+  TextField,
+  Typography,
+  UniversalFilter
+} from "@sistent/sistent";
+
+export const filterSchema = {
+  type: {
+    name: "Type",
+    options: [
+      { label: "Deployment", value: "deployment" },
+      { label: "Service", value: "service" },
+      { label: "Config Map", value: "configmap" }
+    ]
+  },
+  visibility: {
+    name: "Visibility",
+    options: [
+      { label: "Public", value: "public" },
+      { label: "Private", value: "private" }
+    ]
+  }
+};
+
+export const catalogRows = [
+  { name: "Istio Bookinfo", type: "deployment", visibility: "public", owner: "Alice" },
+  { name: "Redis Cache", type: "service", visibility: "private", owner: "Bob" },
+  { name: "Nginx Ingress", type: "deployment", visibility: "private", owner: "Charlie" },
+  { name: "App Settings", type: "configmap", visibility: "public", owner: "Alice" },
+  { name: "Payments API", type: "service", visibility: "public", owner: "Bob" }
+];
+
+export const BasicFilterDemo = () => {
+  const [selectedFilters, setSelectedFilters] = useState({ type: "All", visibility: "All" });
+  const [applied, setApplied] = useState(null);
+  const handleApplyFilter = (filters) => setApplied(filters);
+  return (
+    <NoSsr>
+      <Stack direction="row" spacing={2} alignItems="center">
+        <UniversalFilter
+          id="basic-universal-filter"
+          filters={filterSchema}
+          selectedFilters={selectedFilters}
+          setSelectedFilters={setSelectedFilters}
+          handleApplyFilter={handleApplyFilter}
+          variant="outlined"
+        />
+        <Typography variant="body2">
+          {applied
+            ? "Applied: type = " + applied.type + ", visibility = " + applied.visibility
+            : "No filters applied yet. Open the filter and press Apply."}
+        </Typography>
+      </Stack>
+    </NoSsr>
+  );
+};
+
+export const TableFilterDemo = () => {
+  const [selectedFilters, setSelectedFilters] = useState({ type: "All", visibility: "All" });
+  const [appliedFilters, setAppliedFilters] = useState({ type: "All", visibility: "All" });
+  const [search, setSearch] = useState("");
+  const columns = [
+    { name: "name", label: "Name" },
+    { name: "type", label: "Type" },
+    { name: "visibility", label: "Visibility" },
+    { name: "owner", label: "Owner" }
+  ];
+  const [tableCols, updateCols] = useState(columns);
+  const [columnVisibility, setColumnVisibility] = useState({});
+  const data = useMemo(
+    () =>
+      catalogRows
+        .filter((row) => appliedFilters.type === "All" || row.type === appliedFilters.type)
+        .filter(
+          (row) =>
+            appliedFilters.visibility === "All" || row.visibility === appliedFilters.visibility
+        )
+        .filter((row) => row.name.toLowerCase().includes(search.trim().toLowerCase()))
+        .map((row) => [row.name, row.type, row.visibility, row.owner]),
+    [appliedFilters, search]
+  );
+  const options = {
+    filter: false,
+    download: false,
+    print: false,
+    viewColumns: false,
+    selectableRows: "none",
+    responsive: "standard",
+    pagination: false,
+    search: false,
+    elevation: 1
+  };
+  return (
+    <NoSsr>
+      <Stack direction="row" spacing={2} alignItems="center" style={{ marginBottom: "1rem" }}>
+        <TextField
+          size="small"
+          label="Search designs"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <UniversalFilter
+          id="table-universal-filter"
+          filters={filterSchema}
+          selectedFilters={selectedFilters}
+          setSelectedFilters={setSelectedFilters}
+          handleApplyFilter={(filters) => setAppliedFilters(filters)}
+          variant="outlined"
+        />
+      </Stack>
+      <ResponsiveDataTable
+        columns={columns}
+        data={data}
+        options={options}
+        tableCols={tableCols}
+        updateCols={updateCols}
+        columnVisibility={columnVisibility}
+      />
+    </NoSsr>
+  );
+};
+
+export const daysAgo = (days) => new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+export const activityQuickRanges = [
+  { label: "Last 24 hours", getRange: () => ({ startDate: daysAgo(1), endDate: new Date() }) },
+  { label: "Last 7 days", getRange: () => ({ startDate: daysAgo(7), endDate: new Date() }) },
+  { label: "Last 30 days", getRange: () => ({ startDate: daysAgo(30), endDate: new Date() }) }
+];
+
+export const DateRangeFilterDemo = () => {
+  const [selectedFilters, setSelectedFilters] = useState({ type: "All" });
+  const [selectedDateRange, setSelectedDateRange] = useState({
+    startDate: daysAgo(7),
+    endDate: new Date()
+  });
+  return (
+    <NoSsr>
+      <Stack direction="row" spacing={2} alignItems="center">
+        <UniversalFilter
+          id="date-universal-filter"
+          filters={{ type: filterSchema.type }}
+          selectedFilters={selectedFilters}
+          setSelectedFilters={setSelectedFilters}
+          handleApplyFilter={() => {}}
+          variant="outlined"
+          datePicker
+          selectedDateRange={selectedDateRange}
+          setSelectedDateRange={setSelectedDateRange}
+          quickDateRanges={activityQuickRanges}
+        />
+        <Typography variant="body2">
+          {selectedDateRange.startDate.toLocaleDateString()} &rarr;{" "}
+          {selectedDateRange.endDate.toLocaleDateString()}
+        </Typography>
+      </Stack>
+    </NoSsr>
+  );
+};
+
+The UniversalFilter is controlled from the parent: the parent owns the selected values, while the component owns the panel and its draft state until the user presses <strong>Apply</strong>.
+
+<a id="Attribute Filtering">
+  <h2>Attribute Filtering</h2>
+</a>
+
+A schema of two attributes rendered as multi-attribute selects. Nothing is committed until <strong>Apply</strong> is pressed, at which point <code>handleApplyFilter</code> receives the applied values.
+
+<div className="showcase">
+  <div className="items">
+    <ThemeWrapper>
+      <BasicFilterDemo />
+    </ThemeWrapper>
+  </div>
+  <CodeBlock name="basic-universal-filter" collapsible code={`import { useState } from "react";
+import { UniversalFilter } from "@sistent/sistent";
+
+const filterSchema = {
+  type: {
+    name: "Type",
+    options: [
+      { label: "Deployment", value: "deployment" },
+      { label: "Service", value: "service" },
+      { label: "Config Map", value: "configmap" },
+    ],
+  },
+  visibility: {
+    name: "Visibility",
+    options: [
+      { label: "Public", value: "public" },
+      { label: "Private", value: "private" },
+    ],
+  },
+};
+
+export default function BasicFilter() {
+  const [selectedFilters, setSelectedFilters] = useState({
+    type: "All",
+    visibility: "All",
+  });
+
+  const handleApplyFilter = (filters) => {
+    // filters holds the values the user just applied
+    fetchDesigns(filters);
+  };
+
+  return (
+    <UniversalFilter
+      id="basic-universal-filter"
+      filters={filterSchema}
+      selectedFilters={selectedFilters}
+      setSelectedFilters={setSelectedFilters}
+      handleApplyFilter={handleApplyFilter}
+      variant="outlined"
+    />
+  );
+}`} />
+</div>
+
+<a id="Filtering a Table">
+  <h2>Filtering a Table</h2>
+</a>
+
+The common pairing: a search input for free text and a UniversalFilter for structured attributes, both feeding the same data set. Search narrows results as the user types, while attribute filters are committed on <strong>Apply</strong>.
+
+<div className="showcase">
+  <div className="items">
+    <ThemeWrapper>
+      <TableFilterDemo />
+    </ThemeWrapper>
+  </div>
+  <CodeBlock name="table-universal-filter" collapsible code={`import { useMemo, useState } from "react";
+import {
+  NoSsr,
+  ResponsiveDataTable,
+  Stack,
+  TextField,
+  UniversalFilter,
+} from "@sistent/sistent";
+
+const columns = [
+  { name: "name", label: "Name" },
+  { name: "type", label: "Type" },
+  { name: "visibility", label: "Visibility" },
+  { name: "owner", label: "Owner" },
+];
+
+export default function FilteredCatalog({ rows }) {
+  const [selectedFilters, setSelectedFilters] = useState({
+    type: "All",
+    visibility: "All",
+  });
+  const [appliedFilters, setAppliedFilters] = useState(selectedFilters);
+  const [search, setSearch] = useState("");
+  const [tableCols, updateCols] = useState(columns);
+  const [columnVisibility, setColumnVisibility] = useState({});
+
+  const data = useMemo(
+    () =>
+      rows
+        .filter(
+          (row) =>
+            appliedFilters.type === "All" ||
+            row.type === appliedFilters.type
+        )
+        .filter(
+          (row) =>
+            appliedFilters.visibility === "All" ||
+            row.visibility === appliedFilters.visibility
+        )
+        .filter((row) =>
+          row.name.toLowerCase().includes(search.trim().toLowerCase())
+        )
+        .map((row) => [row.name, row.type, row.visibility, row.owner]),
+    [rows, appliedFilters, search]
+  );
+
+  return (
+    <NoSsr>
+      <Stack direction="row" spacing={2} alignItems="center">
+        <TextField
+          size="small"
+          label="Search designs"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <UniversalFilter
+          id="table-universal-filter"
+          filters={filterSchema}
+          selectedFilters={selectedFilters}
+          setSelectedFilters={setSelectedFilters}
+          handleApplyFilter={setAppliedFilters}
+          variant="outlined"
+        />
+      </Stack>
+      <ResponsiveDataTable
+        columns={columns}
+        data={data}
+        options={{ filter: false, search: false, selectableRows: "none" }}
+        tableCols={tableCols}
+        updateCols={updateCols}
+        columnVisibility={columnVisibility}
+      />
+    </NoSsr>
+  );
+}`} />
+</div>
+
+<a id="Date Range Filtering">
+  <h2>Date Range Filtering</h2>
+</a>
+
+Enabling <code>datePicker</code> adds a quick-range select and start and end date-time pickers. Range changes apply immediately, without waiting for <strong>Apply</strong>, and the pickers keep the start on or before the end.
+
+<div className="showcase">
+  <div className="items">
+    <ThemeWrapper>
+      <DateRangeFilterDemo />
+    </ThemeWrapper>
+  </div>
+  <CodeBlock name="date-universal-filter" collapsible code={`import { useState } from "react";
+import { UniversalFilter } from "@sistent/sistent";
+
+const daysAgo = (days) =>
+  new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+const quickDateRanges = [
+  {
+    label: "Last 24 hours",
+    getRange: () => ({ startDate: daysAgo(1), endDate: new Date() }),
+  },
+  {
+    label: "Last 7 days",
+    getRange: () => ({ startDate: daysAgo(7), endDate: new Date() }),
+  },
+  {
+    label: "Last 30 days",
+    getRange: () => ({ startDate: daysAgo(30), endDate: new Date() }),
+  },
+];
+
+export default function ActivityFilter() {
+  const [selectedFilters, setSelectedFilters] = useState({ type: "All" });
+  const [selectedDateRange, setSelectedDateRange] = useState({
+    startDate: daysAgo(7),
+    endDate: new Date(),
+  });
+
+  return (
+    <UniversalFilter
+      id="date-universal-filter"
+      filters={filterSchema}
+      selectedFilters={selectedFilters}
+      setSelectedFilters={setSelectedFilters}
+      handleApplyFilter={(filters) =>
+        fetchActivity(filters, selectedDateRange)
+      }
+      variant="outlined"
+      datePicker
+      selectedDateRange={selectedDateRange}
+      setSelectedDateRange={setSelectedDateRange}
+      quickDateRanges={quickDateRanges}
+    />
+  );
+}`} />
+</div>
+
+<p>
+  The date pickers load <code>@mui/x-date-pickers</code> and <code>date-fns</code> on demand. Both must be installed in the consuming project whenever <code>datePicker</code> is enabled.
+</p>
+
+<a id="Props">
+  <h2>Component API &amp; Props</h2>
+</a>
+
+<div className="table-container">
+  <table className="props-table">
+    <thead>
+      <tr>
+        <th>Prop</th>
+        <th>Type</th>
+        <th>Default</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>filters</code></td>
+        <td><code>Record&lt;string, FilterColumn&gt;</code></td>
+        <td><em>required</em></td>
+        <td>Schema of filterable attributes. Each entry supplies a <code>name</code> label and an <code>options</code> list.</td>
+      </tr>
+      <tr>
+        <td><code>selectedFilters</code></td>
+        <td><code>Record&lt;string, string&gt;</code></td>
+        <td><em>required</em></td>
+        <td>Currently applied value per attribute key. Use <code>&quot;All&quot;</code> for an unfiltered attribute.</td>
+      </tr>
+      <tr>
+        <td><code>setSelectedFilters</code></td>
+        <td><code>Dispatch&lt;SetStateAction&lt;Record&lt;string, string&gt;&gt;&gt;</code></td>
+        <td><em>required</em></td>
+        <td>State setter the component calls with the draft values when <strong>Apply</strong> is pressed.</td>
+      </tr>
+      <tr>
+        <td><code>handleApplyFilter</code></td>
+        <td><code>(filters?: Record&lt;string, string&gt;) =&gt; void</code></td>
+        <td><em>required</em></td>
+        <td>Invoked after the panel closes, receiving the applied values. Trigger the data fetch here.</td>
+      </tr>
+      <tr>
+        <td><code>variant</code></td>
+        <td><code>&#39;outlined&#39; | &#39;filled&#39; | &#39;standard&#39;</code></td>
+        <td><code>&#39;outlined&#39;</code></td>
+        <td>Input styling forwarded to every select in the panel.</td>
+      </tr>
+      <tr>
+        <td><code>showAllOption</code></td>
+        <td><code>boolean</code></td>
+        <td><code>true</code></td>
+        <td>Prepends an <code>All</code> option to each select so an individual attribute can be cleared.</td>
+      </tr>
+      <tr>
+        <td><code>id</code></td>
+        <td><code>string</code></td>
+        <td><em>required</em></td>
+        <td>DOM id of the filter root. Keep it unique per instance.</td>
+      </tr>
+      <tr>
+        <td><code>data-testid</code></td>
+        <td><code>string</code></td>
+        <td><code>&#39;universal-filter&#39;</code></td>
+        <td>Base test id. Inner elements derive from it, for example <code>-apply-btn</code> and <code>-select-</code> plus the attribute key.</td>
+      </tr>
+      <tr>
+        <td><code>datePicker</code></td>
+        <td><code>boolean</code></td>
+        <td><code>false</code></td>
+        <td>Renders the date-range section. Requires <code>selectedDateRange</code> and <code>setSelectedDateRange</code>.</td>
+      </tr>
+      <tr>
+        <td><code>selectedDateRange</code></td>
+        <td><code>&#123; startDate: Date; endDate: Date &#125;</code></td>
+        <td><code>undefined</code></td>
+        <td>Controlled date window shown by the start and end pickers.</td>
+      </tr>
+      <tr>
+        <td><code>setSelectedDateRange</code></td>
+        <td><code>(range: &#123; startDate: Date; endDate: Date &#125;) =&gt; void</code></td>
+        <td><code>undefined</code></td>
+        <td>Called immediately whenever the range changes, including quick-range selection.</td>
+      </tr>
+      <tr>
+        <td><code>quickDateRanges</code></td>
+        <td><code>&#123; label: string; getRange: () =&gt; DateRange &#125;[]</code></td>
+        <td>Last 7 days, 30 days, 3 months, 6 months, 1 year</td>
+        <td>Presets offered in the quick-range select. <code>getRange</code> is evaluated on selection.</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/src/collections/sistent/components/universal-filter/code.mdx
+++ b/src/collections/sistent/components/universal-filter/code.mdx
@@ -255,6 +255,24 @@ const columns = [
   { name: "owner", label: "Owner" },
 ];
 
+const filterSchema = {
+  type: {
+    name: "Type",
+    options: [
+      { label: "Deployment", value: "deployment" },
+      { label: "Service", value: "service" },
+      { label: "Config Map", value: "configmap" },
+    ],
+  },
+  visibility: {
+    name: "Visibility",
+    options: [
+      { label: "Public", value: "public" },
+      { label: "Private", value: "private" },
+    ],
+  },
+};
+
 export default function FilteredCatalog({ rows }) {
   const [selectedFilters, setSelectedFilters] = useState({
     type: "All",
@@ -334,6 +352,17 @@ import { UniversalFilter } from "@sistent/sistent";
 const daysAgo = (days) =>
   new Date(Date.now() - days * 24 * 60 * 60 * 1000);
 
+const filterSchema = {
+  type: {
+    name: "Type",
+    options: [
+      { label: "Deployment", value: "deployment" },
+      { label: "Service", value: "service" },
+      { label: "Config Map", value: "configmap" },
+    ],
+  },
+};
+
 const quickDateRanges = [
   {
     label: "Last 24 hours",
@@ -356,6 +385,13 @@ export default function ActivityFilter() {
     endDate: new Date(),
   });
 
+  // The range applies as soon as it changes, so refresh here instead
+  // of waiting for Apply.
+  const handleDateRangeChange = (range) => {
+    setSelectedDateRange(range);
+    fetchActivity(selectedFilters, range);
+  };
+
   return (
     <UniversalFilter
       id="date-universal-filter"
@@ -368,7 +404,7 @@ export default function ActivityFilter() {
       variant="outlined"
       datePicker
       selectedDateRange={selectedDateRange}
-      setSelectedDateRange={setSelectedDateRange}
+      setSelectedDateRange={handleDateRangeChange}
       quickDateRanges={quickDateRanges}
     />
   );

--- a/src/collections/sistent/components/universal-filter/guidance.mdx
+++ b/src/collections/sistent/components/universal-filter/guidance.mdx
@@ -1,0 +1,113 @@
+---
+title: Universal Filter Guidance
+component: universal-filter
+description: The Universal Filter provides a single, reusable control for filtering tables and catalogs across multiple attributes, with optional date-range selection.
+---
+
+The UniversalFilter is designed to be dropped beside any table or catalog toolbar. Applying it consistently keeps filtering behaviour predictable as users move between Meshery, Kanvas, and Layer5 Cloud.
+
+<a id="Do">
+  <h2>Do</h2>
+</a>
+
+<ul>
+  <li>Place the filter in the toolbar of the view it filters, next to the search field and to the right of the data set title.</li>
+  <li>Keep <code>selectedFilters</code> in the parent so the applied values can drive the query that fetches rows.</li>
+  <li>Use <code>All</code> as the reset value for an attribute — the component treats it as &quot;not filtered&quot; and excludes it from the badge count.</li>
+  <li>Perform the data fetch inside <code>handleApplyFilter</code>, which receives the freshly applied values as its argument.</li>
+  <li>Give every instance a unique <code>id</code>, and a <code>data-testid</code> when the view carries more than one filter.</li>
+  <li>Combine the filter with a separate search input for free-text queries, and reset pagination to the first page whenever filters are applied.</li>
+</ul>
+
+<a id="Dont">
+  <h2>Don&#39;t</h2>
+</a>
+
+<ul>
+  <li>Use it for a single attribute — a lone select or chip group is lighter and clearer.</li>
+  <li>Re-fetch on every dropdown change; the component intentionally batches changes behind <strong>Apply</strong>.</li>
+  <li>Load unbounded option lists into a filter group. Beyond roughly a dozen options, use a searchable field instead.</li>
+  <li>Read <code>selectedFilters</code> as a free-form value — it is a flat map of attribute key to a single selected value.</li>
+  <li>Enable <code>datePicker</code> without also supplying <code>selectedDateRange</code> and <code>setSelectedDateRange</code>; the date section is skipped unless all three are present.</li>
+</ul>
+
+<a id="Filter Schemas">
+  <h2>Filter Schemas</h2>
+</a>
+
+<p>
+  The <code>filters</code> prop is a record keyed by attribute. Each entry supplies the label shown above the select and the options offered inside it. The key is what appears in <code>selectedFilters</code>, so name it after the query parameter it maps to.
+</p>
+
+<div className="table-container">
+  <table className="props-table">
+    <thead>
+      <tr>
+        <th>Field</th>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>name</code></td>
+        <td><code>string</code></td>
+        <td>Human-readable label rendered above the select, for example <code>&quot;Visibility&quot;</code>.</td>
+      </tr>
+      <tr>
+        <td><code>options</code></td>
+        <td><code>&#123; label: string; value: string &#125;[]</code></td>
+        <td>Choices for the attribute. <code>value</code> is what lands in <code>selectedFilters</code>; <code>label</code> is what the user reads.</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<ul>
+  <li>Declare schema objects outside the component, or memoise them — a new object identity on every render re-creates the panel contents.</li>
+  <li>Order keys by how often they are used; the panel renders them top to bottom in declaration order.</li>
+  <li>Keep <code>value</code> aligned with the API contract so applied filters can be forwarded to the backend without translation.</li>
+  <li>If a stored value is no longer present in <code>options</code>, the select falls back to the first available option rather than rendering blank.</li>
+</ul>
+
+<a id="Date Range Filtering">
+  <h2>Date Range Filtering</h2>
+</a>
+
+<p>
+  Set <code>datePicker</code> and supply a controlled <code>selectedDateRange</code> of the shape <code>&#123; startDate: Date; endDate: Date &#125;</code> together with its setter. The section renders a quick-range select and a pair of date-time pickers.
+</p>
+
+<ul>
+  <li>The range is <strong>applied immediately</strong> when it changes — unlike the attribute selects, it does not wait for <strong>Apply</strong>. Keep the handler cheap, or debounce the fetch it triggers.</li>
+  <li>The pickers keep the range coherent: moving the start past the end pushes the end forward, and moving the end before the start pulls the start back.</li>
+  <li>Seed <code>selectedDateRange</code> with a sensible default window rather than leaving it empty, so the view always has a bounded query.</li>
+  <li>The date pickers rely on the optional peer dependencies <code>@mui/x-date-pickers</code> and <code>date-fns</code>. Install both in any project that enables <code>datePicker</code>.</li>
+</ul>
+
+<a id="Quick Date Options">
+  <h2>Quick Date Options</h2>
+</a>
+
+<p>
+  Quick ranges are presets that fill both pickers in one action. When <code>quickDateRanges</code> is omitted, the component ships with <em>Last 7 days</em>, <em>Last 30 days</em>, <em>Last 3 months</em>, <em>Last 6 months</em>, and <em>Last 1 year</em>.
+</p>
+
+<ul>
+  <li>Each option is <code>&#123; label: string; getRange: () =&gt; &#123; startDate: Date; endDate: Date &#125; &#125;</code>. Compute dates inside <code>getRange</code> so &quot;last 7 days&quot; stays relative to now.</li>
+  <li>Override the defaults only when the domain calls for it — an audit log may want <em>Last 24 hours</em>, a billing view <em>This month</em>.</li>
+  <li>Keep labels short and unambiguous; they are read in a narrow select and repeated on mobile in the bottom sheet.</li>
+  <li>The quick-range select does not stay visually selected after use. It is an action that seeds the pickers, and the resulting window is shown by the start and end fields.</li>
+</ul>
+
+<a id="Active Filters">
+  <h2>Active Filters</h2>
+</a>
+
+<ul>
+  <li>The badge counts entries in <code>selectedFilters</code> whose value is set and is not <code>All</code>, giving users a glance-able sense of how narrow the current view is.</li>
+  <li>To clear everything, reset <code>selectedFilters</code> to <code>All</code> for each key and call the same handler the filter uses, so the data set and the badge stay in step.</li>
+  <li>Set <code>showAllOption</code> to <code>false</code> only when an attribute must always be constrained; the badge will then include that attribute permanently.</li>
+  <li>For views where the applied filters need to stay visible after the panel closes, render chips from <code>selectedFilters</code> beside the trigger — the state already lives in the parent.</li>
+  <li>Reflect applied filters in the URL when the view is shareable, so a filtered table survives a reload.</li>
+</ul>

--- a/src/collections/sistent/components/universal-filter/index.mdx
+++ b/src/collections/sistent/components/universal-filter/index.mdx
@@ -1,0 +1,58 @@
+---
+name: "Universal Filter"
+title: Universal Filter
+published: true
+component: universal-filter
+description: The Universal Filter provides a single, reusable control for filtering tables and catalogs across multiple attributes, with optional date-range selection.
+---
+
+The <strong>UniversalFilter</strong> component gives every table, catalog, and list in Layer5 projects a consistent way to narrow down what is displayed. Instead of each view inventing its own filter bar, a single control renders one dropdown per filterable attribute, collects the user's choices, and commits them all at once.
+
+<a id="Overview">
+  <h2>Overview</h2>
+</a>
+
+Use the <strong>UniversalFilter</strong> when a data set can be narrowed along two or more independent attributes — for example filtering designs by <em>type</em> and <em>visibility</em>, or connections by <em>kind</em> and <em>status</em>. The control appears as a filter icon with a badge showing how many attributes are currently constrained. Clicking it opens a panel containing one select per attribute and an <strong>Apply</strong> button.
+
+Selections are held as a draft while the panel is open and are only committed to the parent when <strong>Apply</strong> is pressed, so a user can adjust several attributes without triggering a re-fetch for each change. On screens narrower than the <code>sm</code> breakpoint the panel is presented as a bottom sheet instead of a popper, so the same component works on mobile without extra code.
+
+<a id="Anatomy">
+  <h2>Anatomy</h2>
+</a>
+
+<ul>
+  <li><strong>Filter trigger</strong> — A tooltip icon button labelled &quot;Filter&quot; that opens and closes the panel.</li>
+  <li><strong>Active filter badge</strong> — A primary-coloured badge over the trigger, counting the attributes whose value is set to something other than <code>All</code>. It is hidden when nothing is filtered.</li>
+  <li><strong>Panel</strong> — A popper anchored to the trigger on desktop, or a bottom sheet titled &quot;Filters&quot; on small screens.</li>
+  <li><strong>Filter groups</strong> — One label and select per entry in the <code>filters</code> schema, rendered in the order the keys are declared.</li>
+  <li><strong>Date range section</strong> — Optional. A &quot;Quick Ranges&quot; select plus <strong>Start</strong> and <strong>End</strong> date-time pickers, rendered only when date filtering is enabled.</li>
+  <li><strong>Apply button</strong> — Commits the draft selections, closes the panel, and invokes the apply handler.</li>
+</ul>
+
+<a id="Variants">
+  <h2>Variants</h2>
+</a>
+
+<h3>Attribute filtering</h3>
+
+The default form. Each key in the <code>filters</code> schema becomes a select with an <code>All</code> option prepended, letting the user clear an individual attribute without clearing the rest.
+
+<h3>Filtering with date range</h3>
+
+Setting <code>datePicker</code> adds a date-range section beneath the attribute selects. It offers preset ranges such as <em>Last 7 days</em> and <em>Last 30 days</em>, alongside explicit start and end pickers for arbitrary windows.
+
+<h3>Input variants</h3>
+
+The <code>variant</code> prop is forwarded to every select in the panel, so the filter can be rendered as <code>outlined</code> (default), <code>filled</code>, or <code>standard</code> to match the surrounding form styling.
+
+<a id="Accessibility">
+  <h2>Accessibility</h2>
+</a>
+
+<ul>
+  <li>The trigger is a tooltip icon button with the accessible name &quot;Filter&quot;, so it is reachable and operable from the keyboard.</li>
+  <li>Every filter group renders a visible label bound to its select — always give each entry in the schema a human-readable <code>name</code>.</li>
+  <li>The badge count is supplementary information; the applied values remain visible inside the panel, so meaning is never carried by the badge alone.</li>
+  <li>The panel closes on click-away and returns focus to the page, and the bottom sheet variant provides its own dismiss affordance on touch devices.</li>
+  <li>Pass a unique <code>id</code> per instance so multiple filters on one page remain individually addressable by assistive technology and tests.</li>
+</ul>


### PR DESCRIPTION
**Description**

This PR fixes #7984

`UniversalFilter` is one of the core filtering components exported by Sistent, but it had no entry in the centralized component reference at https://layer5.io/projects/sistent/components. Developers reusing it across Layer5 projects had no documented reference for its filter schema, its date-range integration, or how selections are committed — the API had to be read from the library source.

This PR adds that documentation, following the new Sistent MDX documentation structure.

**What was added**

Three new files under `src/collections/sistent/components/universal-filter/`:

| File | Tab | Contents |
| --- | --- | --- |
| `index.mdx` | Overview | What the component is for (multi-attribute filtering across tables and catalogs), anatomy of the control — filter trigger, active-filter badge, panel, filter groups, date-range section, Apply button — variants, and accessibility notes. |
| `guidance.mdx` | Guidance | Do / Don't guidance, the filter schema shape as a field table, date-range picker integration, quick date options, and active-filter handling. |
| `code.mdx` | Code | Three live examples paired with copyable snippets, plus the full props table. |

The examples in `code.mdx` are:

1. **Attribute filtering** — a two-attribute schema demonstrating that selections are held as a draft and committed only when **Apply** is pressed.
2. **Filtering a table** — the common pairing of a free-text search input with `UniversalFilter`, both feeding a `ResponsiveDataTable`.
3. **Date range filtering** — `datePicker` enabled with custom `quickDateRanges`, showing the applied window.

**How it was done**

- Matched the conventions of the already-documented components (`table`, `permissions`): same frontmatter fields (`name`, `title`, `published`, `component`, `description`), the same `<a id="...">` section anchors that drive the in-page TOC, the same `showcase` / `items` markup, and the same `props-table` markup for the API reference.
- Live previews render inside `<ThemeWrapper>` so they follow the site's light/dark mode, and each is paired with a collapsible `<CodeBlock>` holding the copyable source.
- Demos are wrapped in `<NoSsr>` because the component branches on `useMediaQuery` — a popper on desktop, a bottom sheet below the `sm` breakpoint — which would otherwise risk a hydration mismatch.
- Documented behaviour was taken from the component's actual implementation rather than assumed. Specifically:
  - selections are drafted internally and only committed to `setSelectedFilters` / `handleApplyFilter` on **Apply**;
  - `"All"` is the per-attribute reset value, and is excluded from the active-filter badge count;
  - date-range changes apply **immediately**, unlike the attribute selects, and the pickers clamp start and end so the range stays coherent;
  - the default `quickDateRanges` are last 7 days, 30 days, 3 months, 6 months, and 1 year;
  - a selected value no longer present in `options` falls back to the first option rather than rendering blank;
  - `datePicker` requires the optional peer dependencies `@mui/x-date-pickers` and `date-fns`, which the component loads on demand.

**No existing files needed changes.** `gatsby-node.js` derives the routes from the directory name, and both the components landing page and the Sistent TOC build their lists from GraphQL, so the new pages are picked up automatically at:

- `/projects/sistent/components/universal-filter`
- `/projects/sistent/components/universal-filter/guidance`
- `/projects/sistent/components/universal-filter/code`

**Notes for Reviewers**

- All three files were verified to compile with `@mdx-js/mdx` v3 — the version the site builds with — before committing.
- The props table documents every prop the component accepts, including `data-testid`, whose derived ids (`-apply-btn`, `-select-<key>`, `-option-<value>`, `-start-date`, `-end-date`) are useful when writing tests against views that embed the filter.
- The guidance page deliberately calls out that date-range changes bypass **Apply**, since that asymmetry is easy to miss and affects how consumers wire up their fetch.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive UniversalFilter documentation covering setup, usage, anatomy, accessibility, and responsive behavior.
  - Added interactive examples for attribute, table, search, and date-range filtering.
  - Documented draft-and-apply workflows, reset behavior, URL synchronization, quick date presets, and active-filter indicators.
  - Added guidance on schemas, state management, dependencies, option limits, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->