### PR TITLE
fix(sistent): honour the contents prop in IntraPage

### DIFF
--- a/src/components/SistentNavigation/intra-page.js
+++ b/src/components/SistentNavigation/intra-page.js
@@ -60,14 +60,22 @@ const JoinCommunityWrapper = styled.div`
   }
 `;
 
-function IntraPage() {
-  const [contents, setContents] = useState([]);
+function IntraPage({ contents: providedContents }) {
+  const [scannedContents, setScannedContents] = useState([]);
+
+  // Pages that build their own layout pass an explicit list of sections.
+  // Pages rendered through the MDX template instead expose their sections
+  // as anchors inside `.main-content`, which are discovered here.
+  const hasProvidedContents = Boolean(providedContents && providedContents.length);
 
   useEffect(() => {
+    if (hasProvidedContents) {
+      return;
+    }
     const anchors = document.querySelectorAll(".main-content > a");
     console.log(anchors);
     if (anchors) {
-      setContents(
+      setScannedContents(
         Array.from(anchors).map((a) => ({
           id: a.id,
           link: `#${a.id}`,
@@ -75,7 +83,9 @@ function IntraPage() {
         }))
       );
     }
-  }, []);
+  }, [hasProvidedContents]);
+
+  const contents = hasProvidedContents ? providedContents : scannedContents;
 
   const [intapath, setIntapath] = useState(null);
   useEffect(() => {

--- a/src/sections/Projects/Sistent/getting-started/about/index.js
+++ b/src/sections/Projects/Sistent/getting-started/about/index.js
@@ -10,7 +10,11 @@ import { useStyledDarkMode } from "../../../../../theme/app/useStyledDarkMode";
 import CodeBlock from "../../../../../components/CodeBlock";
 import { SistentThemeProvider, Button } from "@sistent/sistent";
 
-const contents = [{ id: 0, link: "#About Sistent", text: "About Sistent" }];
+const contents = [
+  { id: 0, link: "#About Sistent", text: "About Sistent" },
+  { id: 1, link: "#Installation", text: "Installation" },
+  { id: 2, link: "#Using local Sistent", text: "Using local Sistent" },
+];
 
 const codes = [
   "npm i @sistent/sistent",


### PR DESCRIPTION
The Sistent IntraPage component declared no props and built its list solely by scanning the DOM for anchors under `.main-content`. That wrapper is rendered only by the MDX component template, so on the Getting Started > About page - which builds its own layout - the query matched nothing and the in-page navigation rendered empty, even though the page passed an explicit contents array that the component discarded.

IntraPage now uses the contents it is given and falls back to the DOM scan when no list is supplied, so the prop-less usage in SistentLayout keeps working unchanged. This matches how the handbook and legal variants of the component already behave.

The About page's contents array listed only the first of its three anchored sections, so it is completed with Installation and Using local Sistent.

Fixes #7992

**Description**

This PR fixes #7992

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expanded in-page navigation for the Sistent Getting Started section.
  * Users can now quickly access About Sistent, Installation, and Using local Sistent sections.
  * Supports explicitly defined navigation sections while retaining automatic section discovery where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->