### PR TITLE
Align Container Styling

### DIFF
--- a/src/components/BGImage/BGImage.styles.js
+++ b/src/components/BGImage/BGImage.styles.js
@@ -3,9 +3,7 @@ import { GatsbyImage } from "gatsby-plugin-image";
 
 
 export const BGWrapper = styled.div`
-  position: relative;
-  width: 100%;
-  margin: 0 auto;
+position: relative; flex-center;
 `;
 
 export const FakeBGImg = styled(GatsbyImage)`


### PR DESCRIPTION
## What was broken
The left container on the Community page has an unwanted border, and the Layer5 logo is not clearly visible.
## What changed
Fixed the styles of the left container to match the right container's styles.
## How to test
Open the layer5.io/community page in a browser.

Closes #8002.

---
<sub>The patch was drafted with LLM assistance and reviewed by me before submitting. Happy to revise or close this if it isn't useful.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved background image layout and centering for more consistent visual alignment.
  * Background imagery now remains positioned relative to its container while being centered horizontally, helping maintain a more balanced appearance across supported layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->