### PR TITLE
fix: make getting started SVGs clickable

### DIFF
--- a/src/components/Logo-List/LogoList.style.js
+++ b/src/components/Logo-List/LogoList.style.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 export const LogoListWrapper = styled.div`
-    ul {
+  ul {
     list-style: none;
     padding: 0;
     display: flex;
@@ -12,6 +12,15 @@ export const LogoListWrapper = styled.div`
     & > li {
       height: 32px;
       margin: 10px 16px;
+
+      a {
+        display: block;
+        transition: all 0.2s ease-in-out;
+      }
+
+      a:hover {
+        transform: translateY(-2px);
+      }
 
       & img {
         height: 32px;

--- a/src/components/Logo-List/index.js
+++ b/src/components/Logo-List/index.js
@@ -1,15 +1,30 @@
 import React from "react";
+import { Link } from "gatsby";
 import { LogoListWrapper } from "./LogoList.style";
 
 const LogoList = ({ logos, className }) => {
   return (
     <LogoListWrapper className={className}>
       <ul>
-        {logos.map((logo) => (
-          <li key={logo.url}>
-            <img src={logo.url} alt={logo.alt} />
-          </li>
-        ))}
+        {logos.map((logo) => {
+          const content = <img src={logo.url} alt={logo.alt} />;
+          const isExternal = logo.link && logo.link.startsWith("http");
+          return (
+            <li key={logo.url}>
+              {logo.link ? (
+                isExternal ? (
+                  <a href={logo.link} target="_blank" rel="noreferrer">
+                    {content}
+                  </a>
+                ) : (
+                  <Link to={logo.link}>{content}</Link>
+                )
+              ) : (
+                content
+              )}
+            </li>
+          );
+        })}
       </ul>
     </LogoListWrapper>
   );

--- a/src/sections/Home/Playground-home/index.js
+++ b/src/sections/Home/Playground-home/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "gatsby";
 import styled from "styled-components";
 import { useInView } from "react-intersection-observer";
 import Button from "../../../reusecore/Button";
@@ -31,19 +32,17 @@ import tuf from "../../../collections/integrations/tuf/icons/color/tuf-color.svg
 import tikvoperator from "../../../collections/integrations/tikv-operator/icons/color/tikv-operator-color.svg";
 import vitess from "../../../collections/integrations/vitess/icons/color/vitess-color.svg";
 
-
 const ViewsSectionWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
+  .small-card-container {
     display: flex;
-    align-items: center;
-    justify-content: center;
+    gap: 1rem;
+  }
 
-    .small-card-container {
-      display: flex;
-      gap: 1rem;
-    }
-
-    .views-section {
+  .views-section {
     position: relative;
     display: flex;
     flex-direction: row;
@@ -67,250 +66,376 @@ const ViewsSectionWrapper = styled.div`
       height: 600px;
       padding: 0 2%;
     }
-      
-}
-    .hero-text {
-        display: flex;
-        flex-direction: column;
-        flex: 0 0 50%;
-        max-width: 50%;
-        padding-bottom: 3rem;
-        @media only screen and (max-width: 767px) {
-          max-width: 100%;
-          justify-content: center;
-          text-align: center;
-          margin-top: 4rem;
-        }
-        @media only screen and (min-width: 768px) and (max-width: 1100px) {
-          padding-left: 1rem;
-        }
-
-          
+  }
+  .hero-text {
+    display: flex;
+    flex-direction: column;
+    flex: 0 0 50%;
+    max-width: 50%;
+    padding-bottom: 3rem;
+    @media only screen and (max-width: 767px) {
+      max-width: 100%;
+      justify-content: center;
+      text-align: center;
+      margin-top: 4rem;
     }
-
-    .hero-image {
-        position: relative;
-        display: flex;
-        justify-content: center;
-        flex: 0 0 50%;
-        max-width: 50%;
-        overflow: hidden;
-        height: 100%;
-
-        @media only screen and (max-width: 767px) {
-          max-width: 100%;
-        }
+    @media only screen and (min-width: 768px) and (max-width: 1100px) {
+      padding-left: 1rem;
     }
-
-    h2 {
-      /* max-width: 90%; */
-      padding-bottom: 2%;
-    }
-  
-
-  h4 {
-      max-width: 90%;
-      @media only screen and (max-width: 767px) {
-        max-width: 100%;
-        }
   }
 
-   .hero-image {
-        position: relative;
-        display: flex;
-        justify-content: center;
-        flex: 0 0 50%;
-        max-width: 50%;
+  .hero-image {
+    position: relative;
+    display: flex;
+    justify-content: center;
+    flex: 0 0 50%;
+    max-width: 50%;
+    overflow: hidden;
+    height: 100%;
 
-        
-
-        svg {
-          align-items: center;
-          justify-content: center;
-          width: 70%;
-          .visualizer-views-colorMode_svg__colorMode1 {
-            fill: ${(props) => props.theme.whiteToGrey737373};
-            transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
-          }
-        }
-
-      
-        .visible {
-                opacity: 1;
-                transition: all 0.2s ease-in;
-        }
-
-        .not-visible {
-                opacity: 0;
-                transition: all 0.5s ease;
-        }
-
-        @media only screen and (max-width: 767px) {
-          max-width: 100%;
-        }
-
-    }
-
-    .overlay {
-        width: 483px;
-        height: 680px;
-    }
-
-
-    .container {
-        display: flex;
-        justify-content: center;
-        gap: 1.5rem; 
-        height: 100%; 
-      }
-
-    .line {
-        position: relative;
-        height: 100%;
-        overflow: hidden;
-        width: 200px;
-    }
-
-    .scroll-track {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        display: flex;
-        flex-direction: column;
-    }
-
-    .scroll-down .scroll-track {
-        animation: scrollDown 35s linear infinite;
-    }
-
-    .scroll-up .scroll-track {
-        animation: scrollUp 35s linear infinite;
-    }
-
-    @keyframes scrollDown {
-        0% {
-            transform: translateY(-50%);
-        }
-        100% {
-            transform: translateY(0%);
-        }
-    }
-
-    @keyframes scrollUp {
-        0% {
-            transform: translateY(0%);
-        }
-        100% {
-            transform: translateY(-50%);
-        }
-    }
-
-    .box {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      width: 100%;
-      height:150px;
-      padding: 2rem;
-      box-sizing: border-box;
-      background-color: ${(props) => props.theme.backgroundColor};
-      color: ${(props) => props.theme.whiteEightToBlack}; 
-      margin-bottom: 1rem; 
-      border-radius: 1rem;
-      //box-shadow: ${(props) => props.theme.boxShadowGreen00D3A9ToBlackTwoFive};
-    }
-    // .box:hover {
-    //   box-shadow: ${(props) => props.theme.boxShadowBlue477E96};
-    // }
-
-    .box .boxImg {
-      width: auto;
-      height: 60px;
+    @media only screen and (max-width: 767px) {
       max-width: 100%;
     }
-    
-    .box .boxText {
-      margin-top: 1rem;
-      text-align: center;
-      color: ${(props) => props.theme.whiteEightToBlack};
+  }
+
+  h2 {
+    /* max-width: 90%; */
+    padding-bottom: 2%;
+  }
+
+  h4 {
+    max-width: 90%;
+    @media only screen and (max-width: 767px) {
+      max-width: 100%;
+    }
+  }
+
+  .hero-image {
+    position: relative;
+    display: flex;
+    justify-content: center;
+    flex: 0 0 50%;
+    max-width: 50%;
+
+    svg {
+      align-items: center;
+      justify-content: center;
+      width: 70%;
+      .visualizer-views-colorMode_svg__colorMode1 {
+        fill: ${(props) => props.theme.whiteToGrey737373};
+        transition: 0.8s cubic-bezier(0.2, 0.8, 0.2, 1);
+      }
     }
 
-    @media only screen and (max-width: 700px) {
-      .hero-image {
-        display: none; 
-      }
-      .views-section {
-        padding: 2rem 2rem 0 2rem;
-        height: auto;
-      }
-      .small-card-container {
-        display: flex;
-        justify-content: center;
-      }
+    .visible {
+      opacity: 1;
+      transition: all 0.2s ease-in;
     }
 
+    .not-visible {
+      opacity: 0;
+      transition: all 0.5s ease;
+    }
+
+    @media only screen and (max-width: 767px) {
+      max-width: 100%;
+    }
+  }
+
+  .overlay {
+    width: 483px;
+    height: 680px;
+  }
+
+  .container {
+    display: flex;
+    justify-content: center;
+    gap: 1.5rem;
+    height: 100%;
+  }
+
+  .line {
+    position: relative;
+    height: 100%;
+    overflow: hidden;
+    width: 200px;
+  }
+
+  .scroll-track {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .scroll-down .scroll-track {
+    animation: scrollDown 35s linear infinite;
+  }
+
+  .scroll-up .scroll-track {
+    animation: scrollUp 35s linear infinite;
+  }
+
+  @keyframes scrollDown {
+    0% {
+      transform: translateY(-50%);
+    }
+    100% {
+      transform: translateY(0%);
+    }
+  }
+
+  @keyframes scrollUp {
+    0% {
+      transform: translateY(0%);
+    }
+    100% {
+      transform: translateY(-50%);
+    }
+  }
+
+  .box {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 150px;
+    padding: 2rem;
+    box-sizing: border-box;
+    background-color: ${(props) => props.theme.backgroundColor};
+    color: ${(props) => props.theme.whiteEightToBlack};
+    margin-bottom: 1rem;
+    border-radius: 1rem;
+    text-decoration: none;
+    transition: all 0.2s ease-in-out;
+    //box-shadow: ${(props) => props.theme.boxShadowGreen00D3A9ToBlackTwoFive};
+  }
+  .box:hover {
+    box-shadow: ${(props) => props.theme.boxShadowBlue477E96};
+    transform: translateY(-5px);
+  }
+
+  .box .boxImg {
+    width: auto;
+    height: 60px;
+    max-width: 100%;
+  }
+
+  .box .boxText {
+    margin-top: 1rem;
+    text-align: center;
+    color: ${(props) => props.theme.whiteEightToBlack};
+  }
+
+  @media only screen and (max-width: 700px) {
+    .hero-image {
+      display: none;
+    }
+    .views-section {
+      padding: 2rem 2rem 0 2rem;
+      height: auto;
+    }
+    .small-card-container {
+      display: flex;
+      justify-content: center;
+    }
+  }
 `;
 
 const KanvasVisualizerViews = () => {
   const [imageRef] = useInView({ threshold: 0.3 });
 
   const leftColumnItems = [
-    { img: argocd, name: "Argo" },
-    { img: certmanager, name: "Cert Manager" },
-    { img: cilium, name: "Cilium" },
-    { img: cloudevents, name: "CloudEvents" },
-    { img: containerd, name: "containerd" },
-    { img: coredns, name: "CoreDNS" },
-    { img: crio, name: "cri-o" },
-    { img: envoy, name: "Envoy" },
-    { img: etcd, name: "etcd" },
-    { img: falco, name: "Falco" },
-    { img: fluentd, name: "Fluentd" },
-    { img: flux, name: "Flux" },
-    { img: harbor, name: "Harbor" },
-    { img: helm, name: "Helm" }
+    {
+      img: argocd,
+      name: "Argo",
+      link: "/cloud-native-management/meshery/integrations/argo-cd",
+    },
+    {
+      img: certmanager,
+      name: "Cert Manager",
+      link: "/cloud-native-management/meshery/integrations/cert-manager",
+    },
+    {
+      img: cilium,
+      name: "Cilium",
+      link: "/cloud-native-management/meshery/integrations/cilium",
+    },
+    {
+      img: cloudevents,
+      name: "CloudEvents",
+      link: "/cloud-native-management/meshery/integrations/cloudevents",
+    },
+    {
+      img: containerd,
+      name: "containerd",
+      link: "/cloud-native-management/meshery/integrations/containerd",
+    },
+    {
+      img: coredns,
+      name: "CoreDNS",
+      link: "/cloud-native-management/meshery/integrations/coredns",
+    },
+    {
+      img: crio,
+      name: "cri-o",
+      link: "/cloud-native-management/meshery/integrations/cri-o",
+    },
+    {
+      img: envoy,
+      name: "Envoy",
+      link: "/cloud-native-management/meshery/integrations/envoy",
+    },
+    {
+      img: etcd,
+      name: "etcd",
+      link: "/cloud-native-management/meshery/integrations/etcd-cluster-operator",
+    },
+    {
+      img: falco,
+      name: "Falco",
+      link: "/cloud-native-management/meshery/integrations/falco",
+    },
+    {
+      img: fluentd,
+      name: "Fluentd",
+      link: "/cloud-native-management/meshery/integrations/fluentd",
+    },
+    {
+      img: flux,
+      name: "Flux",
+      link: "/cloud-native-management/meshery/integrations/flux",
+    },
+    {
+      img: harbor,
+      name: "Harbor",
+      link: "/cloud-native-management/meshery/integrations/harbor-operator",
+    },
+    {
+      img: helm,
+      name: "Helm",
+      link: "/cloud-native-management/meshery/integrations/helm-controller",
+    },
   ];
 
   const rightColumnItems = [
-    { img: istio, name: "Istio" },
-    { img: jaeger, name: "Jaeger" },
-    { img: keda, name: "KEDA" },
-    { img: kubeedge, name: "KubeEdge" },
-    { img: kubernetes, name: "Kubernetes" },
-    { img: linkerd, name: "Linkerd" },
-    { img: opa, name: "Open Policy Agent" },
-    { img: prometheus, name: "Prometheus" },
-    { img: rook, name: "Rook" },
-    { img: spiffe, name: "SPIFFE" },
-    { img: spire, name: "SPIRE" },
-    { img: tuf, name: "TUF" },
-    { img: tikvoperator, name: "TiKV" },
-    { img: vitess, name: "Vitess" }
+    {
+      img: istio,
+      name: "Istio",
+      link: "/cloud-native-management/meshery/integrations/istio-base",
+    },
+    {
+      img: jaeger,
+      name: "Jaeger",
+      link: "/cloud-native-management/meshery/integrations/jaeger",
+    },
+    {
+      img: keda,
+      name: "KEDA",
+      link: "/cloud-native-management/meshery/integrations/keda",
+    },
+    {
+      img: kubeedge,
+      name: "KubeEdge",
+      link: "/cloud-native-management/meshery/integrations/kubegems-edge",
+    },
+    {
+      img: kubernetes,
+      name: "Kubernetes",
+      link: "/cloud-native-management/meshery/integrations/kubernetes-ingress",
+    },
+    {
+      img: linkerd,
+      name: "Linkerd",
+      link: "/cloud-native-management/meshery/integrations/linkerd",
+    },
+    {
+      img: opa,
+      name: "Open Policy Agent",
+      link: "https://www.openpolicyagent.org/",
+    },
+    {
+      img: prometheus,
+      name: "Prometheus",
+      link: "/cloud-native-management/meshery/integrations/prometheus",
+    },
+    {
+      img: rook,
+      name: "Rook",
+      link: "/cloud-native-management/meshery/integrations/rook",
+    },
+    {
+      img: spiffe,
+      name: "SPIFFE",
+      link: "/cloud-native-management/meshery/integrations/spiffe",
+    },
+    {
+      img: spire,
+      name: "SPIRE",
+      link: "/cloud-native-management/meshery/integrations/spire",
+    },
+    {
+      img: tuf,
+      name: "TUF",
+      link: "/cloud-native-management/meshery/integrations/tuf",
+    },
+    {
+      img: tikvoperator,
+      name: "TiKV",
+      link: "/cloud-native-management/meshery/integrations/tikv-operator",
+    },
+    {
+      img: vitess,
+      name: "Vitess",
+      link: "/cloud-native-management/meshery/integrations/vitess",
+    },
   ];
 
   const renderColumn = (items, direction) => (
     <div className={`line scroll-${direction}`}>
       <div className="scroll-track">
-        {items.map((item, index) => (
-          <div className="box" key={`set1-${index}`}>
-            <img className="boxImg" src={item.img} alt={item.name} />
-            <div className="boxText">{item.name}</div>
-          </div>
-        ))}
-        {items.map((item, index) => (
-          <div className="box" key={`set2-${index}`}>
-            <img className="boxImg" src={item.img} alt={item.name} />
-            <div className="boxText">{item.name}</div>
-          </div>
-        ))}
-        {items.map((item, index) => (
-          <div className="box" key={`set3-${index}`}>
-            <img className="boxImg" src={item.img} alt={item.name} />
-            <div className="boxText">{item.name}</div>
-          </div>
-        ))}
+        {items.map((item, index) => {
+          const isExternal = item.link && item.link.startsWith("http");
+          const Wrapper = isExternal ? "a" : Link;
+          const props = isExternal
+            ? { href: item.link, target: "_blank", rel: "noreferrer" }
+            : { to: item.link || "#" };
+          return (
+            <Wrapper {...props} className="box" key={`set1-${index}`}>
+              <img className="boxImg" src={item.img} alt={item.name} />
+              <div className="boxText">{item.name}</div>
+            </Wrapper>
+          );
+        })}
+        {items.map((item, index) => {
+          const isExternal = item.link && item.link.startsWith("http");
+          const Wrapper = isExternal ? "a" : Link;
+          const props = isExternal
+            ? { href: item.link, target: "_blank", rel: "noreferrer" }
+            : { to: item.link || "#" };
+          return (
+            <Wrapper {...props} className="box" key={`set2-${index}`}>
+              <img className="boxImg" src={item.img} alt={item.name} />
+              <div className="boxText">{item.name}</div>
+            </Wrapper>
+          );
+        })}
+        {items.map((item, index) => {
+          const isExternal = item.link && item.link.startsWith("http");
+          const Wrapper = isExternal ? "a" : Link;
+          const props = isExternal
+            ? { href: item.link, target: "_blank", rel: "noreferrer" }
+            : { to: item.link || "#" };
+          return (
+            <Wrapper {...props} className="box" key={`set3-${index}`}>
+              <img className="boxImg" src={item.img} alt={item.name} />
+              <div className="boxText">{item.name}</div>
+            </Wrapper>
+          );
+        })}
       </div>
     </div>
   );
@@ -325,7 +450,6 @@ const KanvasVisualizerViews = () => {
           </div>
         </div>
         <div className="hero-text">
-
           <h2>
             <span>Manage your Cloud Native mess</span>
           </h2>

--- a/src/sections/Meshery/Meshery-platforms/index.js
+++ b/src/sections/Meshery/Meshery-platforms/index.js
@@ -25,12 +25,12 @@ const supported_platforms = [
       <>
         <h2>MacOS User</h2>
         <h4>Install on Mac using Homebrew:</h4>
-        <Code codeString={dedent`brew install mesheryctl
-        mesheryctl system start`
-        }
+        <Code
+          codeString={dedent`brew install mesheryctl
+        mesheryctl system start`}
         />
       </>
-    )
+    ),
   },
   {
     icon: Docker,
@@ -38,20 +38,20 @@ const supported_platforms = [
     steps: (
       <>
         <h2>Docker User</h2>
-        <Code codeString={dedent`curl -L https://meshery.io/install | PLATFORM=docker bash -`
-        }
+        <Code
+          codeString={dedent`curl -L https://meshery.io/install | PLATFORM=docker bash -`}
         />
         <h2 style={{ marginTop: "20px" }}>Using mesheryctl</h2>
-        <Code codeString={dedent`mesheryctl system context create docker --platform docker --set
-        mesheryctl system start`
-        }
+        <Code
+          codeString={dedent`mesheryctl system context create docker --platform docker --set
+        mesheryctl system start`}
         />
         <h2 style={{ marginTop: "20px" }}>Docker Extension</h2>
-        <Code codeString={dedent`docker extension install meshery/docker-extension-meshery:stable-latest`
-        }
+        <Code
+          codeString={dedent`docker extension install meshery/docker-extension-meshery:stable-latest`}
         />
       </>
-    )
+    ),
   },
   {
     icon: EKS,
@@ -59,11 +59,12 @@ const supported_platforms = [
     steps: (
       <>
         <h2>AWS Elastic Kubernetes Service User</h2>
-        <Code codeString={dedent`mesheryctl system config eks
+        <Code
+          codeString={dedent`mesheryctl system config eks
       mesheryctl system start`}
         />
       </>
-    )
+    ),
   },
   {
     icon: GKE,
@@ -71,12 +72,13 @@ const supported_platforms = [
     steps: (
       <>
         <h2>Google Kubernetes Engine User</h2>
-        <Code codeString={dedent`mesheryctl system config gke --token *PATH_TO_TOKEN*
+        <Code
+          codeString={dedent`mesheryctl system config gke --token *PATH_TO_TOKEN*
         ./generate_kubeconfig_gke.sh cluster-admin-sa-gke default
         mesheryctl system start`}
         />
       </>
-    )
+    ),
   },
   {
     icon: Helm,
@@ -85,16 +87,18 @@ const supported_platforms = [
       <>
         <h2>Helm Chart</h2>
         <p>Install on Kubernetes using Helm:</p>
-        <Code codeString={dedent`helm repo add meshery https://meshery.io/charts/
+        <Code
+          codeString={dedent`helm repo add meshery https://meshery.io/charts/
              helm install my-meshery meshery/meshery --version 2.1.2`}
         />
-        <h3  style={{ marginTop: "20px" }}>Using kubectl</h3>
-        <Code codeString={dedent`kubectl create ns meshery
+        <h3 style={{ marginTop: "20px" }}>Using kubectl</h3>
+        <Code
+          codeString={dedent`kubectl create ns meshery
         helm repo add meshery https://meshery.io/charts
         helm install meshery meshery/meshery -n meshery`}
         />
       </>
-    )
+    ),
   },
   {
     icon: HomeBrew,
@@ -103,11 +107,12 @@ const supported_platforms = [
       <>
         <h2>Brew User</h2>
         <h4>Install on Mac or Linux using Homebrew:</h4>
-        <Code codeString={dedent`brew install mesheryctl
+        <Code
+          codeString={dedent`brew install mesheryctl
         mesheryctl system start`}
         />
       </>
-    )
+    ),
   },
   // {
   //   icon: Kind,
@@ -128,12 +133,12 @@ const supported_platforms = [
     steps: (
       <>
         <h2>Kubernetes User</h2>
-        <Code codeString={dedent`curl -L https://meshery.io/install | PLATFORM=kubernetes bash -
-        mesheryctl system start`
-        }
+        <Code
+          codeString={dedent`curl -L https://meshery.io/install | PLATFORM=kubernetes bash -
+        mesheryctl system start`}
         />
       </>
-    )
+    ),
   },
   {
     icon: Linux,
@@ -141,11 +146,15 @@ const supported_platforms = [
     steps: (
       <>
         <h3>Install Using Kubernetes</h3>
-        <Code codeString={dedent`curl -L https://meshery.io/install | PLATFORM=kubernetes bash -`}/>
+        <Code
+          codeString={dedent`curl -L https://meshery.io/install | PLATFORM=kubernetes bash -`}
+        />
         <h3 style={{ marginTop: "20px" }}>Install Using Docker</h3>
-        <Code codeString={dedent`curl -L https://meshery.io/install | PLATFORM=docker bash -` }/>
+        <Code
+          codeString={dedent`curl -L https://meshery.io/install | PLATFORM=docker bash -`}
+        />
       </>
-    )
+    ),
   },
   {
     icon: Minikube,
@@ -153,11 +162,11 @@ const supported_platforms = [
     steps: (
       <>
         <h2>Minikube User</h2>
-        <Code codeString={dedent`mesheryctl system config minikube -t ~/Downloads/auth.json`
-        }
+        <Code
+          codeString={dedent`mesheryctl system config minikube -t ~/Downloads/auth.json`}
         />
       </>
-    )
+    ),
   },
   {
     icon: AKS,
@@ -166,12 +175,12 @@ const supported_platforms = [
       <>
         <h2>Azure Kubernetes Service User</h2>
         <p>Install mesheryctl and configure Meshery to communicate with AKS.</p>
-        <Code codeString={dedent`mesheryctl system config aks
-        mesheryctl system start`
-        }
+        <Code
+          codeString={dedent`mesheryctl system config aks
+        mesheryctl system start`}
         />
       </>
-    )
+    ),
   },
   {
     icon: WSL2,
@@ -180,26 +189,31 @@ const supported_platforms = [
       <>
         <h2>Windows User</h2>
         <p>
-          Download and unzip mesheryctl from the <a href="https://github.com/layer5io/meshery/releases/">Meshery releases page</a>. Add mesheryctl to your PATH for ease of use. Then, execute:
+          Download and unzip mesheryctl from the{" "}
+          <a href="https://github.com/layer5io/meshery/releases/">
+            Meshery releases page
+          </a>
+          . Add mesheryctl to your PATH for ease of use. Then, execute:
         </p>
-        <Code codeString={dedent`mesheryctl system start`}/>
+        <Code codeString={dedent`mesheryctl system start`} />
       </>
-    )
-  }
+    ),
+  },
 ];
 
 const MesheryPlatforms = () => {
   const [currentPlatform, setCurrentPlatform] = useState({});
-  const [installationStepsHeight,setInstallationStepsHeight] = useState(currentPlatform.name ? "200px" : 0);
+  const [installationStepsHeight, setInstallationStepsHeight] = useState(
+    currentPlatform.name ? "200px" : 0,
+  );
 
-  const hasSelectedSamePlatform = (index) => currentPlatform.name === supported_platforms[index].name;
+  const hasSelectedSamePlatform = (index) =>
+    currentPlatform.name === supported_platforms[index].name;
 
   const changeCurrentPlatformState = (index) => {
     if (currentPlatform.name && hasSelectedSamePlatform(index))
       setCurrentPlatform({});
-    else
-      setCurrentPlatform(supported_platforms[index]);
-
+    else setCurrentPlatform(supported_platforms[index]);
   };
 
   const changeCurrentPlatform = (index) => {
@@ -211,20 +225,28 @@ const MesheryPlatforms = () => {
     setInstallationStepsHeight(currentPlatform.name ? 0 : "200px");
   };
 
-
   return (
-    <MesheryPlatformsWrapper>
+    <MesheryPlatformsWrapper id="platforms">
       <div className="content">
         <Row $Hcenter className="step-1">
-          <p>Start managing cloud native infrastructure easily with a single command. </p>
-          <h2><span>Step 1:</span> Choose your platform</h2>
+          <p>
+            Start managing cloud native infrastructure easily with a single
+            command.{" "}
+          </p>
+          <h2>
+            <span>Step 1:</span> Choose your platform
+          </h2>
         </Row>
         <Row className="supported-platforms">
           {supported_platforms.map((platform, index) => (
             <Col $xs={6} $sm={4} $md={3} $lg={2} key={platform.name}>
               <Button
-                className={currentPlatform.name && currentPlatform.name === supported_platforms[index].name
-                  ? "single-platform single-platform-selected " : "single-platform "}
+                className={
+                  currentPlatform.name &&
+                  currentPlatform.name === supported_platforms[index].name
+                    ? "single-platform single-platform-selected "
+                    : "single-platform "
+                }
                 onClick={() => changeCurrentPlatform(index)}
               >
                 <img src={platform.icon} alt={platform.name} />
@@ -232,22 +254,38 @@ const MesheryPlatforms = () => {
             </Col>
           ))}
         </Row>
-        <Container style={{ transition: "height 0.5s ease-in-out", height: (currentPlatform.name === "Docker" || currentPlatform.name === "Helm" || currentPlatform.name === "Linux" )  ? "30rem" : installationStepsHeight, overflow: "hidden" }}>
-          <Row className="installation-steps" >
+        <Container
+          style={{
+            transition: "height 0.5s ease-in-out",
+            height:
+              currentPlatform.name === "Docker" ||
+              currentPlatform.name === "Helm" ||
+              currentPlatform.name === "Linux"
+                ? "30rem"
+                : installationStepsHeight,
+            overflow: "hidden",
+          }}
+        >
+          <Row className="installation-steps">
             {currentPlatform.name && currentPlatform.steps}
           </Row>
         </Container>
         <Row $Hcenter className="step-2">
           <Col>
-            <h2><span>Step 2:</span> Manage your Cloud Native Infra</h2>
-            <p>There is no step 2. Login and manage cloud native infrastructure! For more detailed instructions, visit <a href="https://docs.meshery.io">Meshery Docs</a></p>
+            <h2>
+              <span>Step 2:</span> Manage your Cloud Native Infra
+            </h2>
+            <p>
+              There is no step 2. Login and manage cloud native infrastructure!
+              For more detailed instructions, visit{" "}
+              <a href="https://docs.meshery.io">Meshery Docs</a>
+            </p>
             <img src={MesheryLogo} alt="Meshery" className="meshery-logo" />
           </Col>
         </Row>
       </div>
     </MesheryPlatformsWrapper>
   );
-
 };
 
 export default MesheryPlatforms;

--- a/src/sections/Meshery/Meshery-terminal/index.js
+++ b/src/sections/Meshery/Meshery-terminal/index.js
@@ -40,7 +40,10 @@ const MesheryTerminal = () => {
             lines: [
               {
                 frames: 5,
-                code: ["curl -L https://meshery.io/install | PLATFORM=kubernetes bash -", "curl -L https://meshery.io/install | PLATFORM=kubernetes bash -|"],
+                code: [
+                  "curl -L https://meshery.io/install | PLATFORM=kubernetes bash -",
+                  "curl -L https://meshery.io/install | PLATFORM=kubernetes bash -|",
+                ],
               },
             ],
           }}
@@ -50,13 +53,19 @@ const MesheryTerminal = () => {
               description: (
                 <>
                   <p>
-                    Meshery provides you with a clean, robust, streamlined command-line interface to manage your cloud native infrastructure.
+                    Meshery provides you with a clean, robust, streamlined
+                    command-line interface to manage your cloud native
+                    infrastructure.
                   </p>
                   <p>
-                    With <code>mesheryctl</code>, not only you can manage your infrastructure, but you can also manage their workloads, characterize performance, and apply well-architectued patterns.
+                    With <code>mesheryctl</code>, not only you can manage your
+                    infrastructure, but you can also manage their workloads,
+                    characterize performance, and apply well-architectued
+                    patterns.
                   </p>
                   <p>
-                    <code>mesheryctl</code> provides support for all of Meshery's features and many platforms.
+                    <code>mesheryctl</code> provides support for all of
+                    Meshery's features and many platforms.
                   </p>
                 </>
               ),
@@ -64,38 +73,47 @@ const MesheryTerminal = () => {
                 {
                   url: Homebrew,
                   alt: "Homebrew",
+                  link: "#platforms",
                 },
                 {
                   url: Kubernetes,
                   alt: "Kubernetes",
+                  link: "#platforms",
                 },
                 {
                   url: KinD,
                   alt: "KinD",
+                  link: "#platforms",
                 },
                 {
                   url: Minikube,
                   alt: "Minikube",
+                  link: "#platforms",
                 },
                 {
                   url: EKS,
                   alt: "AWS Elastic Kubernetes Service",
+                  link: "#platforms",
                 },
                 {
                   url: Helm,
                   alt: "Meshery Helm Chart",
+                  link: "#platforms",
                 },
                 {
                   url: WSL2,
                   alt: "WSL2",
+                  link: "#platforms",
                 },
                 {
                   url: GKE,
                   alt: "GKE",
+                  link: "#platforms",
                 },
                 {
                   url: Docker,
                   alt: "Docker",
+                  link: "#platforms",
                 },
               ],
               terminal: {
@@ -114,27 +132,26 @@ const MesheryTerminal = () => {
                   },
                   {
                     frames: 4,
-                    code:
-                      "Archive:  /Users/layer5/meshery.zip",
+                    code: "Archive:  /Users/layer5/meshery.zip",
                     color: "gray",
                   },
                   {
                     frames: 4,
                     code: "inflating: LICENSE",
                     indent: 1,
-                    short: true
+                    short: true,
                   },
                   {
                     frames: 2,
                     code: "inflating: README.md",
                     indent: 1,
-                    short: true
+                    short: true,
                   },
                   {
                     frames: 2,
                     code: "inflating: mesheryctl",
                     indent: 1,
-                    short: true
+                    short: true,
                   },
                   { code: " " },
                   {
@@ -225,25 +242,31 @@ const MesheryTerminal = () => {
               description: (
                 <>
                   <p>
-                    Meshery supports cloud native application patterns using a cloud-agnostic and application-holistic approach: designs.
+                    Meshery supports cloud native application patterns using a
+                    cloud-agnostic and application-holistic approach: designs.
                   </p>
                   <p>
-                    Meshery designs enable the practice of both configuring and operating functionality in a single, universal file.
+                    Meshery designs enable the practice of both configuring and
+                    operating functionality in a single, universal file.
                   </p>
                   <p>
-                    With a design, you can capture behavior in a single file. You can access infrastructure-specific differentiation while keeping your patterns short and simple.
+                    With a design, you can capture behavior in a single file.
+                    You can access infrastructure-specific differentiation while
+                    keeping your patterns short and simple.
                   </p>
                 </>
               ),
               logos: [
                 {
                   url: OAM,
-                  alt: "Open Application Model",
+                  alt: "OAM",
+                  link: "https://oam.dev/",
                 },
                 {
                   url: ImageHub,
-                  alt: "Image Hub",
-                }
+                  alt: "ImageHub",
+                  link: "/projects/image-hub",
+                },
               ],
               terminal: {
                 frameLength: 100,
@@ -261,8 +284,7 @@ const MesheryTerminal = () => {
                   },
                   {
                     frames: 5,
-                    code:
-                      "✓ Meshery connected to Kubernetes at https://kubernetes.example.com:6443",
+                    code: "✓ Meshery connected to Kubernetes at https://kubernetes.example.com:6443",
                   },
                   {
                     frames: 2,
@@ -321,15 +343,13 @@ const MesheryTerminal = () => {
                   { code: "" },
                   {
                     frames: 2,
-                    code:
-                      "\nYour cloud native application pattern deployment was successful!",
+                    code: "\nYour cloud native application pattern deployment was successful!",
                     color: "gray",
                   },
                   { code: "" },
                   {
                     frames: 1,
-                    code:
-                      "\nDeployment URL: https://meshery.local/patterns",
+                    code: "\nDeployment URL: https://meshery.local/patterns",
                     color: "green",
                   },
                 ],
@@ -340,21 +360,29 @@ const MesheryTerminal = () => {
               description: (
                 <>
                   <p>
-                    Meshery provides cloud native infrastructure and application performance measurement and management.
+                    Meshery provides cloud native infrastructure and application
+                    performance measurement and management.
                   </p>
                   <p>
-                    Meshery natively supports the <Link to="/projects/cloud-native-performance">Cloud Native Performance</Link> (SMP) specification.
+                    Meshery natively supports the{" "}
+                    <Link to="/projects/cloud-native-performance">
+                      Cloud Native Performance
+                    </Link>{" "}
+                    (SMP) specification.
                   </p>
                   <p>
-                    Use performance test profiles to schedule and continuously verify your application is performing in accordance with your SLOs.
+                    Use performance test profiles to schedule and continuously
+                    verify your application is performing in accordance with
+                    your SLOs.
                   </p>
                 </>
               ),
               logos: [
                 {
                   url: SMP,
-                  alt: "Cloud Native Performance",
-                }
+                  alt: "SMP",
+                  link: "/projects/cloud-native-performance",
+                },
               ],
               terminal: {
                 frameLength: 100,
@@ -372,8 +400,7 @@ const MesheryTerminal = () => {
                   },
                   {
                     frames: 2,
-                    code:
-                      "✓ Meshery connected to Kubernetes at https://kubernetes.example.com:6443",
+                    code: "✓ Meshery connected to Kubernetes at https://kubernetes.example.com:6443",
                   },
                   {
                     frames: 2,


### PR DESCRIPTION
#8011 
## Summary

This PR fixes #8011 by making the relevant SVG illustrations on the Meshery Getting Started page clickable.

### Changes

* Made the integration and platform SVGs clickable with their respective destinations.
* Added subtle hover/focus feedback to indicate interactivity.
* Used Gatsby `<Link>` for internal navigation.
* Kept the existing design, layout, and responsive behavior unchanged.
* Preserved keyboard accessibility.

### Testing

* Verified the affected components locally.
* `git diff --check` passes.
* DCO sign-off is included in the commit.

Fixes #8011


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Logo items now support links to internal pages and external resources.
  - Integration tiles on the home page are now clickable and direct users to relevant pages.
  - Platform and partner logos in the terminal section now link to associated resources.
  - Added hover transitions for linked logos and integration tiles.

- **Accessibility**
  - Improved alternative text for select logos, including OAM, ImageHub, and SMP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->