### PR TITLE
fix(terminal): prevent long URL clipping and improve layout responsiveness

### DIFF
--- a/src/components/Animated-steps-list/AnimatedStepsList.style.js
+++ b/src/components/Animated-steps-list/AnimatedStepsList.style.js
@@ -20,7 +20,7 @@ export const AnimatedStepsListWrapper = styled.div`
         padding-bottom: 395px;
       }
 
-      margin-right: 24px;
+      margin-right: 64px;
       @media (max-width: 1119px) {
         display: none;
       }
@@ -32,7 +32,7 @@ export const AnimatedStepsListWrapper = styled.div`
     }
 
     & .terminal-wrapper {
-      margin-left: 36px;
+      margin-left: 80px;
       position: sticky;
       top: 148px;
       align-self: flex-start;
@@ -41,7 +41,7 @@ export const AnimatedStepsListWrapper = styled.div`
       min-width: 0;
 
       @media (max-width: 1119px) {
-        margin-left: 24px;
+        margin-left: 48px;
       }
 
       @media (max-width: 850px) {

--- a/src/components/Animated-steps-list/AnimatedStepsList.style.js
+++ b/src/components/Animated-steps-list/AnimatedStepsList.style.js
@@ -20,7 +20,7 @@ export const AnimatedStepsListWrapper = styled.div`
         padding-bottom: 395px;
       }
 
-      margin-right: 64px;
+      margin-right: 4rem;
       @media (max-width: 1119px) {
         display: none;
       }
@@ -32,7 +32,7 @@ export const AnimatedStepsListWrapper = styled.div`
     }
 
     & .terminal-wrapper {
-      margin-left: 80px;
+      margin-left: 5rem;
       position: sticky;
       top: 148px;
       align-self: flex-start;
@@ -41,7 +41,7 @@ export const AnimatedStepsListWrapper = styled.div`
       min-width: 0;
 
       @media (max-width: 1119px) {
-        margin-left: 48px;
+        margin-left: 3rem;
       }
 
       @media (max-width: 850px) {

--- a/src/components/Animated-steps-list/AnimatedStepsList.style.js
+++ b/src/components/Animated-steps-list/AnimatedStepsList.style.js
@@ -20,7 +20,7 @@ export const AnimatedStepsListWrapper = styled.div`
         padding-bottom: 395px;
       }
 
-      margin-right: 4rem;
+      margin-right: 2rem;
       @media (max-width: 1119px) {
         display: none;
       }
@@ -32,7 +32,7 @@ export const AnimatedStepsListWrapper = styled.div`
     }
 
     & .terminal-wrapper {
-      margin-left: 5rem;
+      margin-left: 4rem;
       position: sticky;
       top: 148px;
       align-self: flex-start;
@@ -41,7 +41,7 @@ export const AnimatedStepsListWrapper = styled.div`
       min-width: 0;
 
       @media (max-width: 1119px) {
-        margin-left: 3rem;
+        margin-left: 2.5rem;
       }
 
       @media (max-width: 850px) {

--- a/src/components/Animated-steps-list/AnimatedStepsList.style.js
+++ b/src/components/Animated-steps-list/AnimatedStepsList.style.js
@@ -3,6 +3,16 @@ import styled from "styled-components";
 export const AnimatedStepsListWrapper = styled.div`
   .animated-steps-list {
     display: flex;
+    justify-content: space-between;
+    width: 100%;
+
+    @media (min-width: 1200px) {
+      margin-right: calc(
+        -1 * clamp(0px, calc((100vw - 1170px) / 2 - 40px), 140px)
+      );
+      width: calc(100% + clamp(0px, calc((100vw - 1170px) / 2 - 40px), 140px));
+    }
+
     & .indicator-wrapper {
       & > ul {
         position: sticky;
@@ -10,7 +20,7 @@ export const AnimatedStepsListWrapper = styled.div`
         padding-bottom: 395px;
       }
 
-      margin-right: 115px;
+      margin-right: 24px;
       @media (max-width: 1119px) {
         display: none;
       }
@@ -18,17 +28,20 @@ export const AnimatedStepsListWrapper = styled.div`
 
     & .steps-list {
       margin-bottom: 46px;
+      flex-shrink: 0;
     }
 
     & .terminal-wrapper {
-      margin-left: 150px;
+      margin-left: 36px;
       position: sticky;
       top: 148px;
       align-self: flex-start;
       box-shadow: rgb(0 0 0 / 0.35) 7px 10px 25px;
+      flex: 1;
+      min-width: 0;
 
       @media (max-width: 1119px) {
-        margin-left: 75px;
+        margin-left: 24px;
       }
 
       @media (max-width: 850px) {
@@ -38,78 +51,7 @@ export const AnimatedStepsListWrapper = styled.div`
       & > * {
         /* Child should not be sticky now; allow natural flow */
         margin-top: 0;
-
-        @media (min-width: 850px) {
-          max-width: 450px;
-        }
-
-        @media (min-width: 875px) {
-          max-width: 475px;
-        }
-
-        @media (min-width: 900px) {
-          max-width: 520px;
-        }
-
-        @media (min-width: 950px) {
-          max-width: 545px;
-        }
-
-        @media (min-width: 1000px) {
-          max-width: 570px;
-        }
-
-        @media (min-width: 1050px) {
-          max-width: 605px;
-        }
-
-        @media (min-width: 1120px) {
-          max-width: 465px;
-        }
-
-        @media (min-width: 1150px) {
-          max-width: 515px;
-        }
-
-        @media (min-width: 1200px) {
-          max-width: 565px;
-        }
-
-        @media (min-width: 1250px) {
-          max-width: 615px;
-        }
-
-        @media (min-width: 1300px) {
-          max-width: 645px;
-        }
-
-        @media (min-width: 1350px) {
-          max-width: 670px;
-        }
-
-        @media (min-width: 1400px) {
-          max-width: 695px;
-        }
-
-        @media (min-width: 1450px) {
-          max-width: 720px;
-        }
-
-        @media (min-width: 1500px) {
-          max-width: 745px;
-        }
-
-        @media (min-width: 1550px) {
-          max-width: 770px;
-        }
-
-        @media (min-width: 1600px) {
-          max-width: 795px;
-        }
-
-        @media (min-width: 1650px) {
-          max-width: unset;
-        }
+        max-width: 100%;
       }
     }
   }

--- a/src/components/Animated-steps-list/Steps-list/Step/Step.style.js
+++ b/src/components/Animated-steps-list/Steps-list/Step/Step.style.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 export const StepWrapper = styled.li`
-    width: 314px;
+    width: 24rem;
     
     @media (max-width: 850px) {
         width: unset;

--- a/src/components/Terminal/Terminal.style.js
+++ b/src/components/Terminal/Terminal.style.js
@@ -7,7 +7,7 @@ export const TerminalWrapper = styled.div`
   --gray-7: #f7f7f9;
   --gray-6: #dcdde0;
   --gray-5: #bdbec2;
-  --gray-4: #76767d;    
+  --gray-4: #76767d;
   --gray-3: #4c4c53;
   --gray-2: #323339;
   --gray-1: #1d1e23;
@@ -28,7 +28,7 @@ export const TerminalWrapper = styled.div`
 
     .title {
       color: var(--gray-4);
-      font-family: 'Courier New', Courier, monospace;
+      font-family: "Courier New", Courier, monospace;
       font-size: 13.5px;
       margin: 0 auto;
     }
@@ -65,62 +65,68 @@ export const TerminalWrapper = styled.div`
     }
   }
 
-.overflow-wrapper {
-  width: 100%;
-  height: 100%;
-  position: relative;
-  overflow: scroll;
+  .overflow-wrapper {
+    width: 100%;
+    height: 100%;
+    position: relative;
+    overflow: scroll;
 
-  /* Hides the scrollbars */
-  -ms-overflow-style: none; /* IE and Edge */
-  scrollbar-width: none; /* Firefox */
-  &::-webkit-scrollbar {
-    /* Safari */
-    -webkit-appearance: none;
-    width: 0;
-    height: 0;
-  }
-  
-  .code-wrapper {
-    pre {
-      padding: 0;
-      margin: 0;
-      width: 100%;
-      height: 100%;
-      font-style: normal;
-      font-weight: normal;
-      font-size: 12px;
-      line-height: 27px;
-      white-space: pre-wrap;
-      color: ${props => props.theme.secondaryColor};
-      &.short {
-        line-height: 16px;
-      }
-      &.navy {
-        color: var(--vagrant-l1);
-      }
-      &.gray {
-        color: var(--gray-5);
-      }
-      &.white {
-        color: var(--white);
-      }
+    /* Hides the scrollbars */
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+    &::-webkit-scrollbar {
+      /* Safari */
+      -webkit-appearance: none;
+      width: 0;
+      height: 0;
+    }
 
-      wrap-word: normal;
-      
-      @media (min-width: 768px){
-        font-size: 13.5px;
-        line-height: 26px;
+    .code-wrapper {
+      pre {
+        padding: 0;
+        margin: 0;
+        width: 100%;
+        height: 100%;
+        font-style: normal;
+        font-weight: normal;
+        font-size: 12px;
+        line-height: 27px;
+        white-space: pre-wrap;
+        color: ${(props) => props.theme.secondaryColor};
+        &.short {
+          line-height: 16px;
+        }
+        &.navy {
+          color: var(--vagrant-l1);
+        }
+        &.gray {
+          color: var(--gray-5);
+        }
+        &.white {
+          color: var(--white);
+        }
+
+        overflow-wrap: break-word;
+        overflow-wrap: anywhere;
+
+        @media (min-width: 768px) {
+          font-size: 13.5px;
+          line-height: 26px;
+        }
       }
     }
   }
-}
 
-.no-scroll-overflow-wrapper {
+  .no-scroll-overflow-wrapper {
+    overflow-x: hidden;
 
-  .code-wrapper {
-    bottom: 0;
-    position: absolute;
-    min-height: 100%;
+    .code-wrapper {
+      bottom: 0;
+      position: absolute;
+      min-height: 100%;
+      width: 100%;
+      left: 0;
+      box-sizing: border-box;
+    }
   }
-}`;
+`;

--- a/src/components/Terminal/Terminal.style.js
+++ b/src/components/Terminal/Terminal.style.js
@@ -7,7 +7,7 @@ export const TerminalWrapper = styled.div`
   --gray-7: #f7f7f9;
   --gray-6: #dcdde0;
   --gray-5: #bdbec2;
-  --gray-4: #76767d;
+  --gray-4: #76767d;    
   --gray-3: #4c4c53;
   --gray-2: #323339;
   --gray-1: #1d1e23;
@@ -28,7 +28,7 @@ export const TerminalWrapper = styled.div`
 
     .title {
       color: var(--gray-4);
-      font-family: "Courier New", Courier, monospace;
+      font-family: 'Courier New', Courier, monospace;
       font-size: 13.5px;
       margin: 0 auto;
     }
@@ -65,68 +65,62 @@ export const TerminalWrapper = styled.div`
     }
   }
 
-  .overflow-wrapper {
-    width: 100%;
-    height: 100%;
-    position: relative;
-    overflow: scroll;
+.overflow-wrapper {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  overflow: scroll;
 
-    /* Hides the scrollbars */
-    -ms-overflow-style: none; /* IE and Edge */
-    scrollbar-width: none; /* Firefox */
-    &::-webkit-scrollbar {
-      /* Safari */
-      -webkit-appearance: none;
-      width: 0;
-      height: 0;
-    }
+  /* Hides the scrollbars */
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+  &::-webkit-scrollbar {
+    /* Safari */
+    -webkit-appearance: none;
+    width: 0;
+    height: 0;
+  }
+  
+  .code-wrapper {
+    pre {
+      padding: 0;
+      margin: 0;
+      width: 100%;
+      height: 100%;
+      font-style: normal;
+      font-weight: normal;
+      font-size: 12px;
+      line-height: 27px;
+      white-space: pre-wrap;
+      color: ${props => props.theme.secondaryColor};
+      &.short {
+        line-height: 16px;
+      }
+      &.navy {
+        color: var(--vagrant-l1);
+      }
+      &.gray {
+        color: var(--gray-5);
+      }
+      &.white {
+        color: var(--white);
+      }
 
-    .code-wrapper {
-      pre {
-        padding: 0;
-        margin: 0;
-        width: 100%;
-        height: 100%;
-        font-style: normal;
-        font-weight: normal;
-        font-size: 12px;
-        line-height: 27px;
-        white-space: pre-wrap;
-        color: ${(props) => props.theme.secondaryColor};
-        &.short {
-          line-height: 16px;
-        }
-        &.navy {
-          color: var(--vagrant-l1);
-        }
-        &.gray {
-          color: var(--gray-5);
-        }
-        &.white {
-          color: var(--white);
-        }
-
-        overflow-wrap: break-word;
-        overflow-wrap: anywhere;
-
-        @media (min-width: 768px) {
-          font-size: 13.5px;
-          line-height: 26px;
-        }
+      overflow-wrap: anywhere;
+      
+      @media (min-width: 768px){
+        font-size: 13.5px;
+        line-height: 26px;
       }
     }
   }
+}
 
-  .no-scroll-overflow-wrapper {
-    overflow-x: hidden;
+.no-scroll-overflow-wrapper {
 
-    .code-wrapper {
-      bottom: 0;
-      position: absolute;
-      min-height: 100%;
-      width: 100%;
-      left: 0;
-      box-sizing: border-box;
-    }
+  .code-wrapper {
+    bottom: 0;
+    position: absolute;
+    min-height: 100%;
   }
-`;
+}`;


### PR DESCRIPTION
This PR addresses and fixes [#8008](https://github.com/layer5io/layer5/issues/8008) where long URLs (such as `https://github.com/meshery/meshery/tree/v0.6.0/install/deployment_yamls/k8s`) in the Meshery installation terminal on the [Getting Started](https://layer5.io/cloud-native-management/meshery/getting-started) page were getting cut off horizontally on desktop viewports.

### Root Cause
1. **Invalid CSS Property**: The `<pre>` block in `Terminal.style.js` was using `wrap-word: normal;` (an invalid CSS property) without `overflow-wrap: anywhere;`, causing long strings without whitespace to overflow and be clipped by `overflow-x: hidden`.
2. **Layout & Space Utilization**: The previous layout used 18 hardcoded `max-width` media queries and large fixed margins (`margin-left: 150px`) that either caused off-screen overflow on certain screens or left an unused void on the right side on wide desktop screens.

### Changes Made
- **Safe Word Wrapping**: Added `overflow-wrap: anywhere;` and `overflow-wrap: break-word;` in `Terminal.style.js` so continuous strings wrap gracefully on narrow viewports without clipping.
- **Utilize Right-Side Space**: In `AnimatedStepsList.style.js`, added responsive extension using CSS `clamp()` on viewports $\ge 1200\text{px}$ so the terminal naturally fills the available space on the right, aligning under the top navigation action buttons with safe margin and zero horizontal page scroll.
- **Streamlined Layout**: Replaced the 18 hardcoded media query rules with clean flex sizing (`flex: 1; min-width: 0; max-width: 100%`) and balanced spacing (`margin-left: 36px`).

---

### Visual Proof

| Before | After |
| :---: | :---: |
| <img width="1512" height="982" alt="Before" src="https://github.com/user-attachments/assets/99531326-91eb-4f1f-87d3-9be7725e8bc3" /> | <img width="1512" height="982" alt="After" src="https://github.com/user-attachments/assets/d0242acb-c151-48db-9a57-66fb64bafa45" /> |

---

### Checklist
- [x] This PR fixes #8008
- [x] Tested on desktop and mobile viewports with zero horizontal overflow
- [x] Passes ESLint and Prettier checks (`npm run checklint`)
- [x] Signed-off commit (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved responsive layout for animated step lists across desktop and smaller screen sizes.
  - Improved spacing and alignment between step indicators, content, and terminal panels.
  - Standardized step widths for more consistent presentation.
  - Fixed terminal text wrapping to keep long content within its container.
  - Improved horizontal overflow handling in terminal displays.
  - Ensured terminal content uses available space more consistently across screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->