### PR TITLE
fix: add opengraph image for sistent project page

### DIFF
--- a/src/pages/projects/sistent/index.js
+++ b/src/pages/projects/sistent/index.js
@@ -1,5 +1,7 @@
 import React from "react";
 import SistentHome from "../../../sections/Projects/Sistent/index";
+import SEO from "../../../components/seo";
+import seoImage from "../../../assets/images/sistent/icon-only/sistent-icon-color.png";
 
 const SistentIndexPage = () => {
   return (
@@ -10,3 +12,13 @@ const SistentIndexPage = () => {
 };
 
 export default SistentIndexPage;
+
+export const Head = () => {
+  return (
+    <SEO
+      title="Sistent"
+      description="Design system for Layer5 projects"
+      image={seoImage}
+    />
+  );
+};


### PR DESCRIPTION
## Description
This PR resolves the issue where the Sistent project page on Layer5 did not have an Open Graph image specified, causing social platforms (like LinkedIn and Twitter) to display the generic Layer5 logo instead of the Sistent logo when the page is shared.

### Changes Made
* Imported the official `sistent-icon-color.png` asset.
* Utilized the Gatsby `Head` API to inject the `SEO` component into the `SistentIndexPage`.
* Linked the imported Sistent logo to the `image` prop so it properly generates the `og:image` and `twitter:image` metadata tags.

**Resolves:** #8038

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Performed
- [x] Verified `og:image` generation via the local development server (`npm run dev`).
- [x] Verified the generated hash image path correctly resolves to the Sistent logo asset.
- [x] Pre-commit hooks (lint/prettier) successfully passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search engine optimization metadata to the Sistent project page, including its title, description, and icon.
  * Added the Sistent icon for improved page and browser presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->