### PR TITLE
docs(sistent) : add UniversalFilter component documentation

### DIFF
--- a/src/collections/sistent/components/universal-filter/code.mdx
+++ b/src/collections/sistent/components/universal-filter/code.mdx
@@ -251,10 +251,10 @@ export const ActiveFilterChipsDemo = () => {
   <h2>Basic UniversalFilter</h2>
 </a>
 
-Multi-attribute filtering with two column filters. Each dimension renders as a `Select` inside the popper; selections are staged locally and committed on **Apply**.
+Multi-attribute filtering with two column filters. Each dimension renders as a `Select` inside the `Popper` (desktop) / `BottomSheet` (mobile); column selections are staged as `draftFilters` and committed on **Apply**.
 
 <div className="showcase">
-  <div className="items">
+  <div className="items" style={{ display: 'flex', justifyContent: 'center', width: '100%', maxWidth: '400px', margin: '0 auto' }}>
     <ThemeWrapper>
       <BasicUniversalFilterCodeDemo />
     </ThemeWrapper>
@@ -313,7 +313,7 @@ export default function BasicUniversalFilter() {
 Combine a free-text `TextField` search with `UniversalFilter` for mixed query patterns — search narrows by name or description while selects constrain by enumerated attributes. Both inputs should be committed together (e.g., on Apply or via a shared filter handler).
 
 <div className="showcase">
-  <div className="items">
+  <div className="items" style={{ display: 'flex', justifyContent: 'center', width: '100%', maxWidth: '400px', margin: '0 auto' }}>
     <ThemeWrapper>
       <WithSearchUniversalFilterCodeDemo />
     </ThemeWrapper>
@@ -384,10 +384,10 @@ export default function SearchWithUniversalFilter() {
   <h2>With Date Picker</h2>
 </a>
 
-Enable the calendar section by passing `datePicker`, `selectedDateRange`, and `setSelectedDateRange`. The component renders a Quick Ranges selector plus Start/End `DateTimePicker` fields. `DateTimePicker` is lazily loaded and requires optional peers `@mui/x-date-pickers` and `date-fns`.
+Enable the calendar section by passing `datePicker`, `selectedDateRange`, and `setSelectedDateRange`. The component renders a Quick Ranges selector plus Start/End `DateTimePicker` fields. `DateTimePicker` is lazily loaded and requires optional peers `@mui/x-date-pickers` and `date-fns`. Unlike column filters, quick-range and Start/End changes call `setSelectedDateRange` immediately — they are not staged until Apply.
 
 <div className="showcase">
-  <div className="items">
+  <div className="items" style={{ display: 'flex', justifyContent: 'center', width: '100%', maxWidth: '400px', margin: '0 auto' }}>
     <ThemeWrapper>
       <DatePickerUniversalFilterCodeDemo />
     </ThemeWrapper>
@@ -436,7 +436,7 @@ export default function DatePickerUniversalFilter() {
 Override `quickDateRanges` to provide domain-specific presets. Each entry is `{ label, getRange: () => ({ startDate, endDate }) }`. Use `subtractDays`, `subtractMonths`, and `subtractYears` from `@sistent/sistent` for DST-safe, end-of-month-clamped arithmetic.
 
 <div className="showcase">
-  <div className="items">
+  <div className="items" style={{ display: 'flex', justifyContent: 'center', width: '100%', maxWidth: '400px', margin: '0 auto' }}>
     <ThemeWrapper>
       <QuickRangesUniversalFilterCodeDemo />
     </ThemeWrapper>
@@ -493,7 +493,7 @@ export default function QuickRangesFilter() {
 `UniversalFilter` forwards `variant` to each inner `Select` (`outlined` | `filled` | `standard`). Use `outlined` for tables, `filled` for compact tinted toolbars, and `standard` for dense inline filters.
 
 <div className="showcase">
-  <div className="items">
+  <div className="items" style={{ display: 'flex', justifyContent: 'center', width: '100%', maxWidth: '400px', margin: '0 auto' }}>
     <ThemeWrapper>
       <VariantUniversalFilterCodeDemo />
     </ThemeWrapper>
@@ -544,7 +544,7 @@ export default function VariantsDemo() {
 The badge count reflects `Object.values(selectedFilters).filter(v => v && v !== "All").length`. Mirror active selections as removable `Chip`s so users can verify and clear filters without reopening the popover.
 
 <div className="showcase">
-  <div className="items">
+  <div className="items" style={{ display: 'flex', justifyContent: 'center', width: '100%', maxWidth: '400px', margin: '0 auto' }}>
     <ThemeWrapper>
       <ActiveFilterChipsDemo />
     </ThemeWrapper>

--- a/src/collections/sistent/components/universal-filter/code.mdx
+++ b/src/collections/sistent/components/universal-filter/code.mdx
@@ -72,6 +72,8 @@ export const WithSearchUniversalFilterCodeDemo = () => {
     <Box sx={{ display: "flex", gap: 2, alignItems: "center", flexWrap: "wrap", justifyContent: "center" }}>
       <TextField
         placeholder="Search by name, kind, category"
+        aria-label="Search by name, kind, category"
+        inputProps={{ "aria-label": "Search by name, kind, category" }}
         value={search}
         onChange={(e) => setSearch(e.target.value)}
         size="small"
@@ -240,7 +242,18 @@ export const ActiveFilterChipsDemo = () => {
       />
       <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
         {active.map(([k, v]) => (
-          <Chip key={k} label={`${k}: ${v}`} size="small" onDelete={() => setSelectedFilters((prev) => ({ ...prev, [k]: "All" }))} />
+          <Chip
+            key={k}
+            label={`${k}: ${v}`}
+            size="small"
+            onDelete={() =>
+              setSelectedFilters((prev) => {
+                const next = { ...prev, [k]: "All" };
+                console.log("Applied active", next);
+                return next;
+              })
+            }
+          />
         ))}
       </Box>
     </Box>
@@ -356,6 +369,8 @@ export default function SearchWithUniversalFilter() {
     <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
       <TextField
         placeholder="Search by name, kind, category"
+        aria-label="Search by name, kind, category"
+        inputProps={{ "aria-label": "Search by name, kind, category" }}
         value={search}
         onChange={(e) => setSearch(e.target.value)}
         size="small"
@@ -592,7 +607,13 @@ export default function ActiveFilterChips() {
             key={k}
             label={k + ": " + v}
             size="small"
-            onDelete={() => setSelectedFilters((prev) => ({ ...prev, [k]: "All" }))}
+            onDelete={() =>
+              setSelectedFilters((prev) => {
+                const next = { ...prev, [k]: "All" };
+                console.log("Applied active", next);
+                return next;
+              })
+            }
           />
         ))}
       </Box>

--- a/src/collections/sistent/components/universal-filter/code.mdx
+++ b/src/collections/sistent/components/universal-filter/code.mdx
@@ -1,0 +1,602 @@
+---
+title: UniversalFilter Code
+published: true
+component: universal-filter
+description: Code examples for UniversalFilter demonstrating multi-attribute filtering, search integration, and date-range pickers with quick-range presets.
+---
+
+import { useState } from "react";
+import { UniversalFilter, Box, Typography, Chip, TextField, InputAdornment } from "@sistent/sistent";
+import SearchIcon from "@mui/icons-material/Search";
+import { subtractDays, subtractMonths, subtractYears } from "@sistent/sistent";
+
+export const BasicUniversalFilterCodeDemo = () => {
+  const filters = {
+    status: {
+      name: "Status",
+      options: [
+        { label: "Deployed", value: "deployed" },
+        { label: "Pending", value: "pending" },
+        { label: "Failed", value: "failed" },
+      ],
+    },
+    kind: {
+      name: "Kind",
+      options: [
+        { label: "Deployment", value: "deployment" },
+        { label: "Service", value: "service" },
+        { label: "ConfigMap", value: "configmap" },
+      ],
+    },
+  };
+  const [selectedFilters, setSelectedFilters] = useState({
+    status: "All",
+    kind: "All",
+  });
+  return (
+    <UniversalFilter
+      id="code-basic"
+      filters={filters}
+      selectedFilters={selectedFilters}
+      setSelectedFilters={setSelectedFilters}
+      handleApplyFilter={(next) => console.log("Applied:", next)}
+      variant="outlined"
+    />
+  );
+};
+
+export const WithSearchUniversalFilterCodeDemo = () => {
+  const filters = {
+    visibility: {
+      name: "Visibility",
+      options: [
+        { label: "Public", value: "public" },
+        { label: "Private", value: "private" },
+      ],
+    },
+    category: {
+      name: "Category",
+      options: [
+        { label: "Design", value: "design" },
+        { label: "View", value: "view" },
+        { label: "Model", value: "model" },
+      ],
+    },
+  };
+  const [search, setSearch] = useState("");
+  const [selectedFilters, setSelectedFilters] = useState({
+    visibility: "All",
+    category: "All",
+  });
+  return (
+    <Box sx={{ display: "flex", gap: 2, alignItems: "center", flexWrap: "wrap", justifyContent: "center" }}>
+      <TextField
+        placeholder="Search by name, kind, category"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        size="small"
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchIcon fontSize="small" />
+            </InputAdornment>
+          ),
+        }}
+        sx={{ minWidth: 240 }}
+      />
+      <UniversalFilter
+        id="code-with-search"
+        filters={filters}
+        selectedFilters={selectedFilters}
+        setSelectedFilters={setSelectedFilters}
+        handleApplyFilter={(next) => console.log("Search:", search, "Filters:", next)}
+        variant="outlined"
+      />
+    </Box>
+  );
+};
+
+export const DatePickerUniversalFilterCodeDemo = () => {
+  const filters = {
+    status: {
+      name: "Status",
+      options: [
+        { label: "Active", value: "active" },
+        { label: "Inactive", value: "inactive" },
+      ],
+    },
+  };
+  const [selectedFilters, setSelectedFilters] = useState({ status: "All" });
+  const [selectedDateRange, setSelectedDateRange] = useState({
+    startDate: subtractDays(new Date(), 7),
+    endDate: new Date(),
+  });
+  return (
+    <UniversalFilter
+      id="code-date"
+      filters={filters}
+      selectedFilters={selectedFilters}
+      setSelectedFilters={setSelectedFilters}
+      handleApplyFilter={(next) => console.log("Filters:", next, "Range:", selectedDateRange)}
+      variant="outlined"
+      datePicker
+      selectedDateRange={selectedDateRange}
+      setSelectedDateRange={setSelectedDateRange}
+    />
+  );
+};
+
+export const QuickRangesUniversalFilterCodeDemo = () => {
+  const customQuickRanges = [
+    { label: "Last 7 days", getRange: () => ({ startDate: subtractDays(new Date(), 7), endDate: new Date() }) },
+    { label: "Last 30 days", getRange: () => ({ startDate: subtractDays(new Date(), 30), endDate: new Date() }) },
+    { label: "Last 3 months", getRange: () => ({ startDate: subtractMonths(new Date(), 3), endDate: new Date() }) },
+    { label: "Last 6 months", getRange: () => ({ startDate: subtractMonths(new Date(), 6), endDate: new Date() }) },
+    { label: "Last 1 year", getRange: () => ({ startDate: subtractYears(new Date(), 1), endDate: new Date() }) },
+  ];
+  const filters = {
+    kind: {
+      name: "Kind",
+      options: [
+        { label: "Deployment", value: "deployment" },
+        { label: "Service", value: "service" },
+      ],
+    },
+  };
+  const [selectedFilters, setSelectedFilters] = useState({ kind: "All" });
+  const [selectedDateRange, setSelectedDateRange] = useState({
+    startDate: subtractDays(new Date(), 7),
+    endDate: new Date(),
+  });
+  return (
+    <UniversalFilter
+      id="code-quick"
+      filters={filters}
+      selectedFilters={selectedFilters}
+      setSelectedFilters={setSelectedFilters}
+      handleApplyFilter={(next) => console.log("Quick range", selectedDateRange, next)}
+      variant="outlined"
+      datePicker
+      selectedDateRange={selectedDateRange}
+      setSelectedDateRange={setSelectedDateRange}
+      quickDateRanges={customQuickRanges}
+    />
+  );
+};
+
+export const VariantUniversalFilterCodeDemo = () => {
+  const filters = {
+    owner: {
+      name: "Owner",
+      options: [
+        { label: "Alice", value: "alice" },
+        { label: "Bob", value: "bob" },
+        { label: "Charlie", value: "charlie" },
+      ],
+    },
+  };
+  const [selected, setSelected] = useState({ owner: "All" });
+  return (
+    <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap", justifyContent: "center" }}>
+      <UniversalFilter
+        id="code-variant-outlined"
+        filters={filters}
+        selectedFilters={selected}
+        setSelectedFilters={setSelected}
+        handleApplyFilter={(next) => console.log("Outlined", next)}
+        variant="outlined"
+      />
+      <UniversalFilter
+        id="code-variant-filled"
+        filters={filters}
+        selectedFilters={selected}
+        setSelectedFilters={setSelected}
+        handleApplyFilter={(next) => console.log("Filled", next)}
+        variant="filled"
+      />
+      <UniversalFilter
+        id="code-variant-standard"
+        filters={filters}
+        selectedFilters={selected}
+        setSelectedFilters={setSelected}
+        handleApplyFilter={(next) => console.log("Standard", next)}
+        variant="standard"
+      />
+    </Box>
+  );
+};
+
+export const ActiveFilterChipsDemo = () => {
+  const filters = {
+    status: {
+      name: "Status",
+      options: [
+        { label: "Published", value: "published" },
+        { label: "Unpublished", value: "unpublished" },
+      ],
+    },
+    kind: {
+      name: "Kind",
+      options: [
+        { label: "Deployment", value: "deployment" },
+        { label: "Service", value: "service" },
+      ],
+    },
+  };
+  const [selectedFilters, setSelectedFilters] = useState({
+    status: "published",
+    kind: "deployment",
+  });
+  const active = Object.entries(selectedFilters).filter(([, v]) => v && v !== "All");
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 2 }}>
+      <UniversalFilter
+        id="code-active"
+        filters={filters}
+        selectedFilters={selectedFilters}
+        setSelectedFilters={setSelectedFilters}
+        handleApplyFilter={(next) => console.log("Applied active", next)}
+        variant="outlined"
+      />
+      <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+        {active.map(([k, v]) => (
+          <Chip key={k} label={`${k}: ${v}`} size="small" onDelete={() => setSelectedFilters((prev) => ({ ...prev, [k]: "All" }))} />
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+<a id="Basic UniversalFilter">
+  <h2>Basic UniversalFilter</h2>
+</a>
+
+Multi-attribute filtering with two column filters. Each dimension renders as a `Select` inside the popper; selections are staged locally and committed on **Apply**.
+
+<div className="showcase">
+  <div className="items">
+    <ThemeWrapper>
+      <BasicUniversalFilterCodeDemo />
+    </ThemeWrapper>
+  </div>
+  <CodeBlock name="universal-filter-basic" collapsible code={`import { useState } from "react";
+import { UniversalFilter } from "@sistent/sistent";
+
+const filters = {
+  status: {
+    name: "Status",
+    options: [
+      { label: "Deployed", value: "deployed" },
+      { label: "Pending", value: "pending" },
+      { label: "Failed", value: "failed" },
+    ],
+  },
+  kind: {
+    name: "Kind",
+    options: [
+      { label: "Deployment", value: "deployment" },
+      { label: "Service", value: "service" },
+      { label: "ConfigMap", value: "configmap" },
+    ],
+  },
+};
+
+export default function BasicUniversalFilter() {
+  const [selectedFilters, setSelectedFilters] = useState({
+    status: "All",
+    kind: "All",
+  });
+
+  const handleApplyFilter = (next) => {
+    // next is Record<string, string> with committed values
+    console.log("Applied:", next);
+    // e.g., build API query: omit keys where value === "All"
+  };
+
+  return (
+    <UniversalFilter
+      id="catalog-filter"
+      filters={filters}
+      selectedFilters={selectedFilters}
+      setSelectedFilters={setSelectedFilters}
+      handleApplyFilter={handleApplyFilter}
+      variant="outlined"
+    />
+  );
+}`} />
+</div>
+
+<a id="With Search Input">
+  <h2>With Search Input</h2>
+</a>
+
+Combine a free-text `TextField` search with `UniversalFilter` for mixed query patterns — search narrows by name or description while selects constrain by enumerated attributes. Both inputs should be committed together (e.g., on Apply or via a shared filter handler).
+
+<div className="showcase">
+  <div className="items">
+    <ThemeWrapper>
+      <WithSearchUniversalFilterCodeDemo />
+    </ThemeWrapper>
+  </div>
+  <CodeBlock name="universal-filter-with-search" collapsible code={`import { useState } from "react";
+import { UniversalFilter, TextField, InputAdornment, Box } from "@sistent/sistent";
+import SearchIcon from "@mui/icons-material/Search";
+
+const filters = {
+  visibility: {
+    name: "Visibility",
+    options: [
+      { label: "Public", value: "public" },
+      { label: "Private", value: "private" },
+    ],
+  },
+  category: {
+    name: "Category",
+    options: [
+      { label: "Design", value: "design" },
+      { label: "View", value: "view" },
+      { label: "Model", value: "model" },
+    ],
+  },
+};
+
+export default function SearchWithUniversalFilter() {
+  const [search, setSearch] = useState("");
+  const [selectedFilters, setSelectedFilters] = useState({
+    visibility: "All",
+    category: "All",
+  });
+
+  const handleApplyFilter = (next) => {
+    console.log("Search:", search, "Filters:", next);
+    // Combine search + filters into a single query
+  };
+
+  return (
+    <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
+      <TextField
+        placeholder="Search by name, kind, category"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        size="small"
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchIcon fontSize="small" />
+            </InputAdornment>
+          ),
+        }}
+      />
+      <UniversalFilter
+        id="filter-with-search"
+        filters={filters}
+        selectedFilters={selectedFilters}
+        setSelectedFilters={setSelectedFilters}
+        handleApplyFilter={handleApplyFilter}
+        variant="outlined"
+      />
+    </Box>
+  );
+}`} />
+</div>
+
+<a id="With Date Picker">
+  <h2>With Date Picker</h2>
+</a>
+
+Enable the calendar section by passing `datePicker`, `selectedDateRange`, and `setSelectedDateRange`. The component renders a Quick Ranges selector plus Start/End `DateTimePicker` fields. `DateTimePicker` is lazily loaded and requires optional peers `@mui/x-date-pickers` and `date-fns`.
+
+<div className="showcase">
+  <div className="items">
+    <ThemeWrapper>
+      <DatePickerUniversalFilterCodeDemo />
+    </ThemeWrapper>
+  </div>
+  <CodeBlock name="universal-filter-date-picker" collapsible code={`import { useState } from "react";
+import { UniversalFilter } from "@sistent/sistent";
+import { subtractDays } from "@sistent/sistent";
+
+const filters = {
+  status: {
+    name: "Status",
+    options: [
+      { label: "Active", value: "active" },
+      { label: "Inactive", value: "inactive" },
+    ],
+  },
+};
+
+export default function DatePickerUniversalFilter() {
+  const [selectedFilters, setSelectedFilters] = useState({ status: "All" });
+  const [selectedDateRange, setSelectedDateRange] = useState({
+    startDate: subtractDays(new Date(), 7),
+    endDate: new Date(),
+  });
+
+  return (
+    <UniversalFilter
+      id="filter-with-date"
+      filters={filters}
+      selectedFilters={selectedFilters}
+      setSelectedFilters={setSelectedFilters}
+      handleApplyFilter={(next) => console.log("Filters:", next, "Range:", selectedDateRange)}
+      variant="outlined"
+      datePicker
+      selectedDateRange={selectedDateRange}
+      setSelectedDateRange={setSelectedDateRange}
+    />
+  );
+}`} />
+</div>
+
+<a id="With Quick Ranges">
+  <h2>With Quick Ranges</h2>
+</a>
+
+Override `quickDateRanges` to provide domain-specific presets. Each entry is `{ label, getRange: () => ({ startDate, endDate }) }`. Use `subtractDays`, `subtractMonths`, and `subtractYears` from `@sistent/sistent` for DST-safe, end-of-month-clamped arithmetic.
+
+<div className="showcase">
+  <div className="items">
+    <ThemeWrapper>
+      <QuickRangesUniversalFilterCodeDemo />
+    </ThemeWrapper>
+  </div>
+  <CodeBlock name="universal-filter-quick-ranges" collapsible code={`import { useState } from "react";
+import { UniversalFilter } from "@sistent/sistent";
+import { subtractDays, subtractMonths, subtractYears } from "@sistent/sistent";
+
+const customQuickRanges = [
+  { label: "Last 7 days", getRange: () => ({ startDate: subtractDays(new Date(), 7), endDate: new Date() }) },
+  { label: "Last 30 days", getRange: () => ({ startDate: subtractDays(new Date(), 30), endDate: new Date() }) },
+  { label: "Last 3 months", getRange: () => ({ startDate: subtractMonths(new Date(), 3), endDate: new Date() }) },
+  { label: "Last 6 months", getRange: () => ({ startDate: subtractMonths(new Date(), 6), endDate: new Date() }) },
+  { label: "Last 1 year", getRange: () => ({ startDate: subtractYears(new Date(), 1), endDate: new Date() }) },
+];
+
+export default function QuickRangesFilter() {
+  const filters = {
+    kind: {
+      name: "Kind",
+      options: [
+        { label: "Deployment", value: "deployment" },
+        { label: "Service", value: "service" },
+      ],
+    },
+  };
+  const [selectedFilters, setSelectedFilters] = useState({ kind: "All" });
+  const [selectedDateRange, setSelectedDateRange] = useState({
+    startDate: subtractDays(new Date(), 7),
+    endDate: new Date(),
+  });
+
+  return (
+    <UniversalFilter
+      id="filter-quick-ranges"
+      filters={filters}
+      selectedFilters={selectedFilters}
+      setSelectedFilters={setSelectedFilters}
+      handleApplyFilter={(next) => console.log("Quick range", selectedDateRange, next)}
+      variant="outlined"
+      datePicker
+      selectedDateRange={selectedDateRange}
+      setSelectedDateRange={setSelectedDateRange}
+      quickDateRanges={customQuickRanges}
+    />
+  );
+}`} />
+</div>
+
+<a id="Variants">
+  <h2>Variants</h2>
+</a>
+
+`UniversalFilter` forwards `variant` to each inner `Select` (`outlined` | `filled` | `standard`). Use `outlined` for tables, `filled` for compact tinted toolbars, and `standard` for dense inline filters.
+
+<div className="showcase">
+  <div className="items">
+    <ThemeWrapper>
+      <VariantUniversalFilterCodeDemo />
+    </ThemeWrapper>
+  </div>
+  <CodeBlock name="universal-filter-variants" collapsible code={`import { useState } from "react";
+import { UniversalFilter, Box } from "@sistent/sistent";
+
+const filters = {
+  owner: {
+    name: "Owner",
+    options: [
+      { label: "Alice", value: "alice" },
+      { label: "Bob", value: "bob" },
+      { label: "Charlie", value: "charlie" },
+    ],
+  },
+};
+
+function VariantFilter({ variant }) {
+  const [selected, setSelected] = useState({ owner: "All" });
+  return (
+    <UniversalFilter
+      id={"filter-variant-" + variant}
+      filters={filters}
+      selectedFilters={selected}
+      setSelectedFilters={setSelected}
+      handleApplyFilter={(next) => console.log(variant, next)}
+      variant={variant}
+    />
+  );
+}
+
+export default function VariantsDemo() {
+  return (
+    <Box sx={{ display: "flex", gap: 2 }}>
+      <VariantFilter variant="outlined" />
+      <VariantFilter variant="filled" />
+      <VariantFilter variant="standard" />
+    </Box>
+  );
+}`} />
+</div>
+
+<a id="Active Filters Display">
+  <h2>Active Filters Display</h2>
+</a>
+
+The badge count reflects `Object.values(selectedFilters).filter(v => v && v !== "All").length`. Mirror active selections as removable `Chip`s so users can verify and clear filters without reopening the popover.
+
+<div className="showcase">
+  <div className="items">
+    <ThemeWrapper>
+      <ActiveFilterChipsDemo />
+    </ThemeWrapper>
+  </div>
+  <CodeBlock name="universal-filter-active-chips" collapsible code={`import { useState } from "react";
+import { UniversalFilter, Box, Chip } from "@sistent/sistent";
+
+const filters = {
+  status: {
+    name: "Status",
+    options: [
+      { label: "Published", value: "published" },
+      { label: "Unpublished", value: "unpublished" },
+    ],
+  },
+  kind: {
+    name: "Kind",
+    options: [
+      { label: "Deployment", value: "deployment" },
+      { label: "Service", value: "service" },
+    ],
+  },
+};
+
+export default function ActiveFilterChips() {
+  const [selectedFilters, setSelectedFilters] = useState({
+    status: "published",
+    kind: "deployment",
+  });
+  const active = Object.entries(selectedFilters).filter(([, v]) => v && v !== "All");
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 2 }}>
+      <UniversalFilter
+        id="filter-active-chips"
+        filters={filters}
+        selectedFilters={selectedFilters}
+        setSelectedFilters={setSelectedFilters}
+        handleApplyFilter={(next) => console.log("Applied active", next)}
+        variant="outlined"
+      />
+      <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+        {active.map(([k, v]) => (
+          <Chip
+            key={k}
+            label={k + ": " + v}
+            size="small"
+            onDelete={() => setSelectedFilters((prev) => ({ ...prev, [k]: "All" }))}
+          />
+        ))}
+      </Box>
+    </Box>
+  );
+}`} />
+</div>

--- a/src/collections/sistent/components/universal-filter/guidance.mdx
+++ b/src/collections/sistent/components/universal-filter/guidance.mdx
@@ -1,0 +1,263 @@
+---
+title: UniversalFilter Guidance
+published: true
+component: universal-filter
+description: Guidance for filter schemas, date-range picker integrations, quick date options, and active filter handling when using UniversalFilter across tables and catalogs.
+---
+
+import { useState } from "react";
+import { UniversalFilter, Box, Typography, Chip, Button } from "@sistent/sistent";
+import { subtractDays, subtractMonths, subtractYears } from "@sistent/sistent";
+
+export const SchemaDemo = () => {
+  const filters = {
+    status: {
+      name: "Status",
+      options: [
+        { label: "Running", value: "running" },
+        { label: "Stopped", value: "stopped" },
+        { label: "Error", value: "error" },
+      ],
+    },
+    environment: {
+      name: "Environment",
+      options: [
+        { label: "Production", value: "production" },
+        { label: "Staging", value: "staging" },
+        { label: "Development", value: "development" },
+      ],
+    },
+  };
+  const [selected, setSelected] = useState({ status: "All", environment: "All" });
+  return (
+    <UniversalFilter
+      id="guidance-schema"
+      filters={filters}
+      selectedFilters={selected}
+      setSelectedFilters={setSelected}
+      handleApplyFilter={(next) => console.log("Applied schema filters", next)}
+      variant="outlined"
+    />
+  );
+};
+
+export const DatePickerGuidanceDemo = () => {
+  const filters = {
+    type: {
+      name: "Type",
+      options: [
+        { label: "Design", value: "design" },
+        { label: "Filter", value: "filter" },
+      ],
+    },
+  };
+  const [selected, setSelected] = useState({ type: "All" });
+  const [range, setRange] = useState({
+    startDate: subtractDays(new Date(), 30),
+    endDate: new Date(),
+  });
+  return (
+    <UniversalFilter
+      id="guidance-date"
+      filters={filters}
+      selectedFilters={selected}
+      setSelectedFilters={setSelected}
+      handleApplyFilter={() => console.log("Applied with date range", range)}
+      variant="outlined"
+      datePicker
+      selectedDateRange={range}
+      setSelectedDateRange={setRange}
+    />
+  );
+};
+
+export const QuickRangesGuidanceDemo = () => {
+  const customQuickRanges = [
+    { label: "Last 7 days", getRange: () => ({ startDate: subtractDays(new Date(), 7), endDate: new Date() }) },
+    { label: "Last 30 days", getRange: () => ({ startDate: subtractDays(new Date(), 30), endDate: new Date() }) },
+    { label: "Last 90 days", getRange: () => ({ startDate: subtractDays(new Date(), 90), endDate: new Date() }) },
+  ];
+  const filters = {
+    owner: {
+      name: "Owner",
+      options: [
+        { label: "Alice", value: "alice" },
+        { label: "Bob", value: "bob" },
+      ],
+    },
+  };
+  const [selected, setSelected] = useState({ owner: "All" });
+  const [range, setRange] = useState({
+    startDate: subtractDays(new Date(), 7),
+    endDate: new Date(),
+  });
+  return (
+    <UniversalFilter
+      id="guidance-quick"
+      filters={filters}
+      selectedFilters={selected}
+      setSelectedFilters={setSelected}
+      handleApplyFilter={() => console.log("Applied quick range", range)}
+      variant="outlined"
+      datePicker
+      selectedDateRange={range}
+      setSelectedDateRange={setRange}
+      quickDateRanges={customQuickRanges}
+    />
+  );
+};
+
+export const ActiveFiltersGuidanceDemo = () => {
+  const filters = {
+    kind: {
+      name: "Kind",
+      options: [
+        { label: "Deployment", value: "deployment" },
+        { label: "Service", value: "service" },
+      ],
+    },
+    status: {
+      name: "Status",
+      options: [
+        { label: "Active", value: "active" },
+        { label: "Inactive", value: "inactive" },
+      ],
+    },
+  };
+  const [selected, setSelected] = useState({ kind: "deployment", status: "All" });
+  const active = Object.entries(selected).filter(([, v]) => v && v !== "All");
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 2 }}>
+      <UniversalFilter
+        id="guidance-active"
+        filters={filters}
+        selectedFilters={selected}
+        setSelectedFilters={setSelected}
+        handleApplyFilter={(next) => console.log("Applied", next)}
+        variant="outlined"
+      />
+      <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+        {active.map(([k, v]) => (
+          <Chip key={k} label={`${k}: ${v}`} size="small" onDelete={() => setSelected((prev) => ({ ...prev, [k]: "All" }))} />
+        ))}
+        {active.length === 0 && <Typography variant="body2" color="text.secondary">No active filters — all records shown</Typography>}
+      </Box>
+    </Box>
+  );
+};
+
+<a id="Filter Schemas">
+  <h2>Filter Schemas</h2>
+</a>
+
+<p>
+  Each filter dimension is declared as a <code>FilterColumn</code>: <code>{`{ name: string, options: { label: string, value: string }[] }`}</code>. The <code>filters</code> prop is a record keyed by an internal field name (e.g., <code>status</code>, <code>kind</code>) whose value carries the display <code>name</code> and selectable <code>options</code>. Keep keys stable and lowercase slug-style so they match API query parameters and table column <code>name</code> fields.
+</p>
+
+<ul>
+  <li><strong>Shape:</strong> <code>Record&lt;string, FilterColumn&gt;</code> — e.g., <code>{`{ status: { name: "Status", options: [...] } }`}</code>.</li>
+  <li><strong>Label vs Value:</strong> <code>label</code> is user-facing; <code>value</code> is the wire value sent to <code>handleApplyFilter</code> and typically used in URL search params or API filters.</li>
+  <li><strong>Show All:</strong> When <code>showAllOption</code> is <code>true</code> (default), an <code>All</code> option is prepended. Selecting <code>All</code> signals no constraint for that dimension — consumers should omit that key when building queries.</li>
+  <li><strong>Staging vs Commit:</strong> Internally the component stages selections in local state and only commits them to <code>selectedFilters</code> and <code>handleApplyFilter</code> on <strong>Apply</strong>. Do not trigger data fetching on every select change; wait for the Apply event.</li>
+</ul>
+
+<Row className="image-container">
+  <ThemeWrapper>
+    <div style={{ display: "flex", justifyContent: "center", width: "100%", padding: "1rem" }}>
+      <SchemaDemo />
+    </div>
+  </ThemeWrapper>
+</Row>
+
+<a id="Date-Range Picker Integration">
+  <h2>Date-Range Picker Integration</h2>
+</a>
+
+<p>
+  Set <code>datePicker</code> to enable calendar filtering. You must also provide <code>selectedDateRange</code> and <code>setSelectedDateRange</code>. The component then renders a Quick Ranges selector plus two lazily-loaded <code>DateTimePicker</code> fields (Start/End). The pickers clamp values so <code>startDate ≤ endDate</code>.
+</p>
+
+<ul>
+  <li><strong>Peer dependencies:</strong> <code>DateTimePicker</code> is code-split and requires optional peers <code>@mui/x-date-pickers</code> and <code>@mui/lab</code> / <code>date-fns</code> adapter. If those are not installed, rendering with <code>datePicker</code> will throw with installation guidance.</li>
+  <li><strong>Range type:</strong> <code>DateRange = {`{ startDate: Date, endDate: Date }`}</code>. Always construct new <code>Date</code> objects; avoid mutating the existing range in place.</li>
+  <li><strong>Placement:</strong> Keep the date section visually grouped below column filters. The built-in layout already enforces this order.</li>
+  <li><strong>Validation:</strong> When the user picks a Start after the current End, the component clamps End to Start (and vice versa). Re-validate on Apply if your API requires inclusive/exclusive bounds.</li>
+</ul>
+
+<Row className="image-container">
+  <ThemeWrapper>
+    <div style={{ display: "flex", justifyContent: "center", width: "100%", padding: "1rem" }}>
+      <DatePickerGuidanceDemo />
+    </div>
+  </ThemeWrapper>
+</Row>
+
+<a id="Quick Date Options">
+  <h2>Quick Date Options</h2>
+</a>
+
+<p>
+  Quick ranges are declared as <code>QuickDateRangeOption[]</code> where each entry is <code>{`{ label: string, getRange: () => DateRange }`}</code>. The component ships with defaults for <code>Last 7 days</code>, <code>Last 30 days</code>, <code>Last 3 months</code>, <code>Last 6 months</code>, and <code>Last 1 year</code>, computed via <code>subtractDays</code>, <code>subtractMonths</code>, and <code>subtractYears</code> (end-of-month clamped, DST-safe). Override with <code>quickDateRanges</code> when domain presets differ.
+</p>
+
+<ul>
+  <li><strong>Defaults:</strong> Import <code>subtractDays</code>, <code>subtractMonths</code>, <code>subtractYears</code> from <code>@sistent/sistent</code> to build consistent ranges.</li>
+  <li><strong>Custom presets:</strong> Provide only the ranges relevant to the view (e.g., Last 24 hours for logs, Last 90 days for audits). Keep labels concise and sorted ascending by duration.</li>
+  <li><strong>Locale safety:</strong> Helpers use local-time day arithmetic and month-clamping so Feb 29 → Feb 28 and DST boundaries do not drift by an hour.</li>
+</ul>
+
+<Row className="image-container">
+  <ThemeWrapper>
+    <div style={{ display: "flex", justifyContent: "center", width: "100%", padding: "1rem" }}>
+      <QuickRangesGuidanceDemo />
+    </div>
+  </ThemeWrapper>
+</Row>
+
+<a id="Active Filters Handling">
+  <h2>Active Filters Handling</h2>
+</a>
+
+<p>
+  Active filters are those where <code>selectedFilters[key] !== "All"</code> and the value is non-empty. The badge count is <code>Object.values(selectedFilters).filter(v =&gt; v &amp;&amp; v !== "All").length</code>. Treat this as the source of truth for both the badge and any external chip/toggle UI.
+</p>
+
+<ul>
+  <li><strong>Badge:</strong> The trigger badge automatically hides when count is zero (<code>invisible={count===0}</code>).</li>
+  <li><strong>External feedback:</strong> Mirror active selections as removable <code>Chip</code>s or summary text so users need not reopen the popover to confirm scope. Deleting a chip should set that key back to <code>All</code> and re-apply.</li>
+  <li><strong>URL sync:</strong> Persist active filters in URL search params so filtered views are shareable. On mount, hydrate <code>selectedFilters</code> from the URL; on Apply, write back. Exclude <code>All</code> entries.</li>
+  <li><strong>Empty state:</strong> When all dimensions are <code>All</code> and the date range is the default, show “No active filters” rather than an empty chip row.</li>
+  <li><strong>Clear action:</strong> Offer a “Clear all” control that resets every key to <code>All</code> (and the range to the default preset) and triggers <code>handleApplyFilter</code> with the cleared record.</li>
+</ul>
+
+<Row className="image-container">
+  <ThemeWrapper>
+    <div style={{ display: "flex", justifyContent: "center", width: "100%", padding: "1rem" }}>
+      <ActiveFiltersGuidanceDemo />
+    </div>
+  </ThemeWrapper>
+</Row>
+
+<a id="Do">
+  <h2>Do</h2>
+</a>
+
+<ul>
+  <li>Use a single UniversalFilter per toolbar — consolidate dimensions rather than rendering multiple filter popovers.</li>
+  <li>Provide a stable, unique <code>id</code> per table instance to keep <code>data-testid</code> attributes deterministic for tests.</li>
+  <li>Keep option lists under ~15 items; for larger vocabularies, prefer a searchable multi-select or server-driven autocomplete.</li>
+  <li>Use <code>variant="outlined"</code> to match Meshery table density; switch to <code>filled</code> only inside compact toolbars with tinted surfaces.</li>
+  <li>Close the popover after Apply and move focus back to the trigger for keyboard continuity.</li>
+</ul>
+
+<a id="Dont">
+  <h2>Don't</h2>
+</a>
+
+<ul>
+  <li>Do not trigger data fetching on every select change — wait for the Apply action to avoid excessive requests.</li>
+  <li>Do not mutate <code>selectedDateRange</code> in place; always pass a new object via <code>setSelectedDateRange</code>.</li>
+  <li>Do not omit the <code>id</code> prop when multiple tables share a view — duplicated test IDs make e2e selectors ambiguous.</li>
+  <li>Do not hide the Active count and rely on color alone; pair badge feedback with textual chips or summaries.</li>
+  <li>Do not set <code>showAllOption={false}</code> without providing a clear default or allowing deselection — users need a path back to “no constraint”.</li>
+</ul>

--- a/src/collections/sistent/components/universal-filter/guidance.mdx
+++ b/src/collections/sistent/components/universal-filter/guidance.mdx
@@ -138,7 +138,18 @@ export const ActiveFiltersGuidanceDemo = () => {
       />
       <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
         {active.map(([k, v]) => (
-          <Chip key={k} label={`${k}: ${v}`} size="small" onDelete={() => setSelected((prev) => ({ ...prev, [k]: "All" }))} />
+          <Chip
+            key={k}
+            label={`${k}: ${v}`}
+            size="small"
+            onDelete={() =>
+              setSelected((prev) => {
+                const next = { ...prev, [k]: "All" };
+                console.log("Applied", next);
+                return next;
+              })
+            }
+          />
         ))}
         {active.length === 0 && <Typography variant="body2" color="text.secondary">No active filters — all records shown</Typography>}
       </Box>
@@ -223,7 +234,7 @@ export const ActiveFiltersGuidanceDemo = () => {
 </p>
 
 <ul>
-  <li><strong>Badge:</strong> The trigger badge automatically hides when count is zero (<code>invisible={count===0}</code>).</li>
+  <li><strong>Badge:</strong> The trigger badge automatically hides when count is zero (<code>invisible=&#123;count===0&#125;</code>).</li>
   <li><strong>External feedback:</strong> Mirror active selections as removable <code>Chip</code>s or summary text so users need not reopen the popover to confirm scope. Deleting a chip should set that key back to <code>All</code> and re-apply.</li>
   <li><strong>URL sync:</strong> Persist active filters in URL search params so filtered views are shareable. On mount, hydrate <code>selectedFilters</code> from the URL; on Apply, write back. Exclude <code>All</code> entries.</li>
   <li><strong>Empty state:</strong> When all dimensions are <code>All</code> and the date range is the default, show “No active filters” rather than an empty chip row.</li>
@@ -259,5 +270,5 @@ export const ActiveFiltersGuidanceDemo = () => {
   <li>Do not mutate <code>selectedDateRange</code> in place; always pass a new object via <code>setSelectedDateRange</code>.</li>
   <li>Do not omit the <code>id</code> prop when multiple tables share a view — duplicated test IDs make e2e selectors ambiguous.</li>
   <li>Do not hide the Active count and rely on color alone; pair badge feedback with textual chips or summaries.</li>
-  <li>Do not set <code>showAllOption={false}</code> without providing a clear default or allowing deselection — users need a path back to “no constraint”.</li>
+  <li>Do not set <code>showAllOption=&#123;false&#125;</code> without providing a clear default or allowing deselection — users need a path back to “no constraint”.</li>
 </ul>

--- a/src/collections/sistent/components/universal-filter/guidance.mdx
+++ b/src/collections/sistent/components/universal-filter/guidance.mdx
@@ -158,7 +158,7 @@ export const ActiveFiltersGuidanceDemo = () => {
   <li><strong>Shape:</strong> <code>Record&lt;string, FilterColumn&gt;</code> — e.g., <code>{`{ status: { name: "Status", options: [...] } }`}</code>.</li>
   <li><strong>Label vs Value:</strong> <code>label</code> is user-facing; <code>value</code> is the wire value sent to <code>handleApplyFilter</code> and typically used in URL search params or API filters.</li>
   <li><strong>Show All:</strong> When <code>showAllOption</code> is <code>true</code> (default), an <code>All</code> option is prepended. Selecting <code>All</code> signals no constraint for that dimension — consumers should omit that key when building queries.</li>
-  <li><strong>Staging vs Commit:</strong> Internally the component stages selections in local state and only commits them to <code>selectedFilters</code> and <code>handleApplyFilter</code> on <strong>Apply</strong>. Do not trigger data fetching on every select change; wait for the Apply event.</li>
+  <li><strong>Staging vs Commit:</strong> Internally column-filter selections are staged as <code>draftFilters</code> and only committed to <code>selectedFilters</code> via <code>handleApplyFilter</code> on <strong>Apply</strong>. Date-range changes are not staged — <code>handleQuickRangeChange</code>, <code>handleStartDateChange</code> and <code>handleEndDateChange</code> call <code>setSelectedDateRange</code> immediately. Do not trigger data fetching on every select change for column filters; wait for the Apply event, while date-range consumers should react to <code>selectedDateRange</code> updates directly.</li>
 </ul>
 
 <Row className="image-container">
@@ -174,11 +174,11 @@ export const ActiveFiltersGuidanceDemo = () => {
 </a>
 
 <p>
-  Set <code>datePicker</code> to enable calendar filtering. You must also provide <code>selectedDateRange</code> and <code>setSelectedDateRange</code>. The component then renders a Quick Ranges selector plus two lazily-loaded <code>DateTimePicker</code> fields (Start/End). The pickers clamp values so <code>startDate ≤ endDate</code>.
+  Set <code>datePicker</code> to enable calendar filtering. You must also provide <code>selectedDateRange</code> and <code>setSelectedDateRange</code>. The component then renders a Quick Ranges selector plus two lazily-loaded <code>DateTimePicker</code> fields (Start/End). The pickers clamp values so <code>startDate ≤ endDate</code>. Unlike column filters, quick-range and Start/End changes propagate immediately via <code>setSelectedDateRange</code> — they are not staged as <code>draftFilters</code> until Apply (Apply only commits column filters).
 </p>
 
 <ul>
-  <li><strong>Peer dependencies:</strong> <code>DateTimePicker</code> is code-split and requires optional peers <code>@mui/x-date-pickers</code> and <code>@mui/lab</code> / <code>date-fns</code> adapter. If those are not installed, rendering with <code>datePicker</code> will throw with installation guidance.</li>
+  <li><strong>Peer dependencies:</strong> <code>DateTimePicker</code> is code-split and requires optional peers <code>@mui/x-date-pickers</code> and <code>date-fns</code>. If those are not installed, rendering with <code>datePicker</code> will throw with installation guidance.</li>
   <li><strong>Range type:</strong> <code>DateRange = {`{ startDate: Date, endDate: Date }`}</code>. Always construct new <code>Date</code> objects; avoid mutating the existing range in place.</li>
   <li><strong>Placement:</strong> Keep the date section visually grouped below column filters. The built-in layout already enforces this order.</li>
   <li><strong>Validation:</strong> When the user picks a Start after the current End, the component clamps End to Start (and vice versa). Re-validate on Apply if your API requires inclusive/exclusive bounds.</li>
@@ -247,7 +247,7 @@ export const ActiveFiltersGuidanceDemo = () => {
   <li>Provide a stable, unique <code>id</code> per table instance to keep <code>data-testid</code> attributes deterministic for tests.</li>
   <li>Keep option lists under ~15 items; for larger vocabularies, prefer a searchable multi-select or server-driven autocomplete.</li>
   <li>Use <code>variant="outlined"</code> to match Meshery table density; switch to <code>filled</code> only inside compact toolbars with tinted surfaces.</li>
-  <li>Close the popover after Apply and move focus back to the trigger for keyboard continuity.</li>
+  <li>Close the popover/sheet after Apply via the built-in <code>handleClose</code>; if you need keyboard focus to return to the trigger, manage focus restoration in the consumer (the component does not explicitly restore focus after Apply).</li>
 </ul>
 
 <a id="Dont">
@@ -255,7 +255,7 @@ export const ActiveFiltersGuidanceDemo = () => {
 </a>
 
 <ul>
-  <li>Do not trigger data fetching on every select change — wait for the Apply action to avoid excessive requests.</li>
+  <li>Do not trigger data fetching on every column-filter select change — wait for the Apply action to avoid excessive requests. Date-range changes are immediate via <code>setSelectedDateRange</code>, so handle them separately if they should also be Apply-gated.</li>
   <li>Do not mutate <code>selectedDateRange</code> in place; always pass a new object via <code>setSelectedDateRange</code>.</li>
   <li>Do not omit the <code>id</code> prop when multiple tables share a view — duplicated test IDs make e2e selectors ambiguous.</li>
   <li>Do not hide the Active count and rely on color alone; pair badge feedback with textual chips or summaries.</li>

--- a/src/collections/sistent/components/universal-filter/index.mdx
+++ b/src/collections/sistent/components/universal-filter/index.mdx
@@ -128,7 +128,7 @@ UniversalFilter is a centralized, multi-attribute filtering control used across 
   <h2>Overview</h2>
 </a>
 
-The **UniversalFilter** component organizes multiple filter dimensions behind a single **Filter** icon button. On desktop the controls appear in a `Popper` anchored to the trigger; on mobile (`sm` breakpoint) they render in a `Dialog`/`Drawer` for accessible touch interaction. Each filter dimension maps to a `Select` with an optional **All** pass-through option, and an **Apply** button commits the staged selections via `handleApplyFilter`.
+The **UniversalFilter** component organizes multiple filter dimensions behind a single **Filter** icon button. On desktop the controls appear in a `Popper` anchored to the trigger; on mobile (`sm` breakpoint) they render in a `BottomSheet` for accessible touch interaction. Each filter dimension maps to a `Select` with an optional **All** pass-through option. Column-filter selections are staged as `draftFilters` and committed on **Apply** via `handleApplyFilter`, while date-range changes propagate immediately through `setSelectedDateRange`.
 
 Use UniversalFilter when filtering tables or catalogs by several attributes at once — such as status, kind, category, or visibility — and when a unified active-filter count and responsive presentation are required. It is typically placed in the right section of `DataTableToolbar` alongside `SearchBar`, `TableVisibilityControl`, and `ViewSwitch`.
 
@@ -148,11 +148,11 @@ Use UniversalFilter when filtering tables or catalogs by several attributes at o
 
 <ul>
   <li><strong>Filter Trigger</strong> — An icon button (`FilterAlt` icon) wrapped in a `Badge` that shows the count of active (non-“All”) selections.</li>
-  <li><strong>Container</strong> — A `Popper` on desktop and a `Dialog` on mobile (`useMediaQuery(theme.breakpoints.down("sm"))`). Both are anchored to the trigger and close via `ClickAwayListener` / `onClose`.</li>
+  <li><strong>Container</strong> — A `Popper` on desktop and a `BottomSheet` on mobile (`useMediaQuery(theme.breakpoints.down("sm"))`). The desktop popper is anchored to the trigger and uses `ClickAwayListener`; the mobile sheet uses `BottomSheet` `onClose` handling.</li>
   <li><strong>Header</strong> — A tinted header bar displaying “Filters:” when rendered in popper mode.</li>
   <li><strong>Filter Groups</strong> — One group per key in `filters`. Each group renders an `InputLabel` (`FilterColumn.name`) and a `Select` populated from `FilterColumn.options` plus an optional **All** option.</li>
-  <li><strong>Date-Range Section</strong> (optional) — Rendered when `datePicker` is true and `selectedDateRange`/`setSelectedDateRange` are provided. Contains a **Quick Ranges** select and two `DateTimePicker` fields (Start/End).</li>
-  <li><strong>Apply Action</strong> — A contained `Button` labeled “Apply” that copies staged values to `selectedFilters` and invokes `handleApplyFilter`.</li>
+  <li><strong>Date-Range Section</strong> (optional) — Rendered when `datePicker` is true and `selectedDateRange`/`setSelectedDateRange` are provided. Contains a **Quick Ranges** select and two `DateTimePicker` fields (Start/End). Quick-range, Start and End changes call `setSelectedDateRange` immediately — they are not staged.</li>
+  <li><strong>Apply Action</strong> — A contained `Button` labeled “Apply” that commits staged column-filter selections (`draftFilters` → `selectedFilters`) and invokes `handleApplyFilter`. Date-range updates are already propagated via `setSelectedDateRange` before Apply.</li>
 </ul>
 
 <a id="Variants">
@@ -204,5 +204,5 @@ The badge count derives from `Object.values(selectedFilters).filter(v => v && v 
   <li>Each group is wrapped with `role="presentation"` and a `data-testid` of the form `{id}-filter-group-{key}`; labels and selects expose `{id}-label-{key}` and `{id}-select-{key}` for assistive and test targeting.</li>
   <li>The date-range section exposes `{id}-date-range`, `{id}-quick-range-select`, `{id}-start-date`, and `{id}-end-date` data attributes.</li>
   <li>Ensure every Filter trigger receives a unique `id` prop so `data-testid` values remain deterministic across multiple tables on the same page.</li>
-  <li>Keyboard users can open the filter, tab through selects, and activate **Apply** without losing focus context; the popper uses `ClickAwayListener` with `mouseEvent="onMouseDown"` and `touchEvent="onTouchStart"` to preserve expected dismissal semantics.</li>
+  <li>Keyboard users can open the filter, tab through selects, and activate **Apply**; the desktop popper uses `ClickAwayListener` with `mouseEvent="onMouseDown"` and `touchEvent="onTouchStart"` to preserve expected dismissal semantics. The component closes via `handleClose` on Apply but does not explicitly restore focus to the trigger — consumers should manage focus restoration if needed for their keyboard workflow.</li>
 </ul>

--- a/src/collections/sistent/components/universal-filter/index.mdx
+++ b/src/collections/sistent/components/universal-filter/index.mdx
@@ -1,8 +1,9 @@
 ---
-title: UniversalFilter
+name: "Universal Filter"
+title: Universal Filter
 published: true
 component: universal-filter
-description: UniversalFilter is a multi-attribute popover filtering component for tables and catalogs, supporting column-based selects, date-range pickers, quick-range presets, and active-filter badge counts.
+description: The Universal Filter provides a single, reusable control for filtering tables and catalogs across multiple attributes, with optional date-range selection.
 ---
 
 import { useState } from "react";

--- a/src/collections/sistent/components/universal-filter/index.mdx
+++ b/src/collections/sistent/components/universal-filter/index.mdx
@@ -1,0 +1,208 @@
+---
+title: UniversalFilter
+published: true
+component: universal-filter
+description: UniversalFilter is a multi-attribute popover filtering component for tables and catalogs, supporting column-based selects, date-range pickers, quick-range presets, and active-filter badge counts.
+---
+
+import { useState } from "react";
+import { UniversalFilter, Box, Typography, Chip } from "@sistent/sistent";
+import { subtractDays, subtractMonths, subtractYears } from "@sistent/sistent";
+
+export const BasicUniversalFilterDemo = () => {
+  const filters = {
+    status: {
+      name: "Status",
+      options: [
+        { label: "Deployed", value: "deployed" },
+        { label: "Pending", value: "pending" },
+        { label: "Failed", value: "failed" },
+      ],
+    },
+    kind: {
+      name: "Kind",
+      options: [
+        { label: "Deployment", value: "deployment" },
+        { label: "Service", value: "service" },
+        { label: "ConfigMap", value: "configmap" },
+      ],
+    },
+  };
+  const [selectedFilters, setSelectedFilters] = useState({
+    status: "All",
+    kind: "All",
+  });
+  const handleApplyFilter = (next) => {
+    console.log("Applied filters:", next ?? selectedFilters);
+  };
+  return (
+    <UniversalFilter
+      id="demo-basic"
+      filters={filters}
+      selectedFilters={selectedFilters}
+      setSelectedFilters={setSelectedFilters}
+      handleApplyFilter={handleApplyFilter}
+      variant="outlined"
+    />
+  );
+};
+
+export const DatePickerUniversalFilterDemo = () => {
+  const filters = {
+    category: {
+      name: "Category",
+      options: [
+        { label: "Design", value: "design" },
+        { label: "View", value: "view" },
+        { label: "Model", value: "model" },
+      ],
+    },
+  };
+  const [selectedFilters, setSelectedFilters] = useState({ category: "All" });
+  const [selectedDateRange, setSelectedDateRange] = useState({
+    startDate: subtractDays(new Date(), 7),
+    endDate: new Date(),
+  });
+  return (
+    <UniversalFilter
+      id="demo-date"
+      filters={filters}
+      selectedFilters={selectedFilters}
+      setSelectedFilters={setSelectedFilters}
+      handleApplyFilter={(next) => console.log("Applied:", next, selectedDateRange)}
+      variant="outlined"
+      datePicker
+      selectedDateRange={selectedDateRange}
+      setSelectedDateRange={setSelectedDateRange}
+    />
+  );
+};
+
+export const ActiveFiltersDemo = () => {
+  const filters = {
+    status: {
+      name: "Status",
+      options: [
+        { label: "Published", value: "published" },
+        { label: "Unpublished", value: "unpublished" },
+      ],
+    },
+    visibility: {
+      name: "Visibility",
+      options: [
+        { label: "Public", value: "public" },
+        { label: "Private", value: "private" },
+      ],
+    },
+  };
+  const [selectedFilters, setSelectedFilters] = useState({
+    status: "published",
+    visibility: "private",
+  });
+  const activeCount = Object.values(selectedFilters).filter((v) => v && v !== "All").length;
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2, alignItems: "center" }}>
+      <UniversalFilter
+        id="demo-active"
+        filters={filters}
+        selectedFilters={selectedFilters}
+        setSelectedFilters={setSelectedFilters}
+        handleApplyFilter={(next) => console.log("Applied:", next)}
+        variant="outlined"
+      />
+      <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", justifyContent: "center" }}>
+        {Object.entries(selectedFilters)
+          .filter(([, v]) => v && v !== "All")
+          .map(([k, v]) => (
+            <Chip key={k} label={`${k}: ${v}`} size="small" />
+          ))}
+        {activeCount === 0 && <Typography variant="body2" color="text.secondary">No active filters</Typography>}
+      </Box>
+    </Box>
+  );
+};
+
+UniversalFilter is a centralized, multi-attribute filtering control used across Meshery and Kanvas for tables, catalogs, and list views. It consolidates column-based select filters and an optional date-range picker into a single trigger with a badge-count indicator, keeping toolbars compact while supporting complex filter combinations.
+
+<a id="Overview">
+  <h2>Overview</h2>
+</a>
+
+The **UniversalFilter** component organizes multiple filter dimensions behind a single **Filter** icon button. On desktop the controls appear in a `Popper` anchored to the trigger; on mobile (`sm` breakpoint) they render in a `Dialog`/`Drawer` for accessible touch interaction. Each filter dimension maps to a `Select` with an optional **All** pass-through option, and an **Apply** button commits the staged selections via `handleApplyFilter`.
+
+Use UniversalFilter when filtering tables or catalogs by several attributes at once — such as status, kind, category, or visibility — and when a unified active-filter count and responsive presentation are required. It is typically placed in the right section of `DataTableToolbar` alongside `SearchBar`, `TableVisibilityControl`, and `ViewSwitch`.
+
+<Row className="image-container">
+  <ThemeWrapper>
+    <div style={{ display: "flex", justifyContent: "center", width: "100%", padding: "1rem" }}>
+      <BasicUniversalFilterDemo />
+    </div>
+  </ThemeWrapper>
+</Row>
+
+<a id="Anatomy">
+  <h2>Anatomy</h2>
+</a>
+
+<p>A Sistent UniversalFilter is composed of the following parts:</p>
+
+<ul>
+  <li><strong>Filter Trigger</strong> — An icon button (`FilterAlt` icon) wrapped in a `Badge` that shows the count of active (non-“All”) selections.</li>
+  <li><strong>Container</strong> — A `Popper` on desktop and a `Dialog` on mobile (`useMediaQuery(theme.breakpoints.down("sm"))`). Both are anchored to the trigger and close via `ClickAwayListener` / `onClose`.</li>
+  <li><strong>Header</strong> — A tinted header bar displaying “Filters:” when rendered in popper mode.</li>
+  <li><strong>Filter Groups</strong> — One group per key in `filters`. Each group renders an `InputLabel` (`FilterColumn.name`) and a `Select` populated from `FilterColumn.options` plus an optional **All** option.</li>
+  <li><strong>Date-Range Section</strong> (optional) — Rendered when `datePicker` is true and `selectedDateRange`/`setSelectedDateRange` are provided. Contains a **Quick Ranges** select and two `DateTimePicker` fields (Start/End).</li>
+  <li><strong>Apply Action</strong> — A contained `Button` labeled “Apply” that copies staged values to `selectedFilters` and invokes `handleApplyFilter`.</li>
+</ul>
+
+<a id="Variants">
+  <h2>Variants</h2>
+</a>
+
+<h3>Default (Outlined)</h3>
+
+Uses `variant="outlined"` on each inner `Select`. This is the standard density for Meshery tables and catalog toolbars.
+
+<Row className="image-container">
+  <ThemeWrapper>
+    <div style={{ display: "flex", justifyContent: "center", width: "100%", padding: "1rem" }}>
+      <BasicUniversalFilterDemo />
+    </div>
+  </ThemeWrapper>
+</Row>
+
+<h3>With Date-Range Picker</h3>
+
+Set `datePicker` and provide `selectedDateRange` and `setSelectedDateRange` to enable calendar filtering. Includes quick-range presets and paired `DateTimePicker` controls.
+
+<Row className="image-container">
+  <ThemeWrapper>
+    <div style={{ display: "flex", justifyContent: "center", width: "100%", padding: "1rem" }}>
+      <DatePickerUniversalFilterDemo />
+    </div>
+  </ThemeWrapper>
+</Row>
+
+<h3>Active Filter Feedback</h3>
+
+The badge count derives from `Object.values(selectedFilters).filter(v => v && v !== "All").length`. Mirror active selections outside the popover (e.g., as `Chip` lists) so users can confirm applied state without reopening the filter.
+
+<Row className="image-container">
+  <ThemeWrapper>
+    <div style={{ display: "flex", justifyContent: "center", width: "100%", padding: "1rem" }}>
+      <ActiveFiltersDemo />
+    </div>
+  </ThemeWrapper>
+</Row>
+
+<a id="Accessibility">
+  <h2>Accessibility</h2>
+</a>
+
+<ul>
+  <li>The trigger uses `CustomTooltip` with `title="Filter"` and an `aria-label` on the underlying `IconButton` for screen readers.</li>
+  <li>Each group is wrapped with `role="presentation"` and a `data-testid` of the form `{id}-filter-group-{key}`; labels and selects expose `{id}-label-{key}` and `{id}-select-{key}` for assistive and test targeting.</li>
+  <li>The date-range section exposes `{id}-date-range`, `{id}-quick-range-select`, `{id}-start-date`, and `{id}-end-date` data attributes.</li>
+  <li>Ensure every Filter trigger receives a unique `id` prop so `data-testid` values remain deterministic across multiple tables on the same page.</li>
+  <li>Keyboard users can open the filter, tab through selects, and activate **Apply** without losing focus context; the popper uses `ClickAwayListener` with `mouseEvent="onMouseDown"` and `touchEvent="onTouchStart"` to preserve expected dismissal semantics.</li>
+</ul>


### PR DESCRIPTION
###  Description
This PR fixes #7984

This PR adds comprehensive documentation for the **UniversalFilter** component to the Sistent component catalog on `layer5.io`.

### Changes

Added documentation under `src/collections/sistent/components/universal-filter/`:

**`index.mdx` (Overview):**
- Architectural overview of the multi-attribute popover filtering system for tables/catalogs.
- Anatomy: Filter trigger + Badge count, `Popper` (desktop) / `Dialog` (mobile `sm`), Filter Groups (`FilterColumn` → `Select` + `All`), Date-Range section (`DateTimePicker` + Quick Ranges), Apply action.
- Interactive showcases for basic multi-attribute, with date-range picker, and active-filter feedback.
- Variants (`outlined`/`filled`/`standard`) and Accessibility (`data-testid`, `aria-label`, `ClickAwayListener`).

**`guidance.mdx` (Design & Usage Guidelines):**
- **Filter Schemas:** `FilterColumn { name, options: {label,value}[] }` as `Record<string, FilterColumn>`, `showAllOption`, staging vs commit on Apply.
- **Date-Range Picker Integration:** `datePicker` + `selectedDateRange`/`setSelectedDateRange` (`DateRange {startDate,endDate}`), lazy `DateTimePicker` peer deps (`@mui/x-date-pickers`), clamping `startDate ≤ endDate`.
- **Quick Date Options:** `QuickDateRangeOption { label, getRange: ()=>DateRange }` defaults (`Last 7/30 days`, `3/6 months`, `1 year` via `subtractDays`/`subtractMonths`/`subtractYears` – DST-safe, end-of-month clamped).
- **Active Filters Handling:** Badge `Object.values(selectedFilters).filter(v=>v&&v!=="All").length`, Chip mirroring, URL sync, empty/clear-all, Do/Don’t.

**`code.mdx` (Implementation & API):**
- Step-by-step examples with `<ThemeWrapper>` + `<CodeBlock>`:
  - Basic multi-attribute filtering (status/kind)
  - With search `TextField` + `InputAdornment` integration
  - With `datePicker` + `selectedDateRange`
  - With custom `quickDateRanges`
  - Variants forwarded to inner `Select`
  - Active-filter chips (removable, badge-derived)



**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive UniversalFilter documentation with interactive examples.
  * Documented multi-attribute filtering, search integration, date ranges, quick-range presets, variants, and active filter indicators.
  * Added guidance on filter schemas, validation, URL synchronization, accessibility, and responsive desktop and mobile behavior.
  * Included practical examples for applying staged filters, handling date ranges, customizing quick ranges, and displaying active-filter feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->