### PR TITLE
fix: reserve layout space for Partners carousel and Features images

### DIFF
--- a/src/components/Features/index.js
+++ b/src/components/Features/index.js
@@ -91,15 +91,23 @@ const Features = (props) => {
       <ContentWrapper>
         <h2>{props.title}</h2>
         <p className="text">{props.desc}</p>
-        {props.redirectLink ? <Link to={props.redirectLink}>Learn more &rarr;</Link>
-          : (<div className="small-card-container">
+        {props.redirectLink ? (
+          <Link to={props.redirectLink}>Learn more &rarr;</Link>
+        ) : (
+          <div className="small-card-container">
             {props.redirectLinkWithImage.map((item) => (
               <Link key={item.text} className="small-card" to={item.redirect}>
-                <img src={item.image} width={40} alt={item.alt} />
+                <img
+                  src={item.image}
+                  width={item.width || 40}
+                  height={item.height}
+                  alt={item.alt}
+                />
                 <span>{item.text}</span>
               </Link>
             ))}
-          </div>)}
+          </div>
+        )}
       </ContentWrapper>
       {props.animationOne ? (
         <ImageWrapper ref={containerRef}>
@@ -123,7 +131,13 @@ const Features = (props) => {
           >
             <img src={getPerson(props.cursor * 2 + 1)} alt="" />
           </SvgRandomWrapper>
-          <Link to={props.redirectLink ? props.redirectLink : props.redirectLinkWithImage[0].redirect}>
+          <Link
+            to={
+              props.redirectLink
+                ? props.redirectLink
+                : props.redirectLinkWithImage[0].redirect
+            }
+          >
             <img src={props.imgLink} alt="image" />
           </Link>
         </ImageWrapper>
@@ -149,7 +163,13 @@ const Features = (props) => {
           >
             <img src={getPerson(props.cursor * 2 + 1)} alt="" />
           </SvgRandomWrapper>
-          <Link to={props.redirectLink ? props.redirectLink : props.redirectLinkWithImage[0].redirect}>
+          <Link
+            to={
+              props.redirectLink
+                ? props.redirectLink
+                : props.redirectLinkWithImage[0].redirect
+            }
+          >
             <img src={props.imgLink} alt="image" />
           </Link>
         </ImageWrapperTwo>

--- a/src/components/Features/style.js
+++ b/src/components/Features/style.js
@@ -92,9 +92,15 @@ export const ImageWrapper = styled.div`
     rotateY(-25deg) rotateZ(4deg);
   transition: transform 1s ease 0s;
 
-  & > img {
+  /* Matches the real aspect ratio of every image this component renders
+     (whiteboarding/commenting/aws, 877x476) so the box is reserved before
+     the image loads instead of shifting surrounding content (CLS). The
+     image sits inside a Link (renders as <a>), not directly under this
+     wrapper, so the selector has to reach through it. */
+  & > a > img {
     width: 100%;
     height: 100%;
+    aspect-ratio: 877 / 476;
     object-fit: contain;
   }
 
@@ -126,9 +132,15 @@ export const ImageWrapperTwo = styled.div`
   transform: translate(170px, 0px);
   transition: transform 1s ease 0s;
 
-  & > img {
+  /* Matches the real aspect ratio of every image this component renders
+     (whiteboarding/commenting/aws, 877x476) so the box is reserved before
+     the image loads instead of shifting surrounding content (CLS). The
+     image sits inside a Link (renders as <a>), not directly under this
+     wrapper, so the selector has to reach through it. */
+  & > a > img {
     width: 100%;
     height: 100%;
+    aspect-ratio: 877 / 476;
     object-fit: contain;
   }
 

--- a/src/sections/Home/FeaturesContainer/index.js
+++ b/src/sections/Home/FeaturesContainer/index.js
@@ -41,9 +41,9 @@ const FeaturesContainer = () => {
       redirectLink: "",
       desc: (
         <span>
-          Incorporate AWS <i>and</i>{" "} GCP components into Kanvas designs for
-          comprehensive <i>and</i>{" "} intuitive system mapping, documentation, <i>and</i>{" "}
-          orchestration.
+          Incorporate AWS <i>and</i> GCP components into Kanvas designs for
+          comprehensive <i>and</i> intuitive system mapping, documentation,{" "}
+          <i>and</i> orchestration.
         </span>
       ),
       imgLink: isDark ? AWSImage : AWSImageLight,
@@ -53,6 +53,9 @@ const FeaturesContainer = () => {
           text: "Amazon Web Services",
           image: isDark ? AWSLogoDark : AWSLogoLight,
           alt: "Amazon Web Services Logo",
+          // Real SVG is 2500x1465 - reserving this ratio at width=40 avoids a layout shift once it loads.
+          width: 40,
+          height: 23,
           redirect:
             "/cloud-native-management/generate-aws-architecture-diagram",
         },
@@ -60,6 +63,9 @@ const FeaturesContainer = () => {
           text: "Google Cloud Platform",
           image: GCPLogo,
           alt: "Logo Google Cloud Platform",
+          // Real SVG is 256x228.
+          width: 40,
+          height: 36,
           redirect:
             "/cloud-native-management/generate-gcp-architecture-diagram",
         },
@@ -73,7 +79,7 @@ const FeaturesContainer = () => {
       desc: "Crafting cloud-native symphonies: Our engineering diagramming tool is your conductor's baton, turning Kubernetes infrastructure into a canvas for freestyle orchestration.",
       imgLink: isDark ? WhiteboardingImage : WhiteboardingImageLight,
       cursor: true,
-    }
+    },
   ];
 
   useEffect(() => {

--- a/src/sections/Home/Partners-home/partnerSection.style.js
+++ b/src/sections/Home/Partners-home/partnerSection.style.js
@@ -1,103 +1,102 @@
 import styled from "styled-components";
 const PartnerItemWrapper = styled.section`
-    padding: 2rem 0;
-    margin: 0rem 0rem 5rem 0rem;
-    overflow: hidden;
-    .section-title{
-        h4{
-            color: ${props => props.theme.grey737373ToGrey4C4A4A};
-            text-align: center;
-            margin-top: .5rem;
-            transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
-        }
+  padding: 2rem 0;
+  margin: 0rem 0rem 5rem 0rem;
+  overflow: hidden;
+  .section-title {
+    h4 {
+      color: ${(props) => props.theme.grey737373ToGrey4C4A4A};
+      text-align: center;
+      margin-top: 0.5rem;
+      transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
     }
-    .partner-image{
-        margin-left:1.5rem;
-        margin-right:1.5rem;
+  }
+  .partner-image {
+    margin-left: 1.5rem;
+    margin-right: 1.5rem;
+  }
+  .partner-slider {
+    display: flex;
+    justify-content: center;
+    flex-wrap: nowrap;
+    /* Reserves the single-row carousel height on desktop so the slick
+           carousel's DOM restructuring during client-side init/hydration
+           doesn't shift surrounding page content (CLS). Scoped to the
+           desktop breakpoint only - below it, .partner__block__inner wraps
+           into multiple rows by design and this height would be wrong. */
+    @media (min-width: 1401px) {
+      min-height: 110px;
     }
-    .partner-slider{
-        display: flex;
-        justify-content: center;
-        flex-wrap: nowrap;
-        @media(max-width: 1400px){
-            flex-wrap: wrap;
-        }
+    @media (max-width: 1400px) {
+      flex-wrap: wrap;
     }
-		.slick-dots li button:before{
-			color: ${props => props.theme.blue477E96ToGreen00B39F};
-            transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
-		}
-		.slick-dots li.slick-active button:before {
-			color: ${props => props.theme.green009A89ToGreen00B39F};
-            transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
-		}
-		.slick-dots li button:hover{
-				box-shadow: none;
-		}
+  }
+  .slick-dots li button:before {
+    color: ${(props) => props.theme.blue477E96ToGreen00B39F};
+    transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
+  }
+  .slick-dots li.slick-active button:before {
+    color: ${(props) => props.theme.green009A89ToGreen00B39F};
+    transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
+  }
+  .slick-dots li button:hover {
+    box-shadow: none;
+  }
 
-    a.partner-card {
-        @media(max-width: 1400px){
-            flex: 0 0 12%;
-            margin-left:0.5rem;
-            margin-right:0.5rem;
-        }
-
-        &:hover
-        {
-            img{
-                opacity: 1;
-            }
-        }
-
-        #VMware:hover
-        {
-        
-           filter:brightness(10%);
-        
-
-         }
-
-        flex-shrink: 3;
-    
-
-       
-
+  a.partner-card {
+    @media (max-width: 1400px) {
+      flex: 0 0 12%;
+      margin-left: 0.5rem;
+      margin-right: 0.5rem;
     }
+
+    &:hover {
+      img {
+        opacity: 1;
+      }
+    }
+
+    #VMware:hover {
+      filter: brightness(10%);
+    }
+
+    flex-shrink: 3;
+  }
+  img {
+    width: 2rem;
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    max-width: 100%;
+    min-width: 7rem;
+    height: auto;
+    opacity: 0.7;
+    max-height: 100px;
+    @media (max-width: 800px) {
+      min-width: 5.5rem;
+    }
+  }
+  @supports (-webkit-hyphens: none) {
     img {
-        width: 2rem;
-        margin-left:0.5rem;
-        margin-right:0.5rem;
-        max-width: 100%;
-        min-width: 7rem;
-        height:auto;
-        opacity: 0.7;
-        max-height:100px;
-        @media(max-width: 800px){
-                min-width:5.5rem;
-            }
+      min-width: 8rem;
     }
-    @supports (-webkit-hyphens:none) { 
-        img { 
-            min-width: 8rem; 
-          }
-        @media only screen and (max-width: 992px) {
-            img { 
-                min-width: 5.625rem; 
-            }
-        }
+    @media only screen and (max-width: 992px) {
+      img {
+        min-width: 5.625rem;
+      }
     }
-    .partner__block__inner {
-        padding: 5px;
-        margin: 0px;
-        filter:  ${props => props.theme.invertColor};
-        display: flex;
-        transition: all 0.2s ease-in-out;
-        height: 110px;
-    }
-    @media only screen and (max-width: 575px) {
-        margin: 2rem auto;
-    }
-     /* @media only screen and (max-width: 768px) {
+  }
+  .partner__block__inner {
+    padding: 5px;
+    margin: 0px;
+    filter: ${(props) => props.theme.invertColor};
+    display: flex;
+    transition: all 0.2s ease-in-out;
+    height: 110px;
+  }
+  @media only screen and (max-width: 575px) {
+    margin: 2rem auto;
+  }
+  /* @media only screen and (max-width: 768px) {
         .horizontal {
             padding: 2rem 4rem;
         }


### PR DESCRIPTION
## Summary

Closes #8018. Two independent CLS (Cumulative Layout Shift) sources on the homepage:

- **Partners carousel**: the slick/unslick breakpoint switch restructures the DOM on client-side init, shifting content below it. Reserves the single-row height (`min-height: 110px`, matching `.partner__block__inner`'s fixed `height: 110px`) on desktop only (`min-width: 1401px`), where slick renders a single row by design — below that breakpoint `.partner__block__inner` wraps into multiple rows and a fixed height would be wrong.
- **Features section images** (whiteboarding/commenting/aws, all 877×476 SVGs) had no `width`/`height`/`aspect-ratio`, so the browser couldn't reserve their box before load. Added `aspect-ratio: 877 / 476` to the actual `<img>` — it's nested inside a `Link` (renders as `<a>`), so the selector is `& > a > img`, not the `& > img` a first pass would reach for. Also added explicit `width`/`height` to the small AWS/GCP logo icons in the linked-cards row, which were missing them entirely.

## Test plan

- [x] `npm run checklint` — no new errors introduced (286 pre-existing errors in unrelated files untouched by this PR; the 4 files this PR touches lint clean on their own).
- [x] Verified live against `npm run develop:lite`: `getComputedStyle` confirms `aspect-ratio` resolves to `877 / 476` on the actual rendered `<img>` elements (previously `auto`, meaning the original `& > img` selector never matched).
- [x] Verified the carousel reserves ~110–113px on desktop via `getBoundingClientRect`.
- Note: the Features images' *visual* bounding-box ratio still differs from 877/476 because `ImageWrapper`/`ImageWrapperTwo` apply a 3D transform (`perspective` + `scale` + `rotateY`/`rotateZ`) for a hover effect — that's a paint-time projection, not the layout box CLS is actually computed from, so it doesn't affect this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved feature card image sizing and aspect-ratio handling for more consistent layouts.
  * Added explicit dimensions to AWS and GCP logos to help prevent page content from shifting while loading.
  * Reserved space for the partner slider on large desktop screens, reducing layout movement during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->