### PR TITLE
[Community] Update community meeting link

### DIFF
--- a/src/collections/handbook/community-roles/index.mdx
+++ b/src/collections/handbook/community-roles/index.mdx
@@ -72,7 +72,7 @@ The responsibilities of a Community Manager involves building, stewarding, and o
 - Assess each <a href="http://layer5.io/community/members" target="_blank" rel="noopener noreferrer">community member profile</a> for transition to inactive. Use a period of two months of inactivity as the metric.
 - Monthly evaluation of Social sharing and SEO tracker.
 - Monthly evaluation of DevStats
-- Every week on Thursday at 8:30 pm | 10:00 am CT - <Link to="/community/calendar#meetings">meeting</Link> and <a href="https://app.clickup.com/t/85zt86613" target="_blank" rel="noopener noreferrer">minutes</a>.
+- Every week on Thursday at 8:30 pm | 10:00 am CT - <Link to="/community/calendar">meeting</Link> and <Link to="/community/calendar#meetings" target="_blank" rel="noopener noreferrer">minutes</Link>.
 - Event management (Workshops, Webinars, Conferences, CFPs)
 - Reset the Slack invitation on slack.layer5.io and slack.meshery.io monthly.
 

--- a/src/collections/handbook/community-roles/index.mdx
+++ b/src/collections/handbook/community-roles/index.mdx
@@ -72,7 +72,7 @@ The responsibilities of a Community Manager involves building, stewarding, and o
 - Assess each <a href="http://layer5.io/community/members" target="_blank" rel="noopener noreferrer">community member profile</a> for transition to inactive. Use a period of two months of inactivity as the metric.
 - Monthly evaluation of Social sharing and SEO tracker.
 - Monthly evaluation of DevStats
-- Every week on Thursday at 8:30 pm | 10:00 am CT - <a href="http://meet.layer5.io/gaurav-chadha" target="_blank" rel="noopener noreferrer">meeting</a> and <a href="https://app.clickup.com/t/85zt86613" target="_blank" rel="noopener noreferrer">minutes</a>.
+- Every week on Thursday at 8:30 pm | 10:00 am CT - <Link to="/community/calendar#meetings">meeting</Link> and <a href="https://app.clickup.com/t/85zt86613" target="_blank" rel="noopener noreferrer">minutes</a>.
 - Event management (Workshops, Webinars, Conferences, CFPs)
 - Reset the Slack invitation on slack.layer5.io and slack.meshery.io monthly.
 


### PR DESCRIPTION
**Description**

Replace the obsolete community meeting URL in the Community Roles handbook with a Gatsby internal link to the meetings section of the Layer5 community calendar.

**Notes for Reviewers**

- The change follows the documented convention of using Gatsby `Link` for internal navigation.
- Verified the production core build and served page locally.
- Confirmed `/community/handbook/community-roles` returns HTTP 200, contains the new calendar link once, and no longer contains the old meeting URL.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the weekly Community Manager meeting link to point to the Layer5 community calendar.
  * Updated the meeting minutes link to the meetings section of the Layer5 community calendar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->