### PR TITLE
fix: handle posts without tags in related posts

### DIFF
--- a/src/components/Related-Posts/relatedPostsFactory.js
+++ b/src/components/Related-Posts/relatedPostsFactory.js
@@ -23,18 +23,13 @@ class RelatedPostsFactory {
   }
 
   setTags (tags) {
-    this.tags = tags;
+    this.tags = Array.isArray(tags) ? tags : [];
     return this;
   }
 
   getPosts () {
     const { category, tags, posts, maxPosts } = this;
     const identityMap = {};
-
-    if (!!tags === false || tags.length === 0) {
-      console.error("RelatedPostsFactory: Tags not provided, use setTags().");
-      return [];
-    }
 
     if (!!category === false) {
       console.error("RelatedPostsFactory: Category not provided, use setCategory().");
@@ -65,8 +60,9 @@ class RelatedPostsFactory {
     const addTagsPoints = (post, tags) => {
       const tagPoint = 1;
       const slug = getSlug(post);
+      const postTags = Array.isArray(post.frontmatter.tags) ? post.frontmatter.tags : [];
 
-      post.frontmatter.tags.forEach((tag) => {
+      postTags.forEach((tag) => {
         if (includes(tags, tag)) {
           identityMap[slug].points += tagPoint;
         }


### PR DESCRIPTION
**Description**

This PR fixes #8000

### Problem
When a blog post is authored without tags (or with `tags: null` / `tags: []`), `RelatedPostsFactory` encounters two issues:
1. **Runtime Crash on Candidate Posts:** If any candidate post in the GraphQL query has `frontmatter.tags` as `null` or `undefined`, iterating over it with `.forEach()` throws a `TypeError: Cannot read properties of null (reading 'forEach')`, causing the related posts component to crash across all blog pages.
2. **Blocked Category Fallback:** If the current blog post does not have tags, `RelatedPostsFactory.getPosts()` logged an error and exited early with `return []`, preventing the section from showing category-based recommendations (which carry +2 points per match).

### Changes Made
- **Safeguard `setTags()`:** Updated `setTags(tags)` to ensure `this.tags` always defaults to an array (`Array.isArray(tags) ? tags : []`), safely handling `null` and `undefined`.
- **Removed Early Exit Guard:** Removed the strict `if (!tags || tags.length === 0)` guard in `getPosts()` so posts without tags can still recommend related posts based on matching categories.
- **Added Null Check in `addTagsPoints()`:** Safely wrapped `post.frontmatter.tags` in `addTagsPoints()` with `Array.isArray()` before calling `.forEach()`.

---

**Notes for Reviewers**

- Tested with posts having:
  - Valid tags
  - Empty tags (`tags: []`)
  - `tags: null` / omitted tags
- Verified that posts without tags now gracefully fall back to matching related posts by category without console errors or runtime crashes.

---

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
