### PR TITLE
[UI] Fix active in-page navigation link: invalid font-weight and invisible active state

### DIFF
--- a/src/components/SistentNavigation/intra-page.js
+++ b/src/components/SistentNavigation/intra-page.js
@@ -27,11 +27,11 @@ const JoinCommunityWrapper = styled.div`
     overflow: hidden;
 
     .list {
-      color: #000000;
+      color: ${(props) => props.theme.menuColor};
     }
     .active {
-      font-weight: 5000;
-      color: #000000;
+      font-weight: 700;
+      color: ${(props) => props.theme.secondaryColor};
     }
 
     ul {

--- a/src/components/legal-navigation/intra-page.js
+++ b/src/components/legal-navigation/intra-page.js
@@ -20,11 +20,11 @@ const JoinCommunityWrapper = styled.div`
     overflow: hidden;
 
     .list {
-      color: #000000;
+      color: ${(props) => props.theme.menuColor};
     }
     .active {
-      font-weight: 5000;
-      color: #000000;
+      font-weight: 700;
+      color: ${(props) => props.theme.secondaryColor};
     }
 
     ul {

--- a/src/sections/Community/Adventures-of-Five/adventures.style.js
+++ b/src/sections/Community/Adventures-of-Five/adventures.style.js
@@ -404,7 +404,7 @@ export const AdventuresWrapper = styled.div`
     flex-direction: column;
     overflow:hidden;
     .active{
-      font-weight:5000;
+      font-weight: 700;
       color: ${(props) => props.theme.secondaryColor};
     }
     ul{

--- a/src/sections/Community/Handbook/Handbook.style.js
+++ b/src/sections/Community/Handbook/Handbook.style.js
@@ -347,7 +347,7 @@ export const HandbookWrapper = styled.div`
       flex-direction: row;
       overflow:hidden;
       .active{
-        font-weight:5000;
+        font-weight: 700;
         color: ${(props) => props.theme.secondaryColor};
       }
       ul{

--- a/src/sections/Projects/Sistent/sistent.style.js
+++ b/src/sections/Projects/Sistent/sistent.style.js
@@ -442,7 +442,7 @@ const SistentWrapper = styled.div`
     flex-direction: column;
     overflow: hidden;
     .active {
-      font-weight: 5000;
+      font-weight: 700;
       color: ${(props) => props.theme.secondaryColor};
     }
     ul {


### PR DESCRIPTION
**Description**

This PR fixes #7994

Five stylesheets set `font-weight: 5000` on the `.active` state of an in-page ("on this page") navigation link. The CSS Fonts specification defines `font-weight` as accepting numbers in the range `1`–`1000`; `5000` falls outside it, so the declaration is invalid and the browser discards it. The active-section highlight has therefore never rendered bold on any of the affected pages.

In two of the five files the consequence is more than a missing bold. Before this PR, `src/components/SistentNavigation/intra-page.js` and `src/components/legal-navigation/intra-page.js` both read:

```css
.list {
  color: #000000;
}
.active {
  font-weight: 5000;   /* invalid — dropped by the browser */
  color: #000000;      /* identical to .list */
}
```

With the weight dropped and the colour matching the inactive state, `.active` produced **no visual change whatsoever**. On the Sistent documentation and the legal pages there has been no indication at all of which section the reader is currently viewing — the highlight is not subtle, it is absent.

Those same two files also hardcode `#000000` for the inactive links, which renders near-invisible against the dark theme.

**What changed**

| File | Change |
| --- | --- |
| `src/components/SistentNavigation/intra-page.js` | `font-weight: 5000` → `700`; `.active` colour → `theme.secondaryColor`; `.list` colour → `theme.menuColor` |
| `src/components/legal-navigation/intra-page.js` | Same three changes |
| `src/sections/Projects/Sistent/sistent.style.js` | `font-weight: 5000` → `700` |
| `src/sections/Community/Handbook/Handbook.style.js` | `font-weight:5000` → `700` |
| `src/sections/Community/Adventures-of-Five/adventures.style.js` | `font-weight:5000` → `700` |

The last three already coloured `.active` with `${(props) => props.theme.secondaryColor}`, so the invalid weight was the only defect there.

**Why these token choices**

Both replacements follow precedent already in the codebase rather than introducing new values:

- **`theme.secondaryColor`** for the active link — this is exactly what `sistent.style.js`, `Handbook.style.js`, and `adventures.style.js` use for their own `.active` rules. It resolves to the Layer5 caribbean green `#00b39f` in both themes, so the active entry now differs from its neighbours by weight *and* colour.
- **`theme.menuColor`** for the inactive links — a token named for exactly this purpose, resolving to charcoal `#3c494f` in light mode and `#ffffff` in dark mode. The obvious alternative, `theme.textColor`, is `#000000` in *both* palettes and would not have fixed the dark-mode readability problem.

**How to verify**

1. Open any Sistent component doc, e.g. `/projects/sistent/components/table`, at a viewport wider than 1280px so the right-hand section navigation is visible.
2. Scroll through the sections: the entry for the current section is now bold and green, where previously it was indistinguishable from the rest.
3. Toggle dark mode: the inactive entries are legible rather than black-on-dark.
4. Repeat on a legal page, a Handbook page, and Adventures of Five.

In devtools, the `font-weight` declaration on `.active` no longer appears struck-through as invalid.

**Notes for Reviewers**

- After this change, no `font-weight` value outside the valid range remains anywhere under `src/` (verified by grep for four-or-more-digit values).
- All five modified files were syntax-checked before committing.
- **Overlapping PRs on one file:** `src/components/SistentNavigation/intra-page.js` is also touched by #7995 (removes a debug `console.log`) and #8003 (makes the component honour its `contents` prop). The three changes sit in different regions of the file — this PR only touches the styled-components block near the top, while those two touch the component body — so they should merge independently. If any of them does conflict, I am happy to rebase whichever lands last.
- Not addressed here, as it is outside the scope of this issue: `textColor` is defined as `#000000` in both the light and dark palettes in `src/theme/app/themeStyles.js`, which looks like the same class of latent bug. I can open a separate issue for it if that would be useful.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated intra-page navigation colors to follow the active theme.
  - Improved active-link styling with a consistent, supported font weight.
  - Applied these visual updates across community, handbook, legal, and project navigation sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->