### PR TITLE
Fixed the broken link issue in layer5 docs for gatsby in wsl

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -495,7 +495,7 @@ Make sure you have the following prerequisites installed on your operating syste
   gatsby --version
   ```
 
-**Note:** If you're on a _Windows environment_ then it is highly recommended that you install [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/install) both for performance and ease of use. Refer to the [documentation](https://docs.microsoft.com/en-us/windows/dev-environment/javascript/gatsby-on-wsl) for the installation of _Gatsby.js on WSL_.
+**Note:** If you're on a _Windows environment_ then it is highly recommended that you install [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/install) both for performance and ease of use. Refer to the [documentation](https://www.gatsbyjs.com/docs/how-to/local-development/gatsby-on-linux/#windows-subsystem-linux-wsl) for the installation of _Gatsby.js on WSL_.
 
 ## Set up your Local Development Environment
 


### PR DESCRIPTION
this issue fixes a bug in documentation encountered via the documentation link attached in docs for installing Gatsby on wsl.

This PR fixes #8046 

**Notes for Reviewers**


**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Gatsby-on-WSL documentation link in the Windows environment guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->